### PR TITLE
uri support

### DIFF
--- a/examples/format_notebooks.py
+++ b/examples/format_notebooks.py
@@ -5,8 +5,10 @@ from copy import deepcopy
 from yapf.yapflib.yapf_api import FormatCode
 
 BANNER_CELL = {
-    "cell_type": "markdown",
-    "id": "db768cda",
+    "cell_type":
+        "markdown",
+    "id":
+        "db768cda",
     "metadata": {},
     "source": [
         "<td>\n",
@@ -16,16 +18,15 @@ BANNER_CELL = {
 }
 
 LINK_CELL = {
-    "cell_type": "markdown",
-    "id": "cb5611d0",
+    "cell_type":
+        "markdown",
+    "id":
+        "cb5611d0",
     "metadata": {},
     "source": [
-        "<td>\n",
-        "<a href=\"{colab}\" target=\"_blank\"><img\n",
+        "<td>\n", "<a href=\"{colab}\" target=\"_blank\"><img\n",
         "src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>\n",
-        "</td>\n",
-        "\n",
-        "<td>\n",
+        "</td>\n", "\n", "<td>\n",
         "<a href=\"{github}\" target=\"_blank\"><img\n",
         "src=\"https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white\" alt=\"GitHub\"></a>\n",
         "</td>"

--- a/labelbox/data/serialization/labelbox_v1/label.py
+++ b/labelbox/data/serialization/labelbox_v1/label.py
@@ -233,7 +233,8 @@ class LBV1Label(BaseModel):
 
     def _is_url(self) -> bool:
         return self.row_data.startswith(
-            ("http://", "https://")) or "tileLayerUrl" in self.row_data
+            ("http://", "https://", "gs://",
+             "s3://")) or "tileLayerUrl" in self.row_data
 
     class Config:
         allow_population_by_field_name = True

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = py36, py37, py38
 # install pytest in the virtualenv where commands will be executed
 deps =
     -rrequirements.txt
-    pytest
+    pytest < 7.0.0
     pytest-cases
 passenv = LABELBOX_TEST_API_KEY_PROD LABELBOX_TEST_API_KEY_STAGING LABELBOX_TEST_ENVIRON
 commands = pytest {posargs}


### PR DESCRIPTION
Annotation types are not designed to work with gcs or s3 uris. We recently updated the exporter to not sign uris which is a breaking change. This will unblock but users will still have to define a custom function for downloading the asset.
