### PR TITLE
get_resource_tags and create_project_resource_tags

### DIFF
--- a/labelbox/__init__.py
+++ b/labelbox/__init__.py
@@ -23,3 +23,5 @@ from labelbox.schema.data_row_metadata import DataRowMetadataOntology
 from labelbox.schema.model_run import ModelRun
 from labelbox.schema.benchmark import Benchmark
 from labelbox.schema.iam_integration import IAMIntegration
+from labelbox.schema.resource_tag import ResourceTag
+from labelbox.schema.project_resource_tag import ProjectResourceTag

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -906,27 +906,3 @@ class Client:
         # But the features are the same so we just grab the feature schema id
         res['id'] = res['normalized']['featureSchemaId']
         return Entity.FeatureSchema(self, res)
-
-    def create_resource_tag(self, tag=None):
-        """
-        Creates a resource tag.
-            >>> tag = {'text': 'tag-1',  'color': 'ffffff'}
-
-        Args:
-            tag (dict): A resource tag {'text': 'tag-1', 'color': 'fffff'}
-        Returns:
-            The created resource tag.
-        """
-        tag_text_param = "text"
-        tag_color_param = "color"
-
-        query_str = """mutation CreateResourceTagPyApi($text:String!,$color:String!) {
-                createResourceTag(input:{text:$%s,color:$%s}) {id,text,color}}
-        """ % (tag_text_param, tag_color_param)
-
-        params = {
-            tag_text_param: tag.get("text", ""),
-            tag_color_param: tag.get("color", "")
-        }
-        res = self.execute(query_str, params)
-        return Entity.ResourceTag(self, res['createResourceTag'])

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -906,3 +906,27 @@ class Client:
         # But the features are the same so we just grab the feature schema id
         res['id'] = res['normalized']['featureSchemaId']
         return Entity.FeatureSchema(self, res)
+
+    def create_resource_tag(self, tag=None):
+        """
+        Creates a resource tag.
+            >>> tag = {'text': 'tag-1',  'color': 'ffffff'}
+
+        Args:
+            tag (dict): A resource tag {'text': 'tag-1', 'color': 'fffff'}
+        Returns:
+            The created resource tag.
+        """
+        tag_text_param = "text"
+        tag_color_param = "color"
+
+        query_str = """mutation CreateResourceTagPyApi($text:String!,$color:String!) {
+                createResourceTag(input:{text:$%s,color:$%s}) {id,text,color}}
+        """ % (tag_text_param, tag_color_param)
+
+        params = {
+            tag_text_param: tag.get("text", ""),
+            tag_color_param: tag.get("color", "")
+        }
+        res = self.execute(query_str, params)
+        return Entity.ResourceTag(self, res['createResourceTag'])

--- a/labelbox/schema/organization.py
+++ b/labelbox/schema/organization.py
@@ -1,3 +1,4 @@
+import json
 from typing import TYPE_CHECKING, List, Optional
 
 from labelbox.exceptions import LabelboxError
@@ -125,6 +126,24 @@ class Organization(DbObject):
             """mutation DeleteMemberPyApi($%s: ID!) {
             updateUser(where: {id: $%s}, data: {deleted: true}) { id deleted }
         }""" % (user_id_param, user_id_param), {user_id_param: user.uid})
+
+    def get_resource_tags(self) -> List["ResourceTag"]:
+        """
+        Returns all resource tags for an organization
+        """
+        res = self.client.execute(
+            """query {
+                organization {
+                    resourceTag {
+                        id,
+                        text,
+                        color
+                    }
+                }
+            }""")
+
+        # print(json.dumps(res['organization']['resourceTag'], indent=2, sort_keys=True))
+        return res['organization']['resourceTag']
 
     def get_iam_integrations(self) -> List["IAMIntegration"]:
         """

--- a/labelbox/schema/organization.py
+++ b/labelbox/schema/organization.py
@@ -44,7 +44,7 @@ class Organization(DbObject):
     users = Relationship.ToMany("User", False)
     projects = Relationship.ToMany("Project", True)
     webhooks = Relationship.ToMany("Webhook", False)
-    resourceTags = Relationship.ToMany("resource_tags", False)
+    resource_tags = Relationship.ToMany("ResourceTags", False)
 
     def invite_user(
             self,

--- a/labelbox/schema/organization.py
+++ b/labelbox/schema/organization.py
@@ -44,7 +44,7 @@ class Organization(DbObject):
     users = Relationship.ToMany("User", False)
     projects = Relationship.ToMany("Project", True)
     webhooks = Relationship.ToMany("Webhook", False)
-    resourceTags = Relationship.ToMany("ResourceTag", False)
+    resourceTags = Relationship.ToMany("resource_tags", False)
 
     def invite_user(
             self,
@@ -161,7 +161,10 @@ class Organization(DbObject):
         query_str = """query GetOrganizationResourceTagsPyApi{organization{resourceTag{%s}}}""" % (
             query.results_query_part(ResourceTag))
 
-        return self.client.execute(query_str)['organization']['resourceTag']
+        return [
+            ResourceTag(self.client, tag) for tag in self.client.execute(
+                query_str)['organization']['resourceTag']
+        ]
 
     def get_iam_integrations(self) -> List["IAMIntegration"]:
         """

--- a/labelbox/schema/organization.py
+++ b/labelbox/schema/organization.py
@@ -142,7 +142,6 @@ class Organization(DbObject):
                 }
             }""")
 
-        # print(json.dumps(res['organization']['resourceTag'], indent=2, sort_keys=True))
         return res['organization']['resourceTag']
 
     def get_iam_integrations(self) -> List["IAMIntegration"]:

--- a/labelbox/schema/organization.py
+++ b/labelbox/schema/organization.py
@@ -161,10 +161,7 @@ class Organization(DbObject):
         query_str = """query GetOrganizationResourceTagsPyApi{organization{resourceTag{%s}}}""" % (
             query.results_query_part(ResourceTag))
 
-        return [
-            ResourceTag(self.client, resourceTag)
-            for resourceTag in res['createResourceTag']
-        ]
+        return self.client.execute(query_str)['organization']['resourceTag']
 
     def get_iam_integrations(self) -> List["IAMIntegration"]:
         """

--- a/labelbox/schema/organization.py
+++ b/labelbox/schema/organization.py
@@ -131,16 +131,7 @@ class Organization(DbObject):
         """
         Returns all resource tags for an organization
         """
-        res = self.client.execute(
-            """query {
-                organization {
-                    resourceTag {
-                        id,
-                        text,
-                        color
-                    }
-                }
-            }""")
+        res = self.client.execute("""query GetOrganizationResourceTagsPyApi{organization{resourceTag{id,text,color}}}""")
 
         return res['organization']['resourceTag']
 

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -121,6 +121,33 @@ class Project(DbObject, Updateable, Deletable):
                                    {id_param: str(self.uid)},
                                    ["project", "members"], ProjectMember)
 
+    def create_project_resource_tags(self, tagIdsParam) -> List["ProjectResourceTag"]:
+        """ Creates a project resource tag
+
+        TODO
+        """
+        project_id_param = "projectId"
+        tag_ids_param = "resourceTagIds"
+
+        query_str = """mutation AttatchProjectResourceTags($%s: ID!, $%s: [String!]) {
+            project(where:{id:$%s}){updateProjectResourceTags(input:{%s:$%s}){id}}
+        }""" % (
+            project_id_param,
+            tag_ids_param,
+            project_id_param,
+            tag_ids_param,
+            tag_ids_param
+        )
+
+        print('tagIdsParam', tagIdsParam)
+        res = self.client.execute(
+            query_str, {
+                project_id_param: self.uid,
+                tag_ids_param: tagIdsParam
+            })
+
+        return res["project"]["updateProjectResourceTags"]
+
     def labels(self, datasets=None, order_by=None) -> PaginatedCollection:
         """ Custom relationship expansion method to support limited filtering.
 

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -132,9 +132,8 @@ class Project(DbObject, Updateable, Deletable):
         project_id_param = "projectId"
         tag_ids_param = "resourceTagIds"
 
-        query_str = """mutation AttatchProjectResourceTags($%s: ID!, $%s: [String!]) {
-            project(where:{id:$%s}){updateProjectResourceTags(input:{%s:$%s}){id}}
-        }""" % (
+        query_str = """mutation AttatchProjectResourceTagsPyApi($%s:ID!,$%s:[String!]) {
+            project(where:{id:$%s}){updateProjectResourceTags(input:{%s:$%s}){id}}}""" % (
             project_id_param,
             tag_ids_param,
             project_id_param,

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -121,10 +121,13 @@ class Project(DbObject, Updateable, Deletable):
                                    {id_param: str(self.uid)},
                                    ["project", "members"], ProjectMember)
 
-    def create_project_resource_tags(self, tagIdsParam) -> List["ProjectResourceTag"]:
-        """ Creates a project resource tag
+    def create_project_resource_tags(self, resource_tag_ids: List[str]) -> List[str]:
+        """ Creates project resource tags
 
-        TODO
+        Args:
+            resource_tag_ids
+        Returns:
+            a list of ResourceTag ids that was created.
         """
         project_id_param = "projectId"
         tag_ids_param = "resourceTagIds"
@@ -139,11 +142,10 @@ class Project(DbObject, Updateable, Deletable):
             tag_ids_param
         )
 
-        print('tagIdsParam', tagIdsParam)
         res = self.client.execute(
             query_str, {
                 project_id_param: self.uid,
-                tag_ids_param: tagIdsParam
+                tag_ids_param: resource_tag_ids
             })
 
         return res["project"]["updateProjectResourceTags"]

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -18,6 +18,7 @@ from labelbox.orm import query
 from labelbox.orm.db_object import DbObject, Updateable, Deletable
 from labelbox.orm.model import Entity, Field, Relationship
 from labelbox.pagination import PaginatedCollection
+from labelbox.schema.resource_tag import ResourceTag
 
 if TYPE_CHECKING:
     from labelbox import BulkImportRequest
@@ -121,7 +122,8 @@ class Project(DbObject, Updateable, Deletable):
                                    {id_param: str(self.uid)},
                                    ["project", "members"], ProjectMember)
 
-    def create_project_resource_tags(self, resource_tag_ids: List[str]) -> List[str]:
+    def update_project_resource_tags(
+            self, resource_tag_ids: List[str]) -> List[ResourceTag]:
         """ Creates project resource tags
 
         Args:
@@ -132,20 +134,15 @@ class Project(DbObject, Updateable, Deletable):
         project_id_param = "projectId"
         tag_ids_param = "resourceTagIds"
 
-        query_str = """mutation AttatchProjectResourceTagsPyApi($%s:ID!,$%s:[String!]) {
-            project(where:{id:$%s}){updateProjectResourceTags(input:{%s:$%s}){id}}}""" % (
-            project_id_param,
-            tag_ids_param,
-            project_id_param,
-            tag_ids_param,
-            tag_ids_param
-        )
+        query_str = """mutation CreateProjectResourceTagsPyApi($%s:ID!,$%s:[String!]) {
+            project(where:{id:$%s}){updateProjectResourceTags(input:{%s:$%s}){%s}}}""" % (
+            project_id_param, tag_ids_param, project_id_param, tag_ids_param,
+            tag_ids_param, query.results_query_part(ResourceTag))
 
-        res = self.client.execute(
-            query_str, {
-                project_id_param: self.uid,
-                tag_ids_param: resource_tag_ids
-            })
+        res = self.client.execute(query_str, {
+            project_id_param: self.uid,
+            tag_ids_param: resource_tag_ids
+        })
 
         return res["project"]["updateProjectResourceTags"]
 

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -134,7 +134,7 @@ class Project(DbObject, Updateable, Deletable):
         project_id_param = "projectId"
         tag_ids_param = "resourceTagIds"
 
-        query_str = """mutation CreateProjectResourceTagsPyApi($%s:ID!,$%s:[String!]) {
+        query_str = """mutation UpdateProjectResourceTagsPyApi($%s:ID!,$%s:[String!]) {
             project(where:{id:$%s}){updateProjectResourceTags(input:{%s:$%s}){%s}}}""" % (
             project_id_param, tag_ids_param, project_id_param, tag_ids_param,
             tag_ids_param, query.results_query_part(ResourceTag))
@@ -144,7 +144,10 @@ class Project(DbObject, Updateable, Deletable):
             tag_ids_param: resource_tag_ids
         })
 
-        return res["project"]["updateProjectResourceTags"]
+        return [
+            ResourceTag(self.client, tag)
+            for tag in res["project"]["updateProjectResourceTags"]
+        ]
 
     def labels(self, datasets=None, order_by=None) -> PaginatedCollection:
         """ Custom relationship expansion method to support limited filtering.

--- a/labelbox/schema/project_resource_tag.py
+++ b/labelbox/schema/project_resource_tag.py
@@ -1,6 +1,7 @@
 from labelbox.orm.db_object import DbObject, Updateable
 from labelbox.orm.model import Field, Relationship
 
+
 class ProjectResourceTag(DbObject, Updateable):
     """ Project resource tag to associate ProjectResourceTag to Project.
 

--- a/labelbox/schema/project_resource_tag.py
+++ b/labelbox/schema/project_resource_tag.py
@@ -1,0 +1,15 @@
+from labelbox.orm.db_object import DbObject, Updateable
+from labelbox.orm.model import Field, Relationship
+
+class ProjectResourceTag(DbObject, Updateable):
+    """ Project resource tag to associate ProjectResourceTag to Project.
+
+    Attributes:
+        resourceTagId (str)
+        projectId (str)
+
+        resource_tag (Relationship): `ToOne` relationship to ResourceTag
+    """
+
+    resourceTagId = Field.ID("resourceTagId")
+    projectId = Field.ID("projectId")

--- a/labelbox/schema/project_resource_tag.py
+++ b/labelbox/schema/project_resource_tag.py
@@ -11,5 +11,5 @@ class ProjectResourceTag(DbObject, Updateable):
         resource_tag (Relationship): `ToOne` relationship to ResourceTag
     """
 
-    resourceTagId = Field.ID("resourceTagId")
-    projectId = Field.ID("projectId")
+    resource_tag_id = Field.ID("resource_tag_id")
+    project_id = Field.ID("project_id")

--- a/labelbox/schema/resource_tag.py
+++ b/labelbox/schema/resource_tag.py
@@ -1,0 +1,15 @@
+from labelbox.orm.db_object import DbObject
+from labelbox.orm.model import Field, Relationship
+
+class ResourceTag(DbObject):
+    """ Resource tag to label and identify your labelbox resources easier.
+
+    Attributes:
+        text (str)
+        color (str)
+
+        project_resource_tag (Relationship): `ToMany` relationship to ProjectResourceTag
+    """
+
+    text = Field.String("text")
+    color = Field.String("color")

--- a/labelbox/schema/resource_tag.py
+++ b/labelbox/schema/resource_tag.py
@@ -1,6 +1,7 @@
 from labelbox.orm.db_object import DbObject, Updateable
 from labelbox.orm.model import Field, Relationship
 
+
 class ResourceTag(DbObject, Updateable):
     """ Resource tag to label and identify your labelbox resources easier.
 

--- a/labelbox/schema/resource_tag.py
+++ b/labelbox/schema/resource_tag.py
@@ -1,7 +1,7 @@
-from labelbox.orm.db_object import DbObject
+from labelbox.orm.db_object import DbObject, Updateable
 from labelbox.orm.model import Field, Relationship
 
-class ResourceTag(DbObject):
+class ResourceTag(DbObject, Updateable):
     """ Resource tag to label and identify your labelbox resources easier.
 
     Attributes:

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -42,9 +42,47 @@ def test_project(client, rand_gen):
     assert project not in final
     assert set(final) == set(before)
 
-    # TODO this should raise ResourceNotFoundError, but it doesn't
-    project = client.get_project(project.uid)
+def test_create_project_resource_tags(client, rand_gen):
+    before = list(client.get_projects())
+    for o in before:
+        assert isinstance(o, Project)
 
+    colorA = "#ffffff"
+    textA = rand_gen(str)
+    tag = {"text": textA, "color": colorA}
+
+    colorB = colorA
+    textB = rand_gen(str)
+    tagB = {"text": textB, "color": colorB}
+
+    project_name = rand_gen(str)
+
+    tagA = client.create_resource_tag(tag)
+    assert tagA.text == textA
+    assert '#' + tagA.color == colorA
+    assert tagA.uid is not None
+
+    org = client.get_organization()
+    tags = org.get_resource_tags()
+    lenA = len(tags)
+    assert lenA > 0
+
+    tagB = client.create_resource_tag(tagB)
+    assert tagB.text == textB
+    assert '#' + tagB.color == colorB
+    assert tagB.uid is not None
+
+    tags = org.get_resource_tags()
+    lenB = len(tags)
+    assert lenB > 0
+    assert lenB > lenA
+
+    p1 = client.create_project(name=project_name)
+    assert p1.uid is not None
+
+    project_resource_tag = p1.create_project_resource_tags([tagA.uid])
+    assert len(project_resource_tag) == 1
+    assert project_resource_tag[0].get("id") == tagA.uid
 
 def test_project_filtering(client, rand_gen):
     name_1 = rand_gen(str)

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -42,10 +42,18 @@ def test_project(client, rand_gen):
     assert project not in final
     assert set(final) == set(before)
 
-def test_create_project_resource_tags(client, rand_gen):
+
+def test_update_project_resource_tags(client, rand_gen):
     before = list(client.get_projects())
     for o in before:
         assert isinstance(o, Project)
+
+    org = client.get_organization()
+    assert org.uid is not None
+
+    project_name = rand_gen(str)
+    p1 = client.create_project(name=project_name)
+    assert p1.uid is not None
 
     colorA = "#ffffff"
     textA = rand_gen(str)
@@ -55,34 +63,30 @@ def test_create_project_resource_tags(client, rand_gen):
     textB = rand_gen(str)
     tagB = {"text": textB, "color": colorB}
 
-    project_name = rand_gen(str)
-
-    tagA = client.create_resource_tag(tag)
+    tagA = client.get_organization().create_resource_tag(tag)
     assert tagA.text == textA
     assert '#' + tagA.color == colorA
     assert tagA.uid is not None
 
-    org = client.get_organization()
     tags = org.get_resource_tags()
     lenA = len(tags)
     assert lenA > 0
 
-    tagB = client.create_resource_tag(tagB)
+    tagB = client.get_organization().create_resource_tag(tagB)
     assert tagB.text == textB
     assert '#' + tagB.color == colorB
     assert tagB.uid is not None
 
-    tags = org.get_resource_tags()
+    tags = client.get_organization().get_resource_tags()
     lenB = len(tags)
     assert lenB > 0
     assert lenB > lenA
 
-    p1 = client.create_project(name=project_name)
-    assert p1.uid is not None
-
-    project_resource_tag = p1.create_project_resource_tags([tagA.uid])
+    project_resource_tag = client.get_project(
+        p1.uid).update_project_resource_tags([str(tagA.uid)])
     assert len(project_resource_tag) == 1
     assert project_resource_tag[0].get("id") == tagA.uid
+
 
 def test_project_filtering(client, rand_gen):
     name_1 = rand_gen(str)

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -85,7 +85,7 @@ def test_update_project_resource_tags(client, rand_gen):
     project_resource_tag = client.get_project(
         p1.uid).update_project_resource_tags([str(tagA.uid)])
     assert len(project_resource_tag) == 1
-    assert project_resource_tag[0].get("id") == tagA.uid
+    assert project_resource_tag[0].uid == tagA.uid
 
 
 def test_project_filtering(client, rand_gen):


### PR DESCRIPTION
This PR adds two calls to our SDK,
- get_resource_tags which returns a list of resource tags for the organization
- create_project_resource_tags(tag_ids = []): to create/associate resource tags to projects

TDD: https://docs.google.com/document/d/1r60QC3Ch_zu3UPEEMVF9R0la4OQlelmQngfhIPMIPEo/edit#heading=h.ql1qz79ruc9v
Jira
https://labelbox.atlassian.net/jira/software/c/projects/ORCH/boards/52?modal=detail&selectedIssue=ORCH-835

https://user-images.githubusercontent.com/74563614/153306005-1aab13fc-42db-459e-b5f0-e8e136e6a0b7.mov

