### PR TITLE
[BACKEND-766] upload with content type guess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 2.4.1 (2020-07-22)
+### Fixed
+* `Dataset.create_data_row` and `Dataset.create_data_rows` will now upload with content type to ensure the Labelbox editor can show videos.
+
 ## Version 2.4 (2020-01-30)
 
 ### Added

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 import json
 import logging
+import mimetypes
 import os
 
 import requests
@@ -171,9 +172,15 @@ class Client:
 
         return response["data"]
 
+    def upload_file(self, path):
+        content_type, _ = mimetypes.guess_type(path)
+        with open(path, "rb") as f:
+            data = (None, f.read(), content_type)
+        return self.upload_data(data)
+
     def upload_data(self, data):
         """ Uploads the given data (bytes) to Labelbox.
-        
+
         Args:
             data (bytes): The data to upload.
         Returns:
@@ -181,10 +188,11 @@ class Client:
         Raises:
             labelbox.exceptions.LabelboxError: If upload failed.
         """
+
         request_data = {
             "operations": json.dumps({
-            "variables": {"file": None, "contentLength": len(data), "sign": False},
-            "query": """mutation UploadFile($file: Upload!, $contentLength: Int!,
+                "variables": {"file": None, "contentLength": len(data), "sign": False},
+                "query": """mutation UploadFile($file: Upload!, $contentLength: Int!,
                                             $sign: Boolean) {
                             uploadFile(file: $file, contentLength: $contentLength,
                                        sign: $sign) {url filename} } """,}),

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -173,10 +173,22 @@ class Client:
         return response["data"]
 
     def upload_file(self, path):
+        """Uploads given path to local file.
+
+        Also includes best guess at the content type of the file.
+
+        Args:
+            path (str): path to local file to be uploaded.
+        Returns:
+            str, the URL of uploaded data.
+        Raises:
+            labelbox.exceptions.LabelboxError: If upload failed.
+
+        """
         content_type, _ = mimetypes.guess_type(path)
+        basename = os.path.basename(path)
         with open(path, "rb") as f:
-            data = (None, f.read(), content_type)
-        return self.upload_data(data)
+            return self.upload_data(data=(basename, f.read(), content_type))
 
     def upload_data(self, data):
         """ Uploads the given data (bytes) to Labelbox.
@@ -188,7 +200,6 @@ class Client:
         Raises:
             labelbox.exceptions.LabelboxError: If upload failed.
         """
-
         request_data = {
             "operations": json.dumps({
                 "variables": {"file": None, "contentLength": len(data), "sign": False},

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -48,8 +48,7 @@ class Dataset(DbObject, Updateable, Deletable):
         # If row data is a local file path, upload it to server.
         row_data = kwargs[DataRow.row_data.name]
         if os.path.exists(row_data):
-            with open(row_data, "rb") as f:
-                kwargs[DataRow.row_data.name] = self.client.upload_data(f.read())
+            kwargs[DataRow.row_data.name] = self.client.upload_file(row_data)
 
         kwargs[DataRow.dataset.name] = self
 
@@ -57,7 +56,7 @@ class Dataset(DbObject, Updateable, Deletable):
 
     def create_data_rows(self, items):
         """ Creates multiple DataRow objects based on the given `items`.
-        
+
         Each element in `items` can be either a `str` or a `dict`. If
         it is a `str`, then it is interpreted as a local file path. The file
         is uploaded to Labelbox and a DataRow referencing it is created.
@@ -91,9 +90,7 @@ class Dataset(DbObject, Updateable, Deletable):
 
         def upload_if_necessary(item):
             if isinstance(item, str):
-                with open(item, "rb") as f:
-                    item_data = f.read()
-                item_url = self.client.upload_data(item_data)
+                item_url = self.client.upload_file(item)
                 # Convert item from str into a dict so it gets processed
                 # like all other dicts.
                 item = {DataRow.row_data: item_url,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="labelbox",
-    version="2.4",
+    version="2.4.1",
     author="Labelbox",
     author_email="engineering@labelbox.com",
     description="Labelbox Python API",


### PR DESCRIPTION
fixes:
https://labelbox.slack.com/archives/C017A1V4XTQ
https://labelbox.blameless.io/incidents/173/events

- local file uploads go thru `client.upload_file`
- `client.upload_file` will guess mimetype and pass along content type for videos (and images)

we call `mimetypes. guess_type` ourselves because `requests.post` [0] will only pass thru a `content_type` if it is specified explicitly.  `RequestField` doesn't call `mimetypes.guess_type` unless it is isntantiated via `from_tuple` rather than thru its `__init__`[1]

[0] https://github.com/psf/requests/blob/8149e9fe54c36951290f198e90d83c8a0498289c/requests/models.py#L141-L166
[1] https://github.com/urllib3/urllib3/blob/ae7f8bbb57e74ffdb327c5e510963a886fa4ed8b/src/urllib3/fields.py#L181