### PR TITLE
[AL-1623] - ModelRun Export Annotations

### DIFF
--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -5,7 +5,6 @@ import time
 import logging
 import requests
 import ndjson
-from labelbox.data.annotation_types.collection import LabelGenerator
 
 from labelbox.pagination import PaginatedCollection
 from labelbox.orm.query import results_query_part

--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -182,8 +182,7 @@ class ModelRun(DbObject):
         })
 
     @experimental
-    def export_model_run_annotations(self,
-                                     download: bool = False) -> LabelGenerator:
+    def export_annotations(self, download: bool = False) -> LabelGenerator:
         """
         Experimental. To use, make sure client has enable_experimental=True.
 

--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -200,8 +200,7 @@ class ModelRun(DbObject):
             None is returned.
         """
         sleep_time = 2
-        query_str = """
-            mutation exportModelRunAnnotationsPyApi($modelRunId: ID!) {
+        query_str = """mutation exportModelRunAnnotationsPyApi($modelRunId: ID!) {
                 exportModelRunAnnotations(data: {modelRunId: $modelRunId}) {
                     downloadUrl createdAt status
                 }

--- a/tests/integration/annotation_import/test_model_run.py
+++ b/tests/integration/annotation_import/test_model_run.py
@@ -73,3 +73,8 @@ def test_model_run_upsert_data_rows_with_existing_labels(
     ])
     assert n_data_rows == len(
         list(model_run_with_model_run_data_rows.model_run_data_rows()))
+
+
+def test_model_run_export_labels(model_run_with_model_run_data_rows):
+    labels = model_run_with_model_run_data_rows.export_labels(download=True)
+    assert len(labels) == 3


### PR DESCRIPTION
Looking to generate annotations similar to project.export_labels()

Currently we cannot do project.label_generator() which would return Label objects as it may struggle to infer media type.