### PR TITLE
[BACKEND-946] [BACKEND-947] [BACKEND-948] pass thru errors, retry, catch bad annotation types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 2.4.5 (2020-08-04)
+### Added
+* retry capabilities for common flaky API failures
+* protection against improper types passed into `Project.upload_anntations`
+* pass thru API error messages when possible
+
 ## Version 2.4.3 (2020-08-04)
 
 ### Added

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -120,27 +120,13 @@ class Client:
             raise labelbox.exceptions.LabelboxError(
                 "Unknown error during Client.query(): " + str(e), e)
 
-        # if we do return a proper error code, reraise
-        if response.status_code != requests.codes.ok:
-            if response.status_code == 400:
-                print('400', response)
-            message = f"{response.status_code} {response.reason}"
-            cause = None
-            try:
-                r_json = response.json()
-            except:
-                pass
-            else:
-                cause = r_json.get('message')
-            raise labelbox.exceptions.LabelboxError(message, cause)
-
         try:
-            response = response.json()
+            r_json = response.json()
         except:
             raise labelbox.exceptions.LabelboxError(
                 "Failed to parse response as JSON: %s" % response.text)
 
-        errors = response.get("errors", [])
+        errors = r_json.get("errors", [])
 
         def check_errors(keywords, *path):
             """ Helper that looks for any of the given `keywords` in any of
@@ -180,7 +166,7 @@ class Client:
                 graphql_error["message"])
 
         # Check if API limit was exceeded
-        response_msg = response.get("message", "")
+        response_msg = r_json.get("message", "")
         if response_msg.startswith("You have exceeded"):
             raise labelbox.exceptions.ApiLimitError(response_msg)
 
@@ -189,7 +175,17 @@ class Client:
             raise labelbox.exceptions.LabelboxError("Unknown error: %s" %
                                                     str(errors))
 
-        return response["data"]
+        # if we do return a proper error code, and didn't catch this above
+        # reraise
+        # this mainly catches a 401 for API access disabled for free tier
+        # TODO: need to unify API errors to handle things more uniformly
+        # in the SDK
+        if response.status_code != requests.codes.ok:
+            message = f"{response.status_code} {response.reason}"
+            cause = r_json.get('message')
+            raise labelbox.exceptions.LabelboxError(message, cause)
+
+        return r_json["data"]
 
     def upload_file(self, path: str) -> str:
         """Uploads given path to local file.

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -122,6 +122,8 @@ class Client:
 
         # if we do return a proper error code, reraise
         if response.status_code != requests.codes.ok:
+            if response.status_code == 400:
+                print('400', response)
             message = f"{response.status_code} {response.reason}"
             cause = None
             try:

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -175,6 +175,9 @@ class Client:
             raise labelbox.exceptions.LabelboxError("Unknown error: %s" %
                                                     str(errors))
 
+        if not response.get('data'):
+            print('response', response)
+            raise
         return response["data"]
 
     def upload_file(self, path: str) -> str:

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -5,6 +5,7 @@ import mimetypes
 import os
 from typing import Tuple
 
+from google.api_core import retry
 import requests
 import requests.exceptions
 
@@ -60,6 +61,8 @@ class Client:
             'Authorization': 'Bearer %s' % api_key
         }
 
+    @retry.Retry(predicate=retry.if_exception_type(
+        labelbox.exceptions.InternalServerError))
     def execute(self, query, params=None, timeout=10.0):
         """ Sends a request to the server for the execution of the
         given query. Checks the response for errors and wraps errors
@@ -123,6 +126,9 @@ class Client:
         try:
             r_json = response.json()
         except:
+            error_502 = '502 Bad Gateway'
+            if error_502 in response.text:
+                raise labelbox.exceptions.InternalServerError(error_502)
             raise labelbox.exceptions.LabelboxError(
                 "Failed to parse response as JSON: %s" % response.text)
 
@@ -169,6 +175,12 @@ class Client:
         response_msg = r_json.get("message", "")
         if response_msg.startswith("You have exceeded"):
             raise labelbox.exceptions.ApiLimitError(response_msg)
+
+        prisma_error = check_errors(["INTERNAL_SERVER_ERROR"], "extensions",
+                                    "code")
+        if prisma_error:
+            raise labelbox.exceptions.InternalServerError(
+                prisma_error["message"])
 
         if len(errors) > 0:
             logger.warning("Unparsed errors on query execution: %r", errors)

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -175,9 +175,6 @@ class Client:
             raise labelbox.exceptions.LabelboxError("Unknown error: %s" %
                                                     str(errors))
 
-        if not response.get('data'):
-            print('response', response)
-            raise
         return response["data"]
 
     def upload_file(self, path: str) -> str:

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -120,6 +120,18 @@ class Client:
             raise labelbox.exceptions.LabelboxError(
                 "Unknown error during Client.query(): " + str(e), e)
 
+        # if we do return a proper error code, reraise
+        if response.status_code != requests.codes.ok:
+            message = f"{response.status_code} {response.reason}"
+            cause = None
+            try:
+                r_json = response.json()
+            except:
+                pass
+            else:
+                cause = r_json.get('message')
+            raise labelbox.exceptions.LabelboxError(message, cause)
+
         try:
             response = response.json()
         except:

--- a/labelbox/exceptions.py
+++ b/labelbox/exceptions.py
@@ -48,6 +48,16 @@ class ValidationFailedError(LabelboxError):
     pass
 
 
+class InternalServerError(LabelboxError):
+    """Nondescript prisma or 502 related errors.
+
+    Meant to be retryable.
+
+    TODO: these errors need better messages from platform
+    """
+    pass
+
+
 class InvalidQueryError(LabelboxError):
     """ Indicates a malconstructed or unsupported query (either by GraphQL in
     general or by Labelbox specifically). This can be the result of either client

--- a/labelbox/schema/bulk_import_request.py
+++ b/labelbox/schema/bulk_import_request.py
@@ -218,6 +218,9 @@ class BulkImportRequest(DbObject):
             BulkImportRequest object
         """
         data_str = ndjson.dumps(predictions)
+        if not data_str:
+            raise ValueError('annotations cannot be empty')
+
         data = data_str.encode('utf-8')
         file_name = _make_file_name(project_id, name)
         request_data = _make_request_data(project_id, name, len(data_str),

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -410,13 +410,16 @@ class Project(DbObject, Updateable, Deletable):
                     file=path,
                     validate_file=True,
                 )
-        else:
+        elif isinstance(annotations, Iterable):
             return BulkImportRequest.create_from_objects(
                 client=self.client,
                 project_id=self.uid,
                 name=name,
                 predictions=annotations,  # type: ignore
             )
+        else:
+            raise ValueError(
+                f'Invalid annotations given of type: {type(annotations)}')
 
 
 class LabelingParameterOverride(DbObject):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,8 @@
-[mypy]
+[mypy-backoff.*]
+ignore_missing_imports = True
+
+[mypy-ndjson.*]
+ignore_missing_imports = True
+
+[mypy-google.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,2 @@
-[mypy-backoff.*]
-ignore_missing_imports = True
-
-[mypy-ndjson.*]
+[mypy]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,12 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://labelbox.com",
     packages=setuptools.find_packages(),
-    install_requires=["backoff==1.10.0", "ndjson==0.3.1", "requests==2.22.0"],
+    install_requires=[
+        "backoff==1.10.0",
+        "ndjson==0.3.1",
+        "requests==2.22.0",
+        "google-api-core>=1.22.1",
+    ],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: Apache Software License',

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,7 @@ setuptools.setup(
     install_requires=[
         "backoff==1.10.0",
         "ndjson==0.3.1",
-        "requests==2.22.0",
-        "google-api-core>=1.22.1",
+        "requests>=2.22.0",
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="labelbox",
-    version="2.4.4",
+    version="2.4.5",
     author="Labelbox",
     author_email="engineering@labelbox.com",
     description="Labelbox Python API",

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
         "backoff==1.10.0",
         "ndjson==0.3.1",
         "requests>=2.22.0",
+        "google-api-core>=1.22.1",
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tests/integration/test_labeling_frontend.py
+++ b/tests/integration/test_labeling_frontend.py
@@ -3,13 +3,15 @@ from labelbox import LabelingFrontend
 
 def test_get_labeling_frontends(client):
     frontends = list(client.get_labeling_frontends())
-    assert len(frontends) == 1, frontends
+    assert len(frontends) >= 1, (
+        'Projects should have at least one frontend by default.')
 
     # Test filtering
-    single = list(
-        client.get_labeling_frontends(where=LabelingFrontend.iframe_url_path ==
-                                      frontends[0].iframe_url_path))
-    assert len(single) == 1, single
+    target_frontend = frontends[0]
+    filtered_frontends = client.get_labeling_frontends(
+        where=LabelingFrontend.iframe_url_path == target_frontend.iframe_url_path)
+    for frontend in filtered_frontends:
+        assert target_frontend == frontend
 
 
 def test_labeling_frontend_connecting_to_project(project):

--- a/tests/integration/test_labeling_frontend.py
+++ b/tests/integration/test_labeling_frontend.py
@@ -9,7 +9,8 @@ def test_get_labeling_frontends(client):
     # Test filtering
     target_frontend = frontends[0]
     filtered_frontends = client.get_labeling_frontends(
-        where=LabelingFrontend.iframe_url_path == target_frontend.iframe_url_path)
+        where=LabelingFrontend.iframe_url_path ==
+        target_frontend.iframe_url_path)
     for frontend in filtered_frontends:
         assert target_frontend == frontend
 


### PR DESCRIPTION
1. https://labelbox.atlassian.net/browse/BACKEND-946
pass thru api unavailable message
2. https://labelbox.atlassian.net/browse/BACKEND-947
retry capabilities for 502 and prisma failures
3. clean up labeling frontend test so it works on any project with more than 1 editor
4. loosen requirement version