### PR TITLE
add datarow to etl

### DIFF
--- a/examples/integrations/gcp/src/jobs/etl/images/bounding_box/bounding_box_etl.py
+++ b/examples/integrations/gcp/src/jobs/etl/images/bounding_box/bounding_box_etl.py
@@ -98,7 +98,9 @@ def process_label(label: Label, bucket: Bucket) -> str:
         # TODO: Replace with the split from the export in the future.
         'dataItemResourceLabels': {
             "aiplatform.googleapis.com/ml_use": ['test', 'train', 'validation']
-                                                [random.randint(0, 2)]
+                                                [random.randint(0, 2)],
+            "dataRowId":
+                label.data.uid
         }
     })
 

--- a/examples/integrations/gcp/src/jobs/etl/images/classification/classification_etl.py
+++ b/examples/integrations/gcp/src/jobs/etl/images/classification/classification_etl.py
@@ -66,7 +66,9 @@ def process_single_classification_label(label: Label, bucket: Bucket) -> str:
         # TODO: Replace with the split from the export in the future.
         'dataItemResourceLabels': {
             "aiplatform.googleapis.com/ml_use": ['test', 'train', 'validation']
-                                                [random.randint(0, 2)]
+                                                [random.randint(0, 2)],
+            "dataRowId":
+                label.data.uid
         }
     })
 
@@ -93,7 +95,9 @@ def process_multi_classification_label(label: Label, bucket: Bucket) -> str:
         # TODO: Replace with the split from the export in the future.
         'dataItemResourceLabels': {
             "aiplatform.googleapis.com/ml_use": ['test', 'train', 'validation']
-                                                [random.randint(0, 2)]
+                                                [random.randint(0, 2)],
+            "dataRowId":
+                label.data.uid
         }
     })
 

--- a/examples/integrations/gcp/src/jobs/etl/text/classification/classification_etl.py
+++ b/examples/integrations/gcp/src/jobs/etl/text/classification/classification_etl.py
@@ -54,7 +54,9 @@ def process_single_classification_label(label: Label) -> str:
         # TODO: Replace with the split from the export in the future.
         'dataItemResourceLabels': {
             "aiplatform.googleapis.com/ml_use": ['test', 'train', 'validation']
-                                                [random.randint(0, 2)]
+                                                [random.randint(0, 2)],
+            "dataRowId":
+                label.data.uid
         }
     })
 
@@ -79,7 +81,9 @@ def process_multi_classification_label(label: Label) -> str:
         # TODO: Replace with the split from the export in the future.
         'dataItemResourceLabels': {
             "aiplatform.googleapis.com/ml_use": ['test', 'train', 'validation']
-                                                [random.randint(0, 2)]
+                                                [random.randint(0, 2)],
+            "dataRowId":
+                label.data.uid
         }
     })
 

--- a/examples/integrations/gcp/src/jobs/etl/text/ner/ner_etl.py
+++ b/examples/integrations/gcp/src/jobs/etl/text/ner/ner_etl.py
@@ -67,7 +67,9 @@ def process_label(label: Label) -> str:
         "textContent": label.data.value,
         'dataItemResourceLabels': {
             "aiplatform.googleapis.com/ml_use": ['test', 'train', 'validation']
-                                                [random.randint(0, 2)]
+                                                [random.randint(0, 2)],
+            "dataRowId":
+                label.data.uid
         }
     })
 


### PR DESCRIPTION
Write data row ids out to the training file. 

According to the vertex docs:

`dataItemResourceLabels` - Can contain any number of key-value string pairs. 


https://cloud.google.com/vertex-ai/docs/datasets/prepare-image#single-label-classification


