### PR TITLE
consistent drawing behavior

### DIFF
--- a/labelbox/data/annotation_types/geometry/geometry.py
+++ b/labelbox/data/annotation_types/geometry/geometry.py
@@ -27,6 +27,7 @@ class Geometry(BaseModel, ABC):
                 raise ValueError(
                     "Must either provide canvas or height and width")
             canvas = np.zeros((height, width, 3), dtype=np.uint8)
+        canvas = np.ascontiguousarray(canvas)
         return canvas
 
     @property


### PR DESCRIPTION
If an array is non-contiguous then opencv drawing functions return opencv matrix objects instead of numpy arrays. Adding np.ascontiguous array prevents this situation from occuring. It also doesn't do anything unless the array is non-contiguous so there isn't any extra overhead for adding this each time. 