### PR TITLE
[AL-1688] Inclusion of warning messages

### DIFF
--- a/labelbox/data/annotation_types/classification/classification.py
+++ b/labelbox/data/annotation_types/classification/classification.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Union, Optional
+import warnings
 
 try:
     from typing import Literal
@@ -17,7 +18,6 @@ class _TempName(BaseModel):
         res = super().dict(*args, **kwargs)
         res.pop('name')
         return res
-
 
 class ClassificationAnswer(FeatureSchema):
     """
@@ -74,4 +74,10 @@ class Dropdown(_TempName):
     - This is not currently compatible with MAL.
     """
     name: Literal["dropdown"] = "dropdown"
-    answer: List[ClassificationAnswer]
+    answer: List[ClassificationAnswer]    
+
+    def __init__(self, **data: Any):
+        warnings.warn(
+            "Dropdown classification is deprecated and will be "
+            "removed in a future release")
+        super().__init__(**data)       

--- a/labelbox/data/annotation_types/classification/classification.py
+++ b/labelbox/data/annotation_types/classification/classification.py
@@ -19,6 +19,7 @@ class _TempName(BaseModel):
         res.pop('name')
         return res
 
+
 class ClassificationAnswer(FeatureSchema):
     """
     - Represents a classification option.
@@ -72,12 +73,15 @@ class Dropdown(_TempName):
     """
     - A classification with many selected options allowed .
     - This is not currently compatible with MAL.
+
+    Deprecation Notice: Dropdown classification is deprecated and will be
+        removed in a future release. Dropdown will also
+        no longer be able to be created in the Editor on 3/31/2022.    
     """
     name: Literal["dropdown"] = "dropdown"
-    answer: List[ClassificationAnswer]    
+    answer: List[ClassificationAnswer]
 
     def __init__(self, **data: Any):
-        warnings.warn(
-            "Dropdown classification is deprecated and will be "
-            "removed in a future release")
-        super().__init__(**data)       
+        warnings.warn("Dropdown classification is deprecated and will be "
+                      "removed in a future release")
+        super().__init__(**data)

--- a/labelbox/schema/ontology.py
+++ b/labelbox/schema/ontology.py
@@ -83,6 +83,11 @@ class Option:
 @dataclass
 class Classification:
     """
+
+    Deprecation Notice: Dropdown classification is deprecated and will be
+        removed in a future release. Dropdown will also
+        no longer be able to be created in the Editor on 3/31/2022.
+            
     A classfication to be added to a Project's ontology. The
     classification is dependent on the Classification Type.
 
@@ -131,9 +136,9 @@ class Classification:
     def __post_init__(self):
         if self.class_type == Classification.Type.DROPDOWN:
             warnings.warn(
-            "Dropdown classification is deprecated and will be "
-            "removed in a future release. Dropdown will also "
-            "no longer be able to be created in the Editor on 3/31/2022.")
+                "Dropdown classification is deprecated and will be "
+                "removed in a future release. Dropdown will also "
+                "no longer be able to be created in the Editor on 3/31/2022.")
 
     @property
     def name(self) -> str:

--- a/labelbox/schema/ontology.py
+++ b/labelbox/schema/ontology.py
@@ -4,6 +4,7 @@ import colorsys
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union, Type
+import warnings
 
 from pydantic import constr
 
@@ -126,6 +127,12 @@ class Classification:
     options: List[Option] = field(default_factory=list)
     schema_id: Optional[str] = None
     feature_schema_id: Optional[str] = None
+
+    def __post_init__(self):
+        if self.class_type == Classification.Type.DROPDOWN:
+            warnings.warn(
+            "Dropdown classification is deprecated and will be "
+            "removed in a future release")
 
     @property
     def name(self) -> str:

--- a/labelbox/schema/ontology.py
+++ b/labelbox/schema/ontology.py
@@ -132,7 +132,8 @@ class Classification:
         if self.class_type == Classification.Type.DROPDOWN:
             warnings.warn(
             "Dropdown classification is deprecated and will be "
-            "removed in a future release")
+            "removed in a future release. Dropdown will also "
+            "no longer be able to be created in the Editor on 3/31/2022.")
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Warnings for when an ontology includes Dropdown, or when a user tries to create a Dropdown annotation type.

This includes:
* creation of a Dropdown class object
* pulling an OntologyBuilder object from an existing project or ontology
* creation of a Dropdown annotation type