### PR TITLE
[AL-1885] Update to Pytest Runs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -84,4 +84,4 @@ jobs:
 
           LABELBOX_TEST_API_KEY_STAGING: ${{ secrets[matrix.staging-key] }}
         run: |
-          tox -e py -- -svvx
+          tox -e py -- -svv --reruns 3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -84,4 +84,4 @@ jobs:
 
           LABELBOX_TEST_API_KEY_STAGING: ${{ secrets[matrix.staging-key] }}
         run: |
-          tox -e py -- -svv --reruns 3
+          tox -e py -- -svv --reruns 5 --reruns-delay 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
 
-RUN pip install pytest pytest-cases
+RUN pip install pytest pytest-cases pytest-rerunfailures
 RUN apt-get -y update
 RUN apt install -y libsm6 \
                 libxext6 \

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,16 @@ test-local: build
 	docker run -it -v ${PWD}:/usr/src -w /usr/src \
 		-e LABELBOX_TEST_ENVIRON="local" \
 		-e LABELBOX_TEST_API_KEY_LOCAL=${LABELBOX_TEST_API_KEY_LOCAL} \
-		local/labelbox-python:test pytest $(PATH_TO_TEST) -svvx
+		local/labelbox-python:test pytest $(PATH_TO_TEST) 
 
 test-staging: build
 	docker run -it -v ${PWD}:/usr/src -w /usr/src \
 		-e LABELBOX_TEST_ENVIRON="staging" \
 		-e LABELBOX_TEST_API_KEY_STAGING=${LABELBOX_TEST_API_KEY_STAGING} \
-		local/labelbox-python:test pytest $(PATH_TO_TEST) -svvx
+		local/labelbox-python:test pytest $(PATH_TO_TEST) 
 
 test-prod: build
 	docker run -it -v ${PWD}:/usr/src -w /usr/src \
 		-e LABELBOX_TEST_ENVIRON="prod" \
 		-e LABELBOX_TEST_API_KEY_PROD=${LABELBOX_TEST_API_KEY_PROD} \
-		local/labelbox-python:test pytest $(PATH_TO_TEST) -svvx
+		local/labelbox-python:test pytest $(PATH_TO_TEST) 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = -s -vv --reruns 3
+addopts = -s -vv --reruns 5 --reruns-delay 10
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = -s -vv
+addopts = -s -vv --reruns 3
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,6 @@ deps =
     -rrequirements.txt
     pytest < 7.0.0
     pytest-cases
+    pytest-rerunfailures
 passenv = LABELBOX_TEST_API_KEY_PROD LABELBOX_TEST_API_KEY_STAGING LABELBOX_TEST_ENVIRON
 commands = pytest {posargs}


### PR DESCRIPTION
update to use plugin rerunfailure for pytest. reruns 3 times after failure for any failed tests