### PR TITLE
numpy typing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+# Version 3.11.1 (2022-01-10)
+## Fix
+* Make `TypedArray` class compatible with `numpy` versions `>= 1.22.0`
 
 # Version 3.11.0 (2021-12-15)
 

--- a/labelbox/__init__.py
+++ b/labelbox/__init__.py
@@ -1,5 +1,5 @@
 name = "labelbox"
-__version__ = "3.11.0"
+__version__ = "3.11.1"
 
 from labelbox.schema.project import Project
 from labelbox.client import Client

--- a/labelbox/data/annotation_types/types.py
+++ b/labelbox/data/annotation_types/types.py
@@ -25,9 +25,9 @@ class _TypedArray(np.ndarray, Generic[DType, DShape]):
             raise TypeError(f"Expected numpy array. Found {type(val)}")
 
         if sys.version_info.minor > 6:
-            actual_dtype = field.sub_fields[1].type_.__args__[0]
+            actual_dtype = field.sub_fields[-1].type_.__args__[0]
         else:
-            actual_dtype = field.sub_fields[1].type_.__values__[0]
+            actual_dtype = field.sub_fields[-1].type_.__values__[0]
 
         if val.dtype != actual_dtype:
             raise TypeError(

--- a/labelbox/data/annotation_types/types.py
+++ b/labelbox/data/annotation_types/types.py
@@ -1,5 +1,4 @@
 import sys
-import logging
 from typing import Generic, TypeVar
 from typing_extensions import Annotated
 
@@ -8,13 +7,13 @@ from pydantic.fields import ModelField
 import numpy as np
 
 Cuid = Annotated[str, Field(min_length=25, max_length=25)]
-
 DType = TypeVar('DType')
 
-logger = logging.getLogger(__name__)
 
+class TypedArray(Generic[DType]):
 
-class TypedArray(np.ndarray, Generic[DType]):
+    def __new__(cls, *args, **kwargs):
+        return np.ndarray(*args, **kwargs)
 
     @classmethod
     def __get_validators__(cls):

--- a/labelbox/data/annotation_types/types.py
+++ b/labelbox/data/annotation_types/types.py
@@ -1,19 +1,19 @@
 import sys
-from typing import Generic, TypeVar
-from typing_extensions import Annotated
+from typing import Generic, TypeVar, Any
 
+from typing_extensions import Annotated
+from packaging import version
 from pydantic import Field
 from pydantic.fields import ModelField
 import numpy as np
 
 Cuid = Annotated[str, Field(min_length=25, max_length=25)]
+
 DType = TypeVar('DType')
+DShape = TypeVar('DShape')
 
 
-class TypedArray(Generic[DType]):
-
-    def __new__(cls, *args, **kwargs):
-        return np.ndarray(*args, **kwargs)
+class _TypedArray(np.ndarray, Generic[DType, DShape]):
 
     @classmethod
     def __get_validators__(cls):
@@ -25,12 +25,19 @@ class TypedArray(Generic[DType]):
             raise TypeError(f"Expected numpy array. Found {type(val)}")
 
         if sys.version_info.minor > 6:
-            actual_dtype = field.sub_fields[0].type_.__args__[0]
+            actual_dtype = field.sub_fields[1].type_.__args__[0]
         else:
-            actual_dtype = field.sub_fields[0].type_.__values__[0]
+            actual_dtype = field.sub_fields[1].type_.__values__[0]
 
         if val.dtype != actual_dtype:
             raise TypeError(
                 f"Expected numpy array have type {actual_dtype}. Found {val.dtype}"
             )
         return val
+
+
+if version.parse(np.__version__) >= version.parse('1.22.0'):
+    from numpy.typing import _GenericAlias
+    TypedArray = _GenericAlias(_TypedArray, (Any, DType))
+else:
+    TypedArray = _TypedArray[Any, DType]


### PR DESCRIPTION
In the latest numpy release support for typing np.ndarrays was added. This broke the interface for our TypedArray object. The changes in this PR restore's the interface

