### PR TITLE
Add .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Read the docs config file version (Required)
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# Build all formats (epub, pdf, htmlzip)
+formats: 
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+   - requirements: requirements.txt
+   - requirements: docs/requirements.txt
+   - method: setuptools
+     path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 Sphinx==3.4.3
 sphinxcontrib-napoleon==0.7
 sphinx-rtd-theme==0.5.1
-autodoc==0.5.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx==3.4.3
 sphinxcontrib-napoleon==0.7
 sphinx-rtd-theme==0.5.1
+autodoc==0.5.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,6 @@ sys.path.insert(0, os.path.abspath('../..'))
 
 project = 'Labelbox Python API reference'
 copyright = '2021, Labelbox'
-author = 'Alexandra Cota'
 
 release = '2.4'
 


### PR DESCRIPTION
The .readthedocs.yml file is necessary for Readthedocs platform to build and display the sphinx-generated docs. Also added autodoc to requirements.txt.