### PR TITLE
[Fix] Utils not addressing nums

### DIFF
--- a/labelbox/utils.py
+++ b/labelbox/utils.py
@@ -2,7 +2,7 @@ import re
 
 
 def _convert(s, sep, title):
-    components = re.findall(r"[A-Z][a-z0-9]*|[a-z][a-z0-9]*", s)
+    components = re.findall(r"[0-9A-Z][a-z0-9]*|[0-9a-z][a-z0-9]*", s)
     components = list(map(str.lower, filter(None, components)))
     for i in range(len(components)):
         if title(i):


### PR DESCRIPTION
Related to:
https://labelbox.slack.com/archives/C02SQ2VF6KG/p1646872771810379

The current _convert() method ignores numbers and only accounts for letters. Users passing in string are stating that they expect numbers to be retained.

The proposed change will allow both numbers and letters to be retained.