### PR TITLE
[BACKEND-961] readme for testing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,6 +45,9 @@ jobs:
       run: |
         pip install tox==3.18.1 tox-gh-actions==1.3.0
 
+    # TODO: replace tox.ini with what the Makefile does
+    # to make sure local testing is
+    # identical to github actions which uses tox.ini
     - name: Test with tox
       env:
         # make sure to tell tox to use these environs in tox.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3
+
+COPY . /usr/src/labelbox
+WORKDIR /usr/src/labelbox
+
+RUN pip install pytest
+RUN python setup.py install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+
+build:
+	docker build -t local/labelbox-python:test .
+
+test-staging: build
+	docker run -it -v ${PWD}:/usr/src -w /usr/src \
+		-e LABELBOX_TEST_ENVIRON="staging" \
+		-e LABELBOX_TEST_ENDPOINT="https://staging-api.labelbox.com/graphql" \
+		-e LABELBOX_TEST_API_KEY="<REPLACE>" \
+		local/labelbox-python:test pytest $(PATH_TO_TEST)
+
+test-prod: build
+	docker run -it -v ${PWD}:/usr/src -w /usr/src \
+		-e LABELBOX_TEST_ENVIRON="prod" \
+		-e LABELBOX_TEST_ENDPOINT="https://api.labelbox.com/graphql" \
+		-e LABELBOX_TEST_API_KEY="<REPLACE>"
+		local/labelbox-python:test pytest $(PATH_TO_TEST)

--- a/README.md
+++ b/README.md
@@ -32,3 +32,20 @@ client = Client()
 
 ## Repo Organization and Contribution
 Please consult `CONTRIB.md`
+
+## Testing
+1. Update the `Makefile` with your `staging` or `prod` API key.  Make sure the key is not from a free tier account.
+2. To test on `staging`:
+```
+make test-staging
+```
+
+3. To test on `prod`:
+```
+make test-prod
+```
+
+4. If you make any changes and need to rebuild the image used for testing, force a rebuild with the `-B` flag
+```
+make -B {build|test-staging|test_prod}
+```


### PR DESCRIPTION
1. testing instructions in README
2. Makefile for testing (was quickest and easiest; we should formalize/unify with github actions eventually)