### PR TITLE
add python_version to backports-datetime-fromisoformat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "backoff==1.10.0",
-        "backports-datetime-fromisoformat==1.0.0",
+        "backports-datetime-fromisoformat==1.0.0; python_version < '3.7.0'",
         "dataclasses==0.7; python_version < '3.7.0'",
         "ndjson==0.3.1",
         "requests>=2.22.0",


### PR DESCRIPTION
There are no binaries for python > 3.7, making it difficult to install in docker without gcc.