### PR TITLE
Easier fetch bulk import ndjson

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -253,13 +253,15 @@ class Client:
     def upload_data(self,
                     content: bytes,
                     filename: str = None,
-                    content_type: str = None) -> str:
+                    content_type: str = None,
+                    sign: bool = False) -> str:
         """ Uploads the given data (bytes) to Labelbox.
 
         Args:
             content: bytestring to upload
             filename: name of the upload
             content_type: content type of data uploaded
+            sign: whether or not to sign the url
 
         Returns:
             str, the URL of uploaded data.
@@ -274,7 +276,7 @@ class Client:
                     "variables": {
                         "file": None,
                         "contentLength": len(content),
-                        "sign": False
+                        "sign": sign
                     },
                     "query":
                         """mutation UploadFile($file: Upload!, $contentLength: Int!,

--- a/labelbox/schema/bulk_import_request.py
+++ b/labelbox/schema/bulk_import_request.py
@@ -181,9 +181,6 @@ class BulkImportRequest(DbObject):
         Returns:
             ndjson as a list of dicts.
         """
-        if url is None:
-            raise ValueError("Must provide valid ndjson url. Found `None`")
-
         response = requests.get(url)
         response.raise_for_status()
         return ndjson.loads(response.text)

--- a/labelbox/schema/bulk_import_request.py
+++ b/labelbox/schema/bulk_import_request.py
@@ -113,6 +113,37 @@ class BulkImportRequest(DbObject):
     project = Relationship.ToOne("Project")
     created_by = Relationship.ToOne("User", False, "created_by")
 
+    @property
+    def inputs(self):
+        """
+        Inputs for each individual annotation uploaded.
+        * This should match the ndjson annotations that you have uploaded. 
+        * This information will expire after 24 hours.
+        """        
+        return  self._fetch_remote_ndjson(self.input_file_url)
+        
+    @property
+    def errors(self):
+        """
+        Errors for each individual annotation uploaded.
+        * Returns an empty list if there are no errors and None if the update is still running.
+        * This information will expire after 24 hours.        
+        """
+        return  self._fetch_remote_ndjson(self.error_file_url)
+
+    @property
+    def statuses(self):
+        """
+        Status for each individual annotation uploaded.
+        * Returns a status for each row if the upload is done running and was successful. Otherwise it returns None.
+        * This information will expire after 24 hours.        
+        """
+        return  self._fetch_remote_ndjson(self.status_file_url)
+
+    def _fetch_remote_ndjson(self, url):
+        if url is not None:
+            return ndjson.loads(requests.get(url).text)
+
     def refresh(self) -> None:
         """Synchronizes values of all fields with the database.
         """

--- a/labelbox/schema/bulk_import_request.py
+++ b/labelbox/schema/bulk_import_request.py
@@ -135,6 +135,22 @@ class BulkImportRequest(DbObject):
         Returns:
             Empty list if there are no errors and None if the update is still running.
             If there are errors, and the job has completed then a list of dicts containing the error messages will be returned.
+            See below table for detailed response fields.
+
+        .. list-table::
+           :widths: 15 150
+           :header-rows: 1 
+
+           * - Field
+             - Description
+           * - uuid 
+             - Specifies the annotation for the status row.
+           * - dataRow
+             - JSON object containing the Labelbox data row ID for the annotation.
+           * - status
+             - Indicates SUCCESS or FAILURE.
+           * - errors
+             - An array of error messages included when status is FAILURE. Each error has a name, message and optional (can be null) additional_info.
 
         * This information will expire after 24 hours.        
         """

--- a/labelbox/schema/bulk_import_request.py
+++ b/labelbox/schema/bulk_import_request.py
@@ -10,6 +10,7 @@ import backoff
 import ndjson
 import requests
 from pydantic import BaseModel, validator
+from requests.api import request
 from typing_extensions import Literal
 from typing import (Any, List, Optional, BinaryIO, Dict, Iterable, Tuple, Union,
                     Type, Set)
@@ -115,28 +116,41 @@ class BulkImportRequest(DbObject):
     created_by = Relationship.ToOne("User", False, "created_by")
 
     @property
-    def inputs(self) -> Optional[List[Dict[str, str]]]:
+    def inputs(self) -> List[Dict[str, Any]]:
         """
         Inputs for each individual annotation uploaded.
         This should match the ndjson annotations that you have uploaded. 
         
         Returns:
-            Uploaded ndjsons.
+            Uploaded ndjson.
 
         * This information will expire after 24 hours.    
         """
         return self._fetch_remote_ndjson(self.input_file_url)
 
     @property
-    def errors(self) -> Optional[List[Dict[str, str]]]:
+    def errors(self) -> List[Dict[str, Any]]:
         """
-        Errors for each individual annotation uploaded.
+        Errors for each individual annotation uploaded. This is a subset of statuses
 
         Returns:
-            Empty list if there are no errors and None if the update is still running.
-            If there are errors, and the job has completed then a list of dicts containing the error messages will be returned.
-            See below table for detailed response fields.
+            List of dicts containing error messages. Empty list means there were no errors
+            See `BulkImportRequest.statuses` for more details.
 
+        * This information will expire after 24 hours.        
+        """
+        self.wait_until_done()
+        return self._fetch_remote_ndjson(self.error_file_url)
+
+    @property
+    def statuses(self) -> List[Dict[str, Any]]:
+        """
+        Status for each individual annotation uploaded.
+
+        Returns:
+            A status for each annotation if the upload is done running.
+            See below table for more details
+            
         .. list-table::
            :widths: 15 150
            :header-rows: 1 
@@ -150,39 +164,29 @@ class BulkImportRequest(DbObject):
            * - status
              - Indicates SUCCESS or FAILURE.
            * - errors
-             - An array of error messages included when status is FAILURE. Each error has a name, message and optional (can be null) additional_info.
+             - An array of error messages included when status is FAILURE. Each error has a name, message and optional (key might not exist) additional_info.
 
         * This information will expire after 24 hours.        
         """
-        return self._fetch_remote_ndjson(self.error_file_url)
-
-    @property
-    def statuses(self) -> Optional[List[Dict[str, str]]]:
-        """
-        Status for each individual annotation uploaded.
-
-        Returns:
-            A status for each annotation if the upload is done running and was successful. Otherwise it returns None.
-
-        * This information will expire after 24 hours.        
-        """
+        self.wait_until_done()
         return self._fetch_remote_ndjson(self.status_file_url)
 
     @functools.lru_cache()
-    def _fetch_remote_ndjson(
-            self, url: Optional[str]) -> Optional[List[Dict[str, str]]]:
+    def _fetch_remote_ndjson(self, url: str) -> List[Dict[str, Any]]:
         """
         Fetches the remote ndjson file and caches the results.
 
         Args:
-            url (str): either the input_file_url, error_file_url, status_file_url, or None
-                urls are None when the file is unavailable.
+            url (str): Can be any url pointing to an ndjson file.
         Returns:
-            None if the url is None or the ndjson as a list of dicts.
+            ndjson as a list of dicts.
         """
-        if url is not None:
-            return ndjson.loads(requests.get(url).text)
-        return None
+        if url is None:
+            raise ValueError("Must provide valid ndjson url. Found `None`")
+
+        response = requests.get(url)
+        response.raise_for_status()
+        return ndjson.loads(response.text)
 
     def refresh(self) -> None:
         """Synchronizes values of all fields with the database.

--- a/labelbox/schema/enums.py
+++ b/labelbox/schema/enums.py
@@ -3,6 +3,19 @@ from enum import Enum
 
 class BulkImportRequestState(Enum):
     """ State of the import job when importing annotations (RUNNING, FAILED, or FINISHED).
+
+    .. list-table::
+       :widths: 15 150
+       :header-rows: 1 
+
+       * - State
+         - Description
+       * - RUNNING
+         - Indicates that the import job is not done yet.
+       * - FAILED
+         - Indicates the import job failed. Check `BulkImportRequest.errors` for more information
+       * - FINISHED
+         - Indicates the import job is no longer running. Check `BulkImportRequest.statuses` for more information
     """
     RUNNING = "RUNNING"
     FAILED = "FAILED"

--- a/tests/integration/bulk_import/test_bulk_import_request.py
+++ b/tests/integration/bulk_import/test_bulk_import_request.py
@@ -130,14 +130,11 @@ def test_wait_till_done(rectangle_inference, configured_project):
                                                                 annotations=url,
                                                                 validate=False)
 
-    assert bulk_import_request.errors is None
-    assert bulk_import_request.statuses is None
     assert len(bulk_import_request.inputs) == 1
-
     bulk_import_request.wait_until_done()
     assert bulk_import_request.state == BulkImportRequestState.FINISHED
 
-    #Check that the status files are being returned as expected
+    # Check that the status files are being returned as expected
     assert len(bulk_import_request.errors) == 0
     assert len(bulk_import_request.inputs) == 1
     assert bulk_import_request.inputs[0]['uuid'] == rectangle_inference['uuid']

--- a/tests/integration/bulk_import/test_bulk_import_request.py
+++ b/tests/integration/bulk_import/test_bulk_import_request.py
@@ -130,6 +130,10 @@ def test_wait_till_done(rectangle_inference, configured_project):
                                                                 annotations=url,
                                                                 validate=False)
 
+    assert bulk_import_request.errors is None
+    assert bulk_import_request.statuses is None
+    assert len(bulk_import_request.inputs) == 1
+
     bulk_import_request.wait_until_done()
     assert bulk_import_request.state == BulkImportRequestState.FINISHED
 

--- a/tests/integration/bulk_import/test_bulk_import_request.py
+++ b/tests/integration/bulk_import/test_bulk_import_request.py
@@ -133,6 +133,9 @@ def test_wait_till_done(configured_project):
     assert (bulk_import_request.state == BulkImportRequestState.FINISHED or
             bulk_import_request.state == BulkImportRequestState.FAILED)
 
+    assert bulk_import_request.errors is not None
+    assert bulk_import_request.inputs is not None
+
 
 def assert_file_content(url: str, predictions):
     response = requests.get(url)


### PR DESCRIPTION
* Checking status, error, or inputs to a bulk import request is an annoying process. We have made this easier by making these ndjson properties of the BulkImportRequest.
* There is also some improved documentation related to bulk imports since we are moving that out of docs.labelbox.com and into the api reference (sphinx docs).