### PR TITLE
[PLAT-1] Fixes broken API key generation link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Labelbox Python API offers a simple, user-friendly way to interact with the 
 
 * Use Python 3.7 or 3.8.
 * Create an account by visiting http://app.labelbox.com/.
-* [Generate an API key](https://labelbox.com/docs/api/api-keys).
+* [Generate an API key](https://labelbox.com/docs/api/getting-started#create_api_key).
 
 ## Installation & authentication
 


### PR DESCRIPTION
The previous link no longer exists/has been moved.