### PR TITLE
fix resource_manager script crash on custom jobs

### DIFF
--- a/examples/integrations/gcp/utils/resource_manager.py
+++ b/examples/integrations/gcp/utils/resource_manager.py
@@ -91,7 +91,7 @@ def main():
         'CustomPythonPackageTrainingJob', 'CustomTrainingJob',
         'HyperparameterTuningJob', 'PipelineJob'
     ]
-    job_attrs = ['name', 'display_name', 'state.name', 'has_failed']
+    job_attrs = ['name', 'display_name', 'state.name']
 
     endpoint_types = ['Endpoint']
     endpoint_attrs = ['name', 'display_name']


### PR DESCRIPTION
Script was crashing with custom jobs. Removev Redundant "has_failed" column to fix.

(Running, success or failed status is already displayed in the state column)