### PR TITLE
Add type annotation to get_project

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -404,7 +404,7 @@ class Client:
         else:
             return db_object_type(self, res)
 
-    def get_project(self, project_id):
+    def get_project(self, project_id) -> Project:
         """ Gets a single Project with the given ID.
 
             >>> project = client.get_project("<project_id>")


### PR DESCRIPTION
Now usage information for methods will actually show for usages like below.

```
project = client.get_project(PROJECT_ID)

# Let me see usage information...
export_url = project.export_labels() 
```