### PR TITLE
limit picsum requests

### DIFF
--- a/tests/integration/bulk_import/conftest.py
+++ b/tests/integration/bulk_import/conftest.py
@@ -6,8 +6,6 @@ import time
 from labelbox.schema.labeling_frontend import LabelingFrontend
 from labelbox.schema.annotation_import import MALPredictionImport
 
-IMG_URL = "https://picsum.photos/200/300"
-
 
 @pytest.fixture
 def ontology():
@@ -103,7 +101,7 @@ def ontology():
 
 
 @pytest.fixture
-def configured_project(client, ontology, rand_gen):
+def configured_project(client, ontology, rand_gen, image_url):
     project = client.create_project(name=rand_gen(str))
     dataset = client.create_dataset(name=rand_gen(str))
     editor = list(
@@ -112,7 +110,7 @@ def configured_project(client, ontology, rand_gen):
     project.setup(editor, ontology)
     data_row_ids = []
     for _ in range(len(ontology['tools']) + len(ontology['classifications'])):
-        data_row_ids.append(dataset.create_data_row(row_data=IMG_URL).uid)
+        data_row_ids.append(dataset.create_data_row(row_data=image_url).uid)
     project.datasets.connect(dataset)
     project.data_row_ids = data_row_ids
     yield project

--- a/tests/integration/test_data_row_metadata.py
+++ b/tests/integration/test_data_row_metadata.py
@@ -6,7 +6,6 @@ from labelbox import DataRow, Dataset
 from labelbox.schema.data_row_metadata import DataRowMetadataField, DataRowMetadata, DeleteDataRowMetadata, \
     DataRowMetadataOntology
 
-IMG_URL = "https://picsum.photos/id/829/200/300"
 FAKE_SCHEMA_ID = "0" * 25
 SPLIT_SCHEMA_ID = "cko8sbczn0002h2dkdaxb5kal"
 TRAIN_SPLIT_ID = "cko8sbscr0003h2dk04w86hof"
@@ -22,13 +21,14 @@ def mdo(client):
 
 
 @pytest.fixture
-def big_dataset(dataset: Dataset):
+def big_dataset(client, dataset: Dataset, image_url):
+    image_url = client
     task = dataset.create_data_rows([
         {
-            "row_data": IMG_URL,
+            "row_data": image_url,
             "external_id": "my-image"
         },
-    ] * 1000)
+    ] * 500)
     task.wait_till_done()
 
     yield dataset

--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -6,24 +6,22 @@ import requests
 from labelbox import DataRow
 from labelbox.exceptions import InvalidQueryError
 
-IMG_URL = "https://picsum.photos/id/829/200/300"
-
 
 def test_get_data_row(datarow, client):
     assert client.get_data_row(datarow.uid)
 
 
-def test_data_row_bulk_creation(dataset, rand_gen):
+def test_data_row_bulk_creation(dataset, rand_gen, image_url):
     client = dataset.client
     assert len(list(dataset.data_rows())) == 0
 
     # Test creation using URL
     task = dataset.create_data_rows([
         {
-            DataRow.row_data: IMG_URL
+            DataRow.row_data: image_url
         },
         {
-            "row_data": IMG_URL
+            "row_data": image_url
         },
     ])
     assert task in client.get_user().created_tasks()
@@ -35,7 +33,7 @@ def test_data_row_bulk_creation(dataset, rand_gen):
 
     data_rows = list(dataset.data_rows())
     assert len(data_rows) == 2
-    assert {data_row.row_data for data_row in data_rows} == {IMG_URL}
+    assert {data_row.row_data for data_row in data_rows} == {image_url}
 
     # Test creation using file name
     with NamedTemporaryFile() as fp:
@@ -48,20 +46,20 @@ def test_data_row_bulk_creation(dataset, rand_gen):
 
     data_rows = list(dataset.data_rows())
     assert len(data_rows) == 3
-    url = ({data_row.row_data for data_row in data_rows} - {IMG_URL}).pop()
+    url = ({data_row.row_data for data_row in data_rows} - {image_url}).pop()
     assert requests.get(url).content == data
 
     data_rows[0].delete()
 
 
 @pytest.mark.slow
-def test_data_row_large_bulk_creation(dataset, rand_gen):
+def test_data_row_large_bulk_creation(dataset, image_url):
     # Do a longer task and expect it not to be complete immediately
     with NamedTemporaryFile() as fp:
         fp.write("Test data".encode())
         fp.flush()
         task = dataset.create_data_rows([{
-            DataRow.row_data: IMG_URL
+            DataRow.row_data: image_url
         }] * 4500 + [fp.name] * 500)
     assert task.status == "IN_PROGRESS"
     task.wait_till_done()
@@ -70,16 +68,16 @@ def test_data_row_large_bulk_creation(dataset, rand_gen):
 
 
 @pytest.mark.xfail(reason="DataRow.dataset() relationship not set")
-def test_data_row_single_creation(dataset, rand_gen):
+def test_data_row_single_creation(dataset, rand_gen, image_url):
     client = dataset.client
     assert len(list(dataset.data_rows())) == 0
 
-    data_row = dataset.create_data_row(row_data=IMG_URL)
+    data_row = dataset.create_data_row(row_data=image_url)
     assert len(list(dataset.data_rows())) == 1
     assert data_row.dataset() == dataset
     assert data_row.created_by() == client.get_user()
     assert data_row.organization() == client.get_organization()
-    assert requests.get(IMG_URL).content == \
+    assert requests.get(image_url).content == \
         requests.get(data_row.row_data).content
     assert data_row.media_attributes is not None
 
@@ -92,9 +90,9 @@ def test_data_row_single_creation(dataset, rand_gen):
         assert requests.get(data_row_2.row_data).content == data
 
 
-def test_data_row_update(dataset, rand_gen):
+def test_data_row_update(dataset, rand_gen, image_url):
     external_id = rand_gen(str)
-    data_row = dataset.create_data_row(row_data=IMG_URL,
+    data_row = dataset.create_data_row(row_data=image_url,
                                        external_id=external_id)
     assert data_row.external_id == external_id
 
@@ -103,14 +101,14 @@ def test_data_row_update(dataset, rand_gen):
     assert data_row.external_id == external_id_2
 
 
-def test_data_row_filtering_sorting(dataset, rand_gen):
+def test_data_row_filtering_sorting(dataset, image_url):
     task = dataset.create_data_rows([
         {
-            DataRow.row_data: IMG_URL,
+            DataRow.row_data: image_url,
             DataRow.external_id: "row1"
         },
         {
-            DataRow.row_data: IMG_URL,
+            DataRow.row_data: image_url,
             DataRow.external_id: "row2"
         },
     ])
@@ -133,9 +131,9 @@ def test_data_row_filtering_sorting(dataset, rand_gen):
         dataset.data_rows(order_by=DataRow.external_id.desc)) == [row2, row1]
 
 
-def test_data_row_deletion(dataset, rand_gen):
+def test_data_row_deletion(dataset, image_url):
     task = dataset.create_data_rows([{
-        DataRow.row_data: IMG_URL,
+        DataRow.row_data: image_url,
         DataRow.external_id: str(i)
     } for i in range(10)])
     task.wait_till_done()
@@ -159,13 +157,13 @@ def test_data_row_deletion(dataset, rand_gen):
     assert {dr.external_id for dr in data_rows} == expected
 
 
-def test_data_row_iteration(dataset, rand_gen) -> None:
+def test_data_row_iteration(dataset, image_url) -> None:
     task = dataset.create_data_rows([
         {
-            DataRow.row_data: IMG_URL
+            DataRow.row_data: image_url
         },
         {
-            "row_data": IMG_URL
+            "row_data": image_url
         },
     ])
     task.wait_till_done()

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -3,8 +3,6 @@ import requests
 from labelbox import Dataset
 from labelbox.exceptions import ResourceNotFoundError
 
-IMG_URL = "https://picsum.photos/200/300"
-
 
 def test_dataset(client, rand_gen):
     before = list(client.get_datasets())
@@ -61,20 +59,20 @@ def test_dataset_filtering(client, rand_gen):
     d2.delete()
 
 
-def test_get_data_row_for_external_id(dataset, rand_gen):
+def test_get_data_row_for_external_id(dataset, rand_gen, image_url):
     external_id = rand_gen(str)
 
     with pytest.raises(ResourceNotFoundError):
         data_row = dataset.data_row_for_external_id(external_id)
 
-    data_row = dataset.create_data_row(row_data=IMG_URL,
+    data_row = dataset.create_data_row(row_data=image_url,
                                        external_id=external_id)
 
     found = dataset.data_row_for_external_id(external_id)
     assert found.uid == data_row.uid
     assert found.external_id == external_id
 
-    dataset.create_data_row(row_data=IMG_URL, external_id=external_id)
+    dataset.create_data_row(row_data=image_url, external_id=external_id)
     assert len(dataset.data_rows_for_external_id(external_id)) == 2
 
 
@@ -98,11 +96,11 @@ def test_upload_video_file(dataset, sample_video: str) -> None:
         assert response.headers['Content-Type'] == 'video/mp4'
 
 
-def test_data_row_export(dataset):
+def test_data_row_export(dataset, image_url):
     n_data_rows = 5
     ids = set()
     for _ in range(n_data_rows):
-        ids.add(dataset.create_data_row(row_data=IMG_URL))
+        ids.add(dataset.create_data_row(row_data=image_url))
     result = list(dataset.export_data_rows())
     assert len(result) == n_data_rows
     assert set(result) == ids

--- a/tests/integration/test_label.py
+++ b/tests/integration/test_label.py
@@ -6,8 +6,6 @@ import requests
 
 from labelbox import Label
 
-IMG_URL = "https://picsum.photos/200/300"
-
 
 @pytest.mark.skip("Cannot query for labels created with create_label")
 def test_labels(label_pack):
@@ -57,11 +55,11 @@ def test_label_update(label_pack):
 
 
 @pytest.mark.skip("Cannot query for labels created with create_label")
-def test_label_filter_order(client, project, rand_gen):
+def test_label_filter_order(client, project, rand_gen, image_url):
     dataset_1 = client.create_dataset(name=rand_gen(str), projects=project)
     dataset_2 = client.create_dataset(name=rand_gen(str), projects=project)
-    data_row_1 = dataset_1.create_data_row(row_data=IMG_URL)
-    data_row_2 = dataset_2.create_data_row(row_data=IMG_URL)
+    data_row_1 = dataset_1.create_data_row(row_data=image_url)
+    data_row_2 = dataset_2.create_data_row(row_data=image_url)
 
     l1 = project.create_label(data_row=data_row_1, label="l1")
     time.sleep(1)  #Ensure there is no race condition
@@ -86,11 +84,11 @@ def test_label_filter_order(client, project, rand_gen):
 
 
 @pytest.mark.skip("Cannot query for labels created with create_label")
-def test_label_bulk_deletion(project, rand_gen):
+def test_label_bulk_deletion(project, rand_gen, image_url):
     dataset = project.client.create_dataset(name=rand_gen(str),
                                             projects=project)
-    row_1 = dataset.create_data_row(row_data=IMG_URL)
-    row_2 = dataset.create_data_row(row_data=IMG_URL)
+    row_1 = dataset.create_data_row(row_data=image_url)
+    row_2 = dataset.create_data_row(row_data=image_url)
 
     l1 = project.create_label(data_row=row_1, label="l1")
     l2 = project.create_label(data_row=row_1, label="l2")

--- a/tests/integration/test_labeling_parameter_overrides.py
+++ b/tests/integration/test_labeling_parameter_overrides.py
@@ -1,14 +1,12 @@
 import pytest
 from labelbox import DataRow
 
-IMG_URL = "https://picsum.photos/200/300"
 
-
-def test_labeling_parameter_overrides(project, rand_gen):
+def test_labeling_parameter_overrides(project, rand_gen, image_url):
     dataset = project.client.create_dataset(name=rand_gen(str),
                                             projects=project)
 
-    task = dataset.create_data_rows([{DataRow.row_data: IMG_URL}] * 20)
+    task = dataset.create_data_rows([{DataRow.row_data: image_url}] * 20)
     task.wait_till_done()
     assert task.status == "COMPLETE"
 


### PR DESCRIPTION
* Picsum was rate limiting us which caused our backend to throw errors. 
* For each set of tests that we run there is now only one request to picsum and it is made from the client.