### PR TITLE
Change Order of operations in project.setup

### DIFF
--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -199,6 +199,8 @@ class Project(DbObject, Updateable, Deletable):
         if not isinstance(labeling_frontend_options, str):
             labeling_frontend_options = json.dumps(labeling_frontend_options)
 
+        self.labeling_frontend.connect(labeling_frontend)
+
         LFO = Entity.LabelingFrontendOptions
         labeling_frontend_options = self.client._create(
             LFO, {LFO.project: self, LFO.labeling_frontend: labeling_frontend,
@@ -206,7 +208,6 @@ class Project(DbObject, Updateable, Deletable):
                   LFO.organization: organization
                   })
 
-        self.labeling_frontend.connect(labeling_frontend)
         timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         self.update(setup_complete=timestamp)
 


### PR DESCRIPTION
So, I noticed that project.setup is broken currently - if you run it on a pictor project, the LFO get attached but not normalized. This is fixed by ensuring that the Labeling Frontend is attached to the project before the options are created

## Changes

Attach Labeling Frontend to Project before creating the Labeling Frontend Options

## Testing

Tested locally on V4 and Pictor (staging) and had no issues