### PR TITLE
Add details on pip installation - macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ The Labelbox Python API offers a simple, user-friendly way to interact with the 
 
 ## Installation & authentication
 
+0. Prerequisite: Install pip
+
+`pip` is a package manager for Python. **On macOS**, you can set it up to use the default python3 install via -
+```
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python3 get-pip.py
+```
+
+If the installation completes with a warning re: pip not being in your path, you'll need to add it by modifying your shell config (`.zshrc`, `.bashrc` or similar). You might have to modify the command below depending on the version of python3 on your machine.
+
+```
+export PATH=/Users/<your-macOS-username>/Library/Python/3.8/bin:$PATH
+```
+
 1. Install using Python's Pip manager.
 ```
 pip install labelbox


### PR DESCRIPTION
Took me a bit to figure this out since `pip` can be set up with both python 2 and 3

Assuming most devs use macOS locally, this'd be a worthwhile addition to the README imo

![image](https://user-images.githubusercontent.com/2613128/93626102-ecc33d80-f9b0-11ea-9f50-7476ded0d4df.png)
