### PR TITLE
updates to tests after implementation of LabelImport

### DIFF
--- a/tests/integration/annotation_import/test_label_import.py
+++ b/tests/integration/annotation_import/test_label_import.py
@@ -66,7 +66,6 @@ def test_get(client, project, annotation_import_test_helpers):
 
 
 @pytest.mark.slow
-@pytest.mark.skip(reason="beta feature still being developed")
 def test_wait_till_done(client, project, predictions):
     name = str(uuid.uuid4())
     label_import = LabelImport.create_from_objects(client=client,
@@ -76,19 +75,13 @@ def test_wait_till_done(client, project, predictions):
 
     assert len(label_import.inputs) == len(predictions)
     label_import.wait_until_done()
-    # TODO(grant): some of this is commented out
-    # TODO(grant): since the pipeline is not complete, you will get a failed status
 
-    # assert label_import.state == AnnotationImportState.FINISHED
-    # # Check that the status files are being returned as expected
-    # assert len(label_import.errors) == 0
+    assert label_import.state == AnnotationImportState.FINISHED
     assert len(label_import.inputs) == len(predictions)
     input_uuids = [input_annot['uuid'] for input_annot in label_import.inputs]
     inference_uuids = [pred['uuid'] for pred in predictions]
     assert set(input_uuids) == set(inference_uuids)
     assert len(label_import.statuses) == len(predictions)
-    # for status in label_import.statuses:
-    #     assert status['status'] == 'SUCCESS'
     status_uuids = [
         input_annot['uuid'] for input_annot in label_import.statuses
     ]

--- a/tests/integration/test_label.py
+++ b/tests/integration/test_label.py
@@ -1,6 +1,5 @@
 from labelbox.schema.labeling_frontend import LabelingFrontend
 import time
-import json
 
 import pytest
 import requests

--- a/tests/integration/test_label.py
+++ b/tests/integration/test_label.py
@@ -1,5 +1,6 @@
 from labelbox.schema.labeling_frontend import LabelingFrontend
 import time
+import json
 
 import pytest
 import requests
@@ -7,7 +8,6 @@ import requests
 from labelbox import Label
 
 
-@pytest.mark.skip("Cannot query for labels created with create_label")
 def test_labels(label_pack):
     project, dataset, data_row, label = label_pack
 
@@ -30,20 +30,14 @@ def test_labels(label_pack):
     assert list(data_row.labels()) == []
 
 
-def test_label_export(client, label_pack):
-    project, dataset, data_row, label = label_pack
-    #Project has to be setup for export to be possible
-    editor = list(
-        client.get_labeling_frontends(
-            where=LabelingFrontend.name == "editor"))[0]
-    empty_ontology = {"tools": [], "classifications": []}
-    project.setup(editor, empty_ontology)
-    project.create_label(data_row=data_row, label="export_label")
+def test_label_export(client, configured_project_with_label):
+    project, label_id = configured_project_with_label
+
     exported_labels_url = project.export_labels()
     assert exported_labels_url is not None
     exported_labels = requests.get(exported_labels_url)
-    labels = [example['Label'] for example in exported_labels.json()]
-    #assert 'export_label' in labels
+    labels = [example['ID'] for example in exported_labels.json()]
+    assert labels[0] == label_id
     # TODO: Add test for bulk export back.
     # The new exporter doesn't work with the create_label mutation
 
@@ -54,7 +48,6 @@ def test_label_update(label_pack):
     assert label.label == "something else"
 
 
-@pytest.mark.skip("Cannot query for labels created with create_label")
 def test_label_filter_order(client, project, rand_gen, image_url):
     dataset_1 = client.create_dataset(name=rand_gen(str), projects=project)
     dataset_2 = client.create_dataset(name=rand_gen(str), projects=project)
@@ -83,7 +76,6 @@ def test_label_filter_order(client, project, rand_gen, image_url):
     project.delete()
 
 
-@pytest.mark.skip("Cannot query for labels created with create_label")
 def test_label_bulk_deletion(project, rand_gen, image_url):
     dataset = project.client.create_dataset(name=rand_gen(str),
                                             projects=project)

--- a/tests/integration/test_labeler_performance.py
+++ b/tests/integration/test_labeler_performance.py
@@ -3,8 +3,6 @@ import time
 import pytest
 
 
-@pytest.mark.skip(
-    "Cannot query for labeler performance for labels created with create_label")
 def test_labeler_performance(label_pack):
     project, dataset, data_row, label = label_pack
     # Sleep a bit as it seems labeler performance isn't updated immediately.


### PR DESCRIPTION
update to tests that were previously marked skipped before pending LabelImport. Is supposed to be the following step after annotation_submit_fn was removed from the files