### PR TITLE
update user_managment

### DIFF
--- a/examples/basics/user_management.ipynb
+++ b/examples/basics/user_management.ipynb
@@ -93,7 +93,7 @@
             "source": [
                 "# Please provide a dummy email here:\n",
                 "# Preferrably one you can access. If you have a google account you can do email+1@<domain>.com\n",
-                "DUMMY_EMAIL = \"< SET THIS >\"\n",
+                "DUMMY_EMAIL = \"SET THIS"\n",
                 "# This should be set to an account that you wan't to change the permissions for.\n",
                 "# You could invite a new user, accept the invite and use that account if you don't want to effect any active users\n",
                 "DUMMY_USER_ACCOUNT_ID = \"ckneh4n8c9qvq0706uwwg5i16\""


### PR DESCRIPTION
DUMMY_EMAIL field replaced by "SET THIS vs "<SET THIS>" causing admin to set email with <email@domain.com> ref case : https://labelbox.atlassian.net/browse/LS-2287