### PR TITLE
NDTextEntity: fix "start >= end" test

### DIFF
--- a/labelbox/schema/bulk_import_request.py
+++ b/labelbox/schema/bulk_import_request.py
@@ -760,9 +760,9 @@ class NDTextEntity(NDBaseTool):
                 f"A line must have at least 2 points to be valid. Found {v}")
         if v['start'] < 0:
             raise ValueError(f"Text location must be positive. Found {v}")
-        if v['start'] >= v['end']:
+        if v['start'] > v['end']:
             raise ValueError(
-                f"Text start location must be less than end. Found {v}")
+                f"Text start location must be less or equal than end. Found {v}")
         return v
 
 


### PR DESCRIPTION
LabelBox convention about text location is that "end" is the index of the *last* character of the substring (that is not the python convention).
I.e.: `substring = string[v["start"] : v["end"] + 1]`

So, `v["start"] == v["end"]` is a valid case corresponding to a 1-character substring.