### PR TITLE
skip test

### DIFF
--- a/tests/integration/annotation_import/test_label_import.py
+++ b/tests/integration/annotation_import/test_label_import.py
@@ -66,6 +66,7 @@ def test_get(client, project, annotation_import_test_helpers):
 
 
 @pytest.mark.slow
+@pytest.mark.skip(reason="beta feature still being developed")
 def test_wait_till_done(client, project, predictions):
     name = str(uuid.uuid4())
     label_import = LabelImport.create_from_objects(client=client,


### PR DESCRIPTION
Label imports not implemented in prod. So this just hangs forever and stops us from releasing new sdk versions.