### PR TITLE
Change benchmark_id typing to str for LBV1Label

### DIFF
--- a/labelbox/data/serialization/labelbox_v1/label.py
+++ b/labelbox/data/serialization/labelbox_v1/label.py
@@ -131,7 +131,7 @@ class LBV1Label(BaseModel):
     seconds_to_label: Optional[float] = Extra('Seconds to Label')
     agreement: Optional[float] = Extra('Agreement')
     benchmark_agreement: Optional[float] = Extra('Benchmark Agreement')
-    benchmark_id: Optional[float] = Extra('Benchmark ID')
+    benchmark_id: Optional[str] = Extra('Benchmark ID')
     dataset_name: Optional[str] = Extra('Dataset Name')
     reviews: Optional[List[Review]] = Extra('Reviews')
     label_url: Optional[str] = Extra('View Label')


### PR DESCRIPTION
I changed the type for benchmark_id to prevent the following error from happening, following a call to `project.label_genetors()`

`"Unexpected exception while filling the queue. ValidationError(model='LBV1Label', errors=[{'loc': ('Benchmark ID',), 'msg': 'value is not a valid float', 'type': 'type_error.float'}])"`

The error was originally mentioned in ticket  https://labelbox.atlassian.net/browse/LS-797.