### PR TITLE
metadata to attachment

### DIFF
--- a/examples/basics/data_rows.ipynb
+++ b/examples/basics/data_rows.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "posted-nation",
    "metadata": {},
    "outputs": [],
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "beautiful-ready",
    "metadata": {},
    "outputs": [],
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "vertical-stockholm",
    "metadata": {},
    "outputs": [],
@@ -78,21 +78,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "rural-fellow",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Pick a project that has a dataset attached, data has external ids, and there are some labels\n",
     "# This will modify the project so just pick a dummy one that you don't care about\n",
-    "PROJECT_ID = \"ckk4q1viuc0w20704eh69u28h\"\n",
+    "PROJECT_ID = \"ckpnfquwy0kyg0y8t9rwb99cz\"\n",
     "# Only update this if you have an on-prem deployment\n",
     "ENDPOINT = \"https://api.labelbox.com/graphql\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "proof-detective",
    "metadata": {},
    "outputs": [],
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "selective-reconstruction",
    "metadata": {},
    "outputs": [],
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "extra-paris",
    "metadata": {},
    "outputs": [],
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "packed-going",
    "metadata": {},
    "outputs": [
@@ -142,9 +142,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Associated dataset <Dataset {'created_at': datetime.datetime(2021, 3, 28, 23, 35, 34, tzinfo=datetime.timezone.utc), 'description': '', 'name': 'image_mal_dataset', 'uid': 'ckmtsvzps21f80y6205t304se', 'updated_at': datetime.datetime(2021, 3, 28, 23, 35, 34, tzinfo=datetime.timezone.utc)}>\n",
-      "Associated label(s) <Label {'agreement': None, 'benchmark_agreement': None, 'created_at': datetime.datetime(2021, 3, 29, 17, 53, 36, tzinfo=datetime.timezone.utc), 'is_benchmark_reference': False, 'label': '{\"objects\":[{\"featureId\":\"ckmuw40nm00013g68kfua4i88\",\"schemaId\":\"ckk4q1vo80nhv0y92b7vgctgt\",\"title\":\"Frog\",\"value\":\"frog\",\"color\":\"#00D4FF\",\"bbox\":{\"top\":815,\"left\":847,\"height\":247,\"width\":512},\"instanceURI\":\"https://api.labelbox.com/masks/feature/ckmuw40nm00013g68kfua4i88\"}],\"classifications\":[]}', 'seconds_to_label': 0, 'uid': 'ckmuw42qy00033g68zdhpove7', 'updated_at': datetime.datetime(2021, 3, 29, 17, 54, 32, tzinfo=datetime.timezone.utc)}>\n",
-      "External id dbb168f6-4f2c-46e0-a22a-abc837fda3f1\n"
+      "Associated dataset <Dataset {'created_at': datetime.datetime(2021, 6, 8, 2, 40, 10, tzinfo=datetime.timezone.utc), 'description': '', 'name': 'image_mea_dataset', 'uid': 'ckpnfqv6g1rvb0ybt85hjephs', 'updated_at': datetime.datetime(2021, 6, 8, 2, 40, 10, tzinfo=datetime.timezone.utc)}>\n",
+      "Associated label(s) <Label {'agreement': None, 'benchmark_agreement': None, 'created_at': datetime.datetime(2021, 6, 8, 2, 42, 11, tzinfo=datetime.timezone.utc), 'is_benchmark_reference': False, 'label': '{\"objects\":[{\"featureId\":\"ckpnftdgo00013h693jxji4wa\",\"schemaId\":\"ckpnfqw600kyt0y8tgwsb01xg\",\"title\":\"person\",\"value\":\"person\",\"color\":\"#ff0000\",\"bbox\":{\"top\":1044,\"left\":1460,\"height\":265,\"width\":118},\"instanceURI\":\"https://api.labelbox.com/masks/feature/ckpnftdgo00013h693jxji4wa\"},{\"featureId\":\"ckpo2bsq800013h69mi1w6xz1\",\"schemaId\":\"ckpnfqw610kyx0y8t4hotc6ld\",\"title\":\"car\",\"value\":\"car\",\"color\":\"#00ffff\",\"instanceURI\":\"https://api.labelbox.com/masks/feature/ckpo2bsq800013h69mi1w6xz1\"}],\"classifications\":[]}', 'seconds_to_label': 101.633, 'uid': 'ckpnftgpx00033h69z83erv92', 'updated_at': datetime.datetime(2021, 6, 9, 0, 51, 34, tzinfo=datetime.timezone.utc)}>\n",
+      "External id 3b983504-bfbd-4c26-8719-8ef2d5a2c14f\n"
      ]
     }
    ],
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "above-vocabulary",
    "metadata": {},
    "outputs": [
@@ -165,7 +165,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<DataRow {'created_at': datetime.datetime(2021, 3, 28, 23, 35, 35, tzinfo=datetime.timezone.utc), 'external_id': 'dbb168f6-4f2c-46e0-a22a-abc837fda3f1', 'row_data': 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/Kitano_Street_Kobe01s5s4110.jpg/2560px-Kitano_Street_Kobe01s5s4110.jpg', 'uid': 'ckmtsvzx421fb0y62bbsmbavz', 'updated_at': datetime.datetime(2021, 3, 29, 17, 54, 56, tzinfo=datetime.timezone.utc)}>\n"
+      "<DataRow {'created_at': datetime.datetime(2021, 6, 8, 2, 40, 10, tzinfo=datetime.timezone.utc), 'external_id': '3b983504-bfbd-4c26-8719-8ef2d5a2c14f', 'media_attributes': {'width': 2560, 'height': 1707, 'mimeType': 'image/jpeg'}, 'row_data': 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/Kitano_Street_Kobe01s5s4110.jpg/2560px-Kitano_Street_Kobe01s5s4110.jpg', 'uid': 'ckpnfqvcb0t2o0yane73d3whi', 'updated_at': datetime.datetime(2021, 6, 9, 0, 51, tzinfo=datetime.timezone.utc)}>\n"
      ]
     }
    ],
@@ -185,17 +185,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "medical-portuguese",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<DataRow ID: ckmuw60q700ur0y8wcu178hbi>"
+       "<DataRow ID: ckporcoee1c7s0z7fha6l5x0d>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "round-perfume",
    "metadata": {},
    "outputs": [],
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "breeding-brother",
    "metadata": {},
    "outputs": [],
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "thrown-designation",
    "metadata": {},
    "outputs": [],
@@ -256,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "japanese-jefferson",
    "metadata": {},
    "outputs": [],
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "accessible-effort",
    "metadata": {},
    "outputs": [
@@ -304,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "floral-elimination",
    "metadata": {},
    "outputs": [
@@ -312,7 +312,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "18201a8d-34a5-41ea-8ea0-feede9776b4a 18201a8d-34a5-41ea-8ea0-feede9776b4a\n"
+      "337e90de-c13c-48be-a87d-94d331b5e9a7 337e90de-c13c-48be-a87d-94d331b5e9a7\n"
      ]
     }
    ],
@@ -325,17 +325,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "collect-cosmetic",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<AssetMetadata ID: ckmuw6mme5mpr0y839dzheh7c>"
+       "<AssetAttachment ID: ckporcvj61dni0y632e6cb217>"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -343,10 +343,10 @@
    "source": [
     "# We can also create attachments\n",
     "# Attachments are visible for all projects connected to the data_row \n",
-    "data_row.create_metadata(meta_type=\"TEXT\", meta_value=\"LABELERS WILL SEE THIS \")\n",
+    "data_row.create_attachment(attachment_type=\"TEXT\", attachment_value=\"LABELERS WILL SEE THIS \")\n",
     "# See more information here:\n",
     "# https://docs.labelbox.com/data-model/en/index-en#attachments\n",
-    "# Note that meta_value must always be a string (url to a video/image or a text value to display)"
+    "# Note that attachment_value must always be a string (url to a video/image or a text value to display)"
    ]
   },
   {
@@ -359,7 +359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "dental-banana",
    "metadata": {},
    "outputs": [],
@@ -370,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "binary-organic",
    "metadata": {},
    "outputs": [],

--- a/labelbox/orm/db_object.py
+++ b/labelbox/orm/db_object.py
@@ -117,6 +117,10 @@ class RelationshipManager:
     def __call__(self, *args, **kwargs):
         """ Forwards the call to either `_to_many` or `_to_one` methods,
         depending on relationship type. """
+
+        if self.relationship.deprecation_message:
+            logger.warning(self.relationship.deprecation_message)
+
         if self.relationship.relationship_type == Relationship.Type.ToMany:
             return self._to_many(*args, **kwargs)
         else:
@@ -131,7 +135,6 @@ class RelationshipManager:
             iterable over destination DbObject instances.
         """
         rel = self.relationship
-
         if where is not None and not self.supports_filtering:
             raise InvalidQueryError(
                 "Relationship %s.%s doesn't support filtering" %

--- a/labelbox/orm/db_object.py
+++ b/labelbox/orm/db_object.py
@@ -118,8 +118,8 @@ class RelationshipManager:
         """ Forwards the call to either `_to_many` or `_to_one` methods,
         depending on relationship type. """
 
-        if self.relationship.deprecation_message:
-            logger.warning(self.relationship.deprecation_message)
+        if self.relationship.deprecation_warning:
+            logger.warning(self.relationship.deprecation_warning)
 
         if self.relationship.relationship_type == Relationship.Type.ToMany:
             return self._to_many(*args, **kwargs)

--- a/labelbox/orm/model.py
+++ b/labelbox/orm/model.py
@@ -186,7 +186,7 @@ class Relationship:
             (not always) just a camelCase version of `name`.
         cache (bool) : Whether or not to cache the relationship values.
             Useful for objects that aren't directly queryable from the api (relationship query builder won't work)
-            Also useful for expensive ToOne relationships 
+            Also useful for expensive ToOne relationships
 
     """
 
@@ -195,12 +195,12 @@ class Relationship:
         ToMany = auto()
 
     @staticmethod
-    def ToOne(*args, cache=False):
-        return Relationship(Relationship.Type.ToOne, *args, cache=cache)
+    def ToOne(*args, **kwargs):
+        return Relationship(Relationship.Type.ToOne, *args, **kwargs)
 
     @staticmethod
-    def ToMany(*args):
-        return Relationship(Relationship.Type.ToMany, *args)
+    def ToMany(*args, **kwargs):
+        return Relationship(Relationship.Type.ToMany, *args, **kwargs)
 
     def __init__(self,
                  relationship_type,
@@ -208,11 +208,13 @@ class Relationship:
                  filter_deleted=True,
                  name=None,
                  graphql_name=None,
-                 cache=False):
+                 cache=False,
+                 deprecation_message=None):
         self.relationship_type = relationship_type
         self.destination_type_name = destination_type_name
         self.filter_deleted = filter_deleted
         self.cache = cache
+        self.deprecation_message = deprecation_message
 
         if name is None:
             name = utils.snake_case(destination_type_name) + (
@@ -268,14 +270,14 @@ class EntityMeta(type):
 
     def validate_cached_relationships(cls):
         """
-        Graphql doesn't allow for infinite nesting in queries. 
+        Graphql doesn't allow for infinite nesting in queries.
         This function checks that cached relationships result in valid queries.
             * It does this by making sure that a cached relationship do not
               reference any entity with its own cached relationships.
 
-        This check is performed by looking to see if this entity caches 
-        any entities that have their own cached fields. If this entity 
-        that we are checking has any cached fields then we also check 
+        This check is performed by looking to see if this entity caches
+        any entities that have their own cached fields. If this entity
+        that we are checking has any cached fields then we also check
         all currently defined entities to see if they cache this entity.
 
         A two way check is necessary because checks are performed as classes are being defined.

--- a/labelbox/orm/model.py
+++ b/labelbox/orm/model.py
@@ -187,6 +187,7 @@ class Relationship:
         cache (bool) : Whether or not to cache the relationship values.
             Useful for objects that aren't directly queryable from the api (relationship query builder won't work)
             Also useful for expensive ToOne relationships
+        deprecation_warning (string) optional message to display when RelationshipManager is called
 
     """
 
@@ -209,12 +210,12 @@ class Relationship:
                  name=None,
                  graphql_name=None,
                  cache=False,
-                 deprecation_message=None):
+                 deprecation_warning=None):
         self.relationship_type = relationship_type
         self.destination_type_name = destination_type_name
         self.filter_deleted = filter_deleted
         self.cache = cache
-        self.deprecation_message = deprecation_message
+        self.deprecation_warning = deprecation_warning
 
         if name is None:
             name = utils.snake_case(destination_type_name) + (

--- a/labelbox/schema/__init__.py
+++ b/labelbox/schema/__init__.py
@@ -1,4 +1,5 @@
 import labelbox.schema.asset_metadata
+import labelbox.schema.asset_attachment
 import labelbox.schema.bulk_import_request
 import labelbox.schema.benchmark
 import labelbox.schema.data_row

--- a/labelbox/schema/asset_attachment.py
+++ b/labelbox/schema/asset_attachment.py
@@ -1,0 +1,25 @@
+from enum import Enum
+from labelbox.orm.db_object import DbObject
+from labelbox.orm.model import Field
+
+class AssetAttachment(DbObject):
+    """ Asset attachment provides extra context about an asset while labeling.
+
+    Attributes:
+        attachment_type (str): IMAGE, VIDEO, TEXT, or IMAGE_OVERLAY
+        attachment_value (str): URL to an external file or a string of text
+    """
+
+    class MetaType(Enum):
+        VIDEO = "VIDEO"
+        IMAGE = "IMAGE"
+        TEXT = "TEXT"
+        IMAGE_OVERLAY = "IMAGE_OVERLAY"
+
+    # For backwards compatibility
+    for topic in MetaType:
+        vars()[topic.name] = topic.value
+
+
+    attachment_type = Field.String("attachment_type")
+    attachment_value = Field.String("attachment_value")

--- a/labelbox/schema/asset_attachment.py
+++ b/labelbox/schema/asset_attachment.py
@@ -1,4 +1,5 @@
 from enum import Enum
+
 from labelbox.orm.db_object import DbObject
 from labelbox.orm.model import Field
 

--- a/labelbox/schema/asset_attachment.py
+++ b/labelbox/schema/asset_attachment.py
@@ -2,6 +2,7 @@ from enum import Enum
 from labelbox.orm.db_object import DbObject
 from labelbox.orm.model import Field
 
+
 class AssetAttachment(DbObject):
     """ Asset attachment provides extra context about an asset while labeling.
 
@@ -10,16 +11,14 @@ class AssetAttachment(DbObject):
         attachment_value (str): URL to an external file or a string of text
     """
 
-    class MetaType(Enum):
+    class AttachmentType(Enum):
         VIDEO = "VIDEO"
         IMAGE = "IMAGE"
         TEXT = "TEXT"
         IMAGE_OVERLAY = "IMAGE_OVERLAY"
 
-    # For backwards compatibility
-    for topic in MetaType:
+    for topic in AttachmentType:
         vars()[topic.name] = topic.value
 
-
-    attachment_type = Field.String("attachment_type")
-    attachment_value = Field.String("attachment_value")
+    attachment_type = Field.String("attachment_type", "type")
+    attachment_value = Field.String("attachment_value", "value")

--- a/labelbox/schema/asset_metadata.py
+++ b/labelbox/schema/asset_metadata.py
@@ -1,8 +1,10 @@
 from enum import Enum
+import logging
 
 from labelbox.orm.db_object import DbObject
 from labelbox.orm.model import Field
 
+logger = logging.getLogger(__name__)
 
 class AssetMetadata(DbObject):
     """ Asset metadata (AKA Attachments) provides extra context about an asset while labeling.
@@ -11,6 +13,12 @@ class AssetMetadata(DbObject):
         meta_type (str): IMAGE, VIDEO, TEXT, or IMAGE_OVERLAY
         meta_value (str): URL to an external file or a string of text
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        logger.warning(
+            "`create_metadata` is deprecated. Use `create_attachment` instead."
+        )
 
     class MetaType(Enum):
         VIDEO = "VIDEO"

--- a/labelbox/schema/asset_metadata.py
+++ b/labelbox/schema/asset_metadata.py
@@ -6,6 +6,7 @@ from labelbox.orm.model import Field
 
 logger = logging.getLogger(__name__)
 
+
 class AssetMetadata(DbObject):
     """ Asset metadata (AKA Attachments) provides extra context about an asset while labeling.
 
@@ -17,8 +18,7 @@ class AssetMetadata(DbObject):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         logger.warning(
-            "`create_metadata` is deprecated. Use `create_attachment` instead."
-        )
+            "`AssetMetadata` is deprecated. Use `AssetAttachment` instead.")
 
     class MetaType(Enum):
         VIDEO = "VIDEO"

--- a/labelbox/schema/data_row.py
+++ b/labelbox/schema/data_row.py
@@ -42,7 +42,7 @@ class DataRow(DbObject, Updateable, BulkDeletable):
         "AssetMetadata",
         False,
         "metadata",
-        deprecation_message=
+        deprecation_warning=
         "`DataRow.metadata()` is deprecated. Use `DataRow.attachments()` instead."
     )
     attachments = Relationship.ToMany("AssetAttachment", False, "attachments")

--- a/labelbox/schema/data_row.py
+++ b/labelbox/schema/data_row.py
@@ -1,9 +1,11 @@
+import logging
+
 from labelbox.orm import query
 from labelbox.orm.db_object import DbObject, Updateable, BulkDeletable
 from labelbox.orm.model import Entity, Field, Relationship
 from labelbox.schema.asset_attachment import AssetAttachment
 
-import logging
+
 
 logger = logging.getLogger(__name__)
 

--- a/labelbox/schema/data_row.py
+++ b/labelbox/schema/data_row.py
@@ -5,8 +5,6 @@ from labelbox.orm.db_object import DbObject, Updateable, BulkDeletable
 from labelbox.orm.model import Entity, Field, Relationship
 from labelbox.schema.asset_attachment import AssetAttachment
 
-
-
 logger = logging.getLogger(__name__)
 
 

--- a/labelbox/schema/organization.py
+++ b/labelbox/schema/organization.py
@@ -103,10 +103,10 @@ class Organization(DbObject):
         """ Retrieve invite limits for the org
         This already accounts for users currently in the org
         Meaining that  `used = users + invites, remaining = limit - (users + invites)`
-       
+
         Returns:
             InviteLimit
-    
+
         """
         org_id_param = "organizationId"
         res = self.client.execute("""query InvitesLimitPyApi($%s: ID!) {

--- a/tests/integration/test_asset_metadata.py
+++ b/tests/integration/test_asset_metadata.py
@@ -37,7 +37,6 @@ def test_asset_metadata_crud(project, dataset):
         "Relationship DataRow.metadata doesn't support sorting"
 
 
-
 def test_asset_attachment_crud(project, dataset):
     # must attach a dataset to a project before it can be queryable
     # due to permissions

--- a/tests/integration/test_asset_metadata.py
+++ b/tests/integration/test_asset_metadata.py
@@ -1,6 +1,6 @@
-from labelbox.schema.asset_attachment import AssetAttachment
 import pytest
 
+from labelbox.schema.asset_attachment import AssetAttachment
 from labelbox import AssetMetadata
 from labelbox.exceptions import InvalidQueryError
 

--- a/tests/integration/test_asset_metadata.py
+++ b/tests/integration/test_asset_metadata.py
@@ -1,3 +1,4 @@
+from labelbox.schema.asset_attachment import AssetAttachment
 import pytest
 
 from labelbox import AssetMetadata
@@ -34,3 +35,34 @@ def test_asset_metadata_crud(project, dataset):
         data_row.metadata(order_by=AssetMetadata.meta_value.asc)
     assert exc_info.value.message == \
         "Relationship DataRow.metadata doesn't support sorting"
+
+
+
+def test_asset_attachment_crud(project, dataset):
+    # must attach a dataset to a project before it can be queryable
+    # due to permissions
+    project.datasets.connect(dataset)
+    data_row = dataset.create_data_row(row_data=IMG_URL)
+    assert len(list(data_row.metadata())) == 0
+
+    # Create
+    asset = data_row.create_attachment(AssetAttachment.TEXT, "Value")
+    assert asset.attachment_type == AssetAttachment.TEXT
+    assert asset.attachment_value == "Value"
+    assert len(list(data_row.metadata())) == 1
+
+    with pytest.raises(ValueError) as exc_info:
+        data_row.create_attachment("NOT_SUPPORTED_TYPE", "Value")
+    expected_types = {item.value for item in AssetAttachment.AttachmentType}
+    assert str(exc_info.value) == \
+        f"meta_type must be one of {expected_types}. Found NOT_SUPPORTED_TYPE"
+
+    # Check that filtering and sorting is prettily disabled
+    with pytest.raises(InvalidQueryError) as exc_info:
+        data_row.attachments(where=AssetAttachment.attachment_value == "x")
+    assert exc_info.value.message == \
+        "Relationship DataRow.attachments doesn't support filtering"
+    with pytest.raises(InvalidQueryError) as exc_info:
+        data_row.attachments(order_by=AssetAttachment.attachment_value.asc)
+    assert exc_info.value.message == \
+        "Relationship DataRow.attachments doesn't support sorting"


### PR DESCRIPTION
Changes
* Create new AssetAttachment object to replace AssetMetadata
* Replace create_metadata with create_attachments
* Use new attachment queries and mutations
* Add deprecation warnings - the sdk now supports deprecation warnings on relationships
* Update tests and example notebook to use attachments instead of metadata.