### PR TITLE
[WORK-1] remove labelingFrontend.projects from SDK

### DIFF
--- a/labelbox/schema/labeling_frontend.py
+++ b/labelbox/schema/labeling_frontend.py
@@ -20,10 +20,6 @@ class LabelingFrontend(DbObject):
     description = Field.String("description")
     iframe_url_path = Field.String("iframe_url_path")
 
-    # TODO other fields and relationships
-    projects = Relationship.ToMany("Project", True)
-
-
 class LabelingFrontendOptions(DbObject):
     """ Label interface options.
 

--- a/labelbox/schema/labeling_frontend.py
+++ b/labelbox/schema/labeling_frontend.py
@@ -20,6 +20,7 @@ class LabelingFrontend(DbObject):
     description = Field.String("description")
     iframe_url_path = Field.String("iframe_url_path")
 
+
 class LabelingFrontendOptions(DbObject):
     """ Label interface options.
 

--- a/tests/integration/test_labeling_frontend.py
+++ b/tests/integration/test_labeling_frontend.py
@@ -22,8 +22,6 @@ def test_labeling_frontend_connecting_to_project(project):
 
     project.labeling_frontend.connect(frontend)
     assert project.labeling_frontend() == frontend
-    assert project in set(frontend.projects())
 
     project.labeling_frontend.disconnect(frontend)
     assert project.labeling_frontend() == None
-    assert project not in set(frontend.projects())


### PR DESCRIPTION
Builds on https://github.com/Labelbox/intelligence/pull/5010 to remove all `labelingFrontends.projects` references from the SDK + tests

