### PR TITLE
[AL-1283] Merge Label Generator and Video Label Generator

### DIFF
--- a/examples/annotation_types/basics.ipynb
+++ b/examples/annotation_types/basics.ipynb
@@ -140,7 +140,6 @@
                 "    - Covered in this notebook\n",
                 "2. Export labels to an annotation generator\n",
                 "    - `project.label_generator()`\n",
-                "    - `project.video_label_generator()`\n",
                 "3. Use a converter to load from another format\n",
                 "    - Covered in the converters.ipynb notebook."
             ]

--- a/examples/annotation_types/converters.ipynb
+++ b/examples/annotation_types/converters.ipynb
@@ -35,7 +35,6 @@
                 "* The goal is to create a set of converts that convert to and from labelbox annotation types.\n",
                 "* This is automatically used when exporting labels from labelbox with:\n",
                 "    1. `label.label_generator()`\n",
-                "    2. `label.video_label_generator()`\n",
                 "* Currently we support:\n",
                 "    1. NDJson Converter\n",
                 "        - Convert to and from the prediction import format (mea, mal)\n",
@@ -363,7 +362,7 @@
             ],
             "source": [
                 "project = client.get_project(\"ckqcx1d58068c0y619qv7hzgu\")\n",
-                "labels = project.video_label_generator()\n",
+                "labels = project.label_generator()\n",
                 "\n",
                 "for label in labels:\n",
                 "    annotation_lookup = label.frame_annotations()\n",

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -221,6 +221,40 @@ class Project(DbObject, Updateable, Deletable):
                 self.uid)
             time.sleep(sleep_time)
 
+    def video_label_generator(self, timeout_seconds=600, **kwargs):
+        """
+        Download video annotations
+
+        Returns:
+            LabelGenerator for accessing labels for each video
+        """
+        warnings.warn(
+            "video_label_generator will be deprecated in a future release. "
+            "Use label_generator for video or text/image labels."
+            )
+        _check_converter_import()
+        json_data = self.export_labels(download=True,
+                                       timeout_seconds=timeout_seconds,
+                                       **kwargs)
+        # assert that the instance this would fail is only if timeout runs out
+        assert isinstance(
+            json_data,
+            List), "Unable to successfully get labels. Please try again"
+        if json_data is None:
+            raise TimeoutError(
+                f"Unable to download labels in {timeout_seconds} seconds."
+                "Please try again or contact support if the issue persists.")
+        is_video = [
+            'frames' in row['Label'] for row in json_data if row['Label']
+        ]
+        if len(is_video) and not all(is_video):
+            raise ValueError(
+                "Found non-video data rows in export. "
+                "Use project.export_labels() to export projects with mixed data types. "
+                "Or use project.label_generator() for text and imagery data.")
+        return LBV1Converter.deserialize_video(json_data, self.client)            
+            
+
     def label_generator(self, timeout_seconds=600, **kwargs):
         """
         Download text and image annotations, or video annotations.

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -230,8 +230,7 @@ class Project(DbObject, Updateable, Deletable):
         """
         warnings.warn(
             "video_label_generator will be deprecated in a future release. "
-            "Use label_generator for video or text/image labels."
-            )
+            "Use label_generator for video or text/image labels.")
         _check_converter_import()
         json_data = self.export_labels(download=True,
                                        timeout_seconds=timeout_seconds,
@@ -252,8 +251,7 @@ class Project(DbObject, Updateable, Deletable):
                 "Found non-video data rows in export. "
                 "Use project.export_labels() to export projects with mixed data types. "
                 "Or use project.label_generator() for text and imagery data.")
-        return LBV1Converter.deserialize_video(json_data, self.client)            
-            
+        return LBV1Converter.deserialize_video(json_data, self.client)
 
     def label_generator(self, timeout_seconds=600, **kwargs):
         """


### PR DESCRIPTION
This will need to follow standard deprecation procedure once approved.

Calling project.label_generator() will now determine the type of labels and provide either video, or image/text. Mixed data types will still need to use project.export_labels()