### PR TITLE
better error message when schema ids are none

### DIFF
--- a/labelbox/data/ontology.py
+++ b/labelbox/data/ontology.py
@@ -14,6 +14,10 @@ def get_feature_schema_lookup(
 
     def flatten_classification(classifications):
         for classification in classifications:
+            if classification.feature_schema_id is None:
+                raise ValueError(
+                    f"feature_schema_id is None for classification `{classification.name}`."
+                )
             if isinstance(classification, ontology.Classification):
                 classification_lookup[
                     classification.
@@ -28,6 +32,9 @@ def get_feature_schema_lookup(
             flatten_classification(classification.options)
 
     for tool in ontology_builder.tools:
+        if tool.feature_schema_id is None:
+            raise ValueError(
+                f"feature_schema_id is None for tool `{tool.name}`.")
         tool_lookup[tool.name] = tool.feature_schema_id
         flatten_classification(tool.classifications)
     flatten_classification(ontology_builder.classifications)

--- a/labelbox/data/ontology.py
+++ b/labelbox/data/ontology.py
@@ -16,7 +16,7 @@ def get_feature_schema_lookup(
         for classification in classifications:
             if classification.feature_schema_id is None:
                 raise ValueError(
-                    f"feature_schema_id is None for classification `{classification.name}`."
+                    f"feature_schema_id cannot be None for classification `{classification.name}`."
                 )
             if isinstance(classification, ontology.Classification):
                 classification_lookup[
@@ -34,7 +34,7 @@ def get_feature_schema_lookup(
     for tool in ontology_builder.tools:
         if tool.feature_schema_id is None:
             raise ValueError(
-                f"feature_schema_id is None for tool `{tool.name}`.")
+                f"feature_schema_id cannot be None for tool `{tool.name}`.")
         tool_lookup[tool.name] = tool.feature_schema_id
         flatten_classification(tool.classifications)
     flatten_classification(ontology_builder.classifications)


### PR DESCRIPTION
* Throw an error if the schema id does not exist in the ontology
* This was causing weird / unclear errors later on when users go to use the ids