### PR TITLE
[AL-1611] Store Mask Values

### DIFF
--- a/labelbox/data/annotation_types/data/raster.py
+++ b/labelbox/data/annotation_types/data/raster.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from pydantic import root_validator
 
 from .base_data import BaseData
-from ..types import TypedArray
+from ..types import TypedArray, TempFile
 
 
 class RasterData(BaseModel, ABC):
@@ -21,7 +21,7 @@ class RasterData(BaseModel, ABC):
     file_path: Optional[str] = None
     url: Optional[str] = None
     arr: Optional[TypedArray[Literal['uint8']]] = None
-    cache_data: Optional[bytes] = None
+    cache_data: Optional[TempFile] = None
 
     @classmethod
     def from_2D_arr(cls, arr: Union[TypedArray[Literal['uint8']],

--- a/labelbox/data/annotation_types/data/raster.py
+++ b/labelbox/data/annotation_types/data/raster.py
@@ -13,7 +13,7 @@ from joblib import Memory
 from .base_data import BaseData
 from ..types import TypedArray
 
-memory = Memory("/tmp")
+memory = Memory(location="/tmp", verbose=0)
 
 
 #restructured outside of class to use memory cache

--- a/labelbox/data/annotation_types/data/raster.py
+++ b/labelbox/data/annotation_types/data/raster.py
@@ -1,4 +1,4 @@
-import tempfile
+from tempfile import NamedTemporaryFile
 from abc import ABC
 from io import BytesIO
 from typing import Callable, Optional, Union
@@ -21,7 +21,7 @@ class RasterData(BaseModel, ABC):
     file_path: Optional[str] = None
     url: Optional[str] = None
     arr: Optional[TypedArray[Literal['uint8']]] = None
-    cache: bool = False
+    cache_data: Optional[bytes] = None
 
     @classmethod
     def from_2D_arr(cls, arr: Union[TypedArray[Literal['uint8']],
@@ -92,8 +92,6 @@ class RasterData(BaseModel, ABC):
         """
         Property that unifies the data access pattern for all references to the raster.
 
-        RasterData can be cached to disk by setting RasterData.cache = True prior to RasterData.value
-
         Returns:
             numpy representation of the raster
         """
@@ -104,18 +102,12 @@ class RasterData(BaseModel, ABC):
         elif self.file_path is not None:
             with open(self.file_path, "rb") as img:
                 im_bytes = img.read()
-            if self.cache:
-                self.file_path = self._create_cache_file(im_bytes)
-            else:
-                self.im_bytes = im_bytes
             arr = self.bytes_to_np(im_bytes)
             return arr
         elif self.url is not None:
             im_bytes = self.fetch_remote()
-            if self.cache:
-                self.file_path = self._create_cache_file(im_bytes)
-            else:
-                self.im_bytes = im_bytes
+            self.cache_data = self._create_cache_file(im_bytes)
+            self.file_path = self.cache_data.name
             return self.bytes_to_np(im_bytes)
         else:
             raise ValueError("Must set either url, file_path or im_bytes")
@@ -168,9 +160,10 @@ class RasterData(BaseModel, ABC):
         Returns:
             the path of the new file to reference
         """
-        new_file = tempfile.NamedTemporaryFile(delete=False)
+        new_file = NamedTemporaryFile()
         new_file.write(im_bytes)
-        return new_file.name
+        new_file.seek(0)
+        return new_file
 
     @root_validator()
     def validate_args(cls, values):

--- a/labelbox/data/annotation_types/data/raster.py
+++ b/labelbox/data/annotation_types/data/raster.py
@@ -8,9 +8,43 @@ from PIL import Image
 from google.api_core import retry
 from pydantic import BaseModel
 from pydantic import root_validator
+from joblib import Memory
 
 from .base_data import BaseData
 from ..types import TypedArray
+
+memory = Memory("/tmp")
+
+
+#restructured outside of class to use memory cache
+@memory.cache
+def bytes_to_np(image_bytes: bytes) -> np.ndarray:
+    """
+    Converts image bytes to a numpy array
+    Args:
+        image_bytes (bytes): PNG encoded image
+    Returns:
+        numpy array representing the image
+    """
+    arr = np.array(Image.open(BytesIO(image_bytes)))
+    if len(arr.shape) == 2:
+        arr = np.stack((arr,) * 3, axis=-1)
+    return arr[:, :, :3]
+
+
+#restructured outside of class to use memory cache
+@memory.cache
+def np_to_bytes(arr: np.ndarray) -> bytes:
+    """
+    Converts a numpy array to bytes
+    Args:
+        arr (np.array): numpy array representing the image
+    Returns:
+        png encoded bytes
+    """
+    im_bytes = BytesIO()
+    Image.fromarray(arr).save(im_bytes, format="PNG")
+    return im_bytes.getvalue()
 
 
 class RasterData(BaseModel, ABC):
@@ -53,37 +87,11 @@ class RasterData(BaseModel, ABC):
         return cls(arr=arr, **kwargs)
 
     def bytes_to_np(self, image_bytes: bytes) -> np.ndarray:
-        """
-        Converts image bytes to a numpy array
-        Args:
-            image_bytes (bytes): PNG encoded image
-        Returns:
-            numpy array representing the image
-        """
-        arr = np.array(Image.open(BytesIO(image_bytes)))
-        if len(arr.shape) == 2:
-            arr = np.stack((arr,) * 3, axis=-1)
-        return arr[:, :, :3]
+        return bytes_to_np(image_bytes)
 
     def np_to_bytes(self, arr: np.ndarray) -> bytes:
-        """
-        Converts a numpy array to bytes
-        Args:
-            arr (np.array): numpy array representing the image
-        Returns:
-            png encoded bytes
-        """
-        if len(arr.shape) != 3:
-            raise ValueError(
-                "unsupported image format. Must be 3D ([H,W,C])."
-                f"Use {self.__class__.__name__}.from_2D_arr to construct from 2D"
-            )
-        if arr.dtype != np.uint8:
-            raise TypeError(f"image data type must be uint8. Found {arr.dtype}")
-
-        im_bytes = BytesIO()
-        Image.fromarray(arr).save(im_bytes, format="PNG")
-        return im_bytes.getvalue()
+        self._validate_array(arr)
+        return np_to_bytes(arr)
 
     @property
     def value(self) -> np.ndarray:
@@ -124,6 +132,18 @@ class RasterData(BaseModel, ABC):
         response = requests.get(self.url)
         response.raise_for_status()
         return response.content
+
+    def _validate_array(self, arr: np.ndarray) -> None:
+        """
+        Raises an exception if the shape is not supported.
+        """
+        if len(arr.shape) != 3:
+            raise ValueError(
+                "unsupported image format. Must be 3D ([H,W,C])."
+                f"Use {self.__class__.__name__}.from_2D_arr to construct from 2D"
+            )
+        if arr.dtype != np.uint8:
+            raise TypeError(f"image data type must be uint8. Found {arr.dtype}")
 
     @retry.Retry(deadline=30.)
     def create_url(self, signer: Callable[[bytes], str]) -> str:

--- a/labelbox/data/annotation_types/types.py
+++ b/labelbox/data/annotation_types/types.py
@@ -1,5 +1,6 @@
 import sys
 from typing import Generic, TypeVar, Any
+from tempfile import _TemporaryFileWrapper
 
 from typing_extensions import Annotated
 from packaging import version
@@ -41,3 +42,17 @@ if version.parse(np.__version__) >= version.parse('1.22.0'):
     TypedArray = _GenericAlias(_TypedArray, (Any, DType))
 else:
     TypedArray = _TypedArray[Any, DType]
+
+
+class _TempFile(_TemporaryFileWrapper):
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, val):
+        return val
+
+
+TempFile = _TempFile

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ imagesize
 pyproj
 pygeotile
 typing-extensions
-joblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ imagesize
 pyproj
 pygeotile
 typing-extensions
+joblib

--- a/tests/data/annotation_types/test_metrics.py
+++ b/tests/data/annotation_types/test_metrics.py
@@ -21,7 +21,8 @@ def test_legacy_scalar_metric():
             'im_bytes': None,
             'file_path': None,
             'url': None,
-            'arr': None
+            'arr': None,
+            'cache_data': None
         },
         'annotations': [{
             'value': 10.0,
@@ -70,7 +71,8 @@ def test_custom_scalar_metric(feature_name, subclass_name, aggregation, value):
             'im_bytes': None,
             'file_path': None,
             'url': None,
-            'arr': None
+            'arr': None,
+            'cache_data': None
         },
         'annotations': [{
             'value':
@@ -125,7 +127,8 @@ def test_custom_confusison_matrix_metric(feature_name, subclass_name,
             'im_bytes': None,
             'file_path': None,
             'url': None,
-            'arr': None
+            'arr': None,
+            'cache_data': None
         },
         'annotations': [{
             'value':


### PR DESCRIPTION
Allows for caching mask values. This way, when we call on the mask, it is stored on the disk rather than in memory, so it does not take up all the memory space for large projects/number of labels of masks