### PR TITLE
feat: enable image download from blobstorage

### DIFF
--- a/labelbox/data/cloud/blobstorage.py
+++ b/labelbox/data/cloud/blobstorage.py
@@ -1,0 +1,17 @@
+import os
+
+from azure.storage.blob import BlobServiceClient, ContainerClient
+from loguru import logger
+
+
+def create_blobstorage_client(azure_connection: str, azure_container_name: str) -> ContainerClient:
+    service = BlobServiceClient.from_connection_string(azure_connection)
+    return service.get_container_client(azure_container_name)
+
+
+def get_connection_string() -> str:
+    try:
+        return os.environ["AZURE_CONNECTION_STRING"]
+    except KeyError as ex:
+        logger.exception("Environment variable AZURE_CONNECTION_STRING is not set")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ PILLOW
 opencv-python
 typeguard
 imagesize
+azure-storage-blob
+loguru


### PR DESCRIPTION
DISCLAIMER:
This is still work in progress!


**In this PR:**

- enables image downloads from Azure Blobstorage in the `get_image` function to extract image dimension.
- currently assumes that an environment variable called `AZURE_CONNECTION_STRING` will be set for it to work. An exception is raise if not.