### PR TITLE
Add 30 min flag to export_labels.

### DIFF
--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -112,6 +112,8 @@ class Project(DbObject, Updateable, Deletable):
         """ Calls the server-side Label exporting that generates a JSON
         payload, and returns the URL to that payload.
 
+        Will only generate a new URL at a max frequency of 30 min.
+        
         Args:
             timeout_seconds (float): Max waiting time, in seconds.
         Returns:


### PR DESCRIPTION
This was a request from our support team.