### PR TITLE
SE-1295: Update upsert_review_queue so quota_factor can accept 1.0 and 0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 # Version 3.11.1 (2022-01-10)
 ## Fix
 * Make `TypedArray` class compatible with `numpy` versions `>= 1.22.0`
+* `project.upsert_review_queue` quotas can now be in the inclusive range [0,1]
 
 # Version 3.11.0 (2021-12-15)
 

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -681,7 +681,7 @@ class Project(DbObject, Updateable, Deletable):
                 to reinitiate. Between 0 and 1.
         """
 
-        if not 0. < quota_factor < 1.:
+        if not 0. <= quota_factor <= 1.:
             raise ValueError("Quota factor must be in the range of [0,1]")
 
         id_param = "projectId"


### PR DESCRIPTION
Related to ticket https://labelbox.atlassian.net/browse/SE-1295.

Allow SDK to set quota of 0% and 100%. Currently, these values are not accepted.