### PR TITLE
Improve error handling [DIAG-884]

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -199,7 +199,7 @@ class Client:
             return None
 
         def get_error_status_code(error):
-            return error["extensions"]["exception"]["status"]
+            return error["extensions"]["exception"].get("status")
 
         if check_errors(["AUTHENTICATION_ERROR"], "extensions",
                         "code") is not None:
@@ -245,6 +245,12 @@ class Client:
         if resource_conflict_error is not None:
             raise labelbox.exceptions.ResourceConflict(
                 resource_conflict_error["message"])
+
+        malformed_request_error = check_errors(["MALFORMED_REQUEST"],
+                                               "extensions", "code")
+        if malformed_request_error is not None:
+            raise labelbox.exceptions.MalformedQueryException(
+                malformed_request_error["message"])
 
         # A lot of different error situations are now labeled serverside
         # as INTERNAL_SERVER_ERROR, when they are actually client errors.

--- a/labelbox/exceptions.py
+++ b/labelbox/exceptions.py
@@ -42,6 +42,11 @@ class ResourceNotFoundError(LabelboxError):
         self.params = params
 
 
+class ResourceConflict(LabelboxError):
+    """Exception raised when a given resource conflicts with another. """
+    pass
+
+
 class ValidationFailedError(LabelboxError):
     """Exception raised for when a GraphQL query fails validation (query cost,
     etc.) E.g. a query that is too expensive, or depth is too deep.


### PR DESCRIPTION
[JIRA TICKET](https://labelbox.atlassian.net/browse/DIAG-884<JIRA_INFO>)

https://github.com/Labelbox/intelligence/pull/6224
is a related PR in intelligence to improve the errors that are thrown

**Changes**

* Handle a couple types of errors that are often thrown in intelligence rather than just handling them with a generic error
* Remove intelligence stack trace from unhandled errors (ideally, though, now none of the MEA errors are unhandled, so this shouldn't be an issue anyways)

