### PR TITLE
Integration Tests - Update Configured Project with Sleep

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -257,6 +257,8 @@ def configured_project_with_label(client, rand_gen, image_url, project, dataset,
     ])
     project.setup(editor, ontology_builder.asdict())
     ontology = ontology_builder.from_project(project)
+    #TODO: added to avoid index error. remove sleep when api is more consistent
+    time.sleep(2)
     predictions = [{
         "uuid": str(uuid.uuid4()),
         "schemaId": ontology.tools[0].feature_schema_id,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -256,9 +256,10 @@ def configured_project_with_label(client, rand_gen, image_url, project, dataset,
         Tool(tool=Tool.Type.BBOX, name="test-bbox-class"),
     ])
     project.setup(editor, ontology_builder.asdict())
-    ontology = ontology_builder.from_project(project)
     #TODO: added to avoid index error. remove sleep when api is more consistent
     time.sleep(2)
+
+    ontology = ontology_builder.from_project(project)
     predictions = [{
         "uuid": str(uuid.uuid4()),
         "schemaId": ontology.tools[0].feature_schema_id,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -256,7 +256,7 @@ def configured_project_with_label(client, rand_gen, image_url, project, dataset,
         Tool(tool=Tool.Type.BBOX, name="test-bbox-class"),
     ])
     project.setup(editor, ontology_builder.asdict())
-    #TODO: added to avoid index error. remove sleep when api is more consistent
+    #TODO: ontology may not be synchronous after setup. remove sleep when api is more consistent
     time.sleep(2)
 
     ontology = ontology_builder.from_project(project)


### PR DESCRIPTION
Adding a 2s sleep after project.setup() prior to fetching the project's ontology in order to reduce the inconsistency of the API.

Grabbing an ontology immediately after the project was set up would occasionally cause a keyerror.