### PR TITLE
Remove parallel testing during build

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,7 +58,7 @@ jobs:
         mypy -p labelbox --pretty --show-error-codes
     - name: Install package and test dependencies
       run: |
-        pip install tox==3.18.1 tox-gh-actions==1.3.0 pytest-parallel==0.1.0
+        pip install tox==3.18.1
 
     # TODO: replace tox.ini with what the Makefile does
     # to make sure local testing is
@@ -73,4 +73,4 @@ jobs:
         # randall+staging-python@labelbox.com
         LABELBOX_TEST_API_KEY_STAGING: ${{ secrets.STAGING_LABELBOX_API_KEY }}
       run: |
-        pytest --workers 2 -svv
+        pytest -svv

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,6 @@
 [tox]
 envlist = py36, py37, py38
 
-[gh-actions]
-python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-
 [testenv]
 # install pytest in the virtualenv where commands will be executed
 deps =


### PR DESCRIPTION
We can't do parallel testing of the PySDK as all of those tests are connecting to the same (staging) API using the same API key. One of the tests we do is the API limit test, which attempts to overload the endpoint to confirm it will start refusing requests. Running a different test in parallel to that is very likely to cause request refusals in that test as well, resulting in a failed test.

Next, a lot of these tests check the server state to validate that PySDK calls resulted in the right changes. I'm not 100% sure that we would get errors on this point if running tests in parallel, but I am also very far from convinced that we won't. Conceptually it is not fine, the tests are NOT isolated.

One of the reasons why it was possible to introduce these potentially destructive changes to the tests is that they were always a bit (quite a bit) flaky and more or less expected to fail. This needs to change, otherwise automated building / testing is pointless.