### PR TITLE
revised video and text export notebooks

### DIFF
--- a/examples/label_export/text.ipynb
+++ b/examples/label_export/text.ipynb
@@ -1,343 +1,324 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "id": "db768cda",
-            "metadata": {},
-            "source": [
-                "<td>\n",
-                "   <a target=\"_blank\" href=\"https://labelbox.com\" ><img src=\"https://labelbox.com/blog/content/images/2021/02/logo-v4.svg\" width=256/></a>\n",
-                "</td>"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "cb5611d0",
-            "metadata": {},
-            "source": [
-                "<td>\n",
-                "<a href=\"https://colab.research.google.com/github/Labelbox/labelbox-python/blob/develop/examples/label_export/text.ipynb\" target=\"_blank\"><img\n",
-                "src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>\n",
-                "</td>\n",
-                "\n",
-                "<td>\n",
-                "<a href=\"https://github.com/Labelbox/labelbox-python/tree/develop/examples/label_export/text.ipynb\" target=\"_blank\"><img\n",
-                "src=\"https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white\" alt=\"GitHub\"></a>\n",
-                "</td>"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "employed-baptist",
-            "metadata": {},
-            "source": [
-                "# Text Data Export\n",
-                "* Export labels from text annotation projects"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 1,
-            "id": "manual-parks",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "!pip install labelbox"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 2,
-            "id": "supported-shield",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from labelbox import Client\n",
-                "import requests\n",
-                "from collections import Counter\n",
-                "import os"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 4,
-            "id": "nominated-press",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Pick a project that has entity tools in the ontology and has completed labels\n",
-                "PROJECT_ID = \"ckme5v7aykpoj0709ufi5h6i2\""
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "078de7d7",
-            "metadata": {},
-            "source": [
-                "# API Key and Client\n",
-                "Provide a valid api key below in order to properly connect to the Labelbox Client."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 5,
-            "id": "aerial-general",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Add your api key\n",
-                "API_KEY = None\n",
-                "client = Client(api_key=API_KEY)\n",
-                "project = client.get_project(PROJECT_ID)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "finished-helicopter",
-            "metadata": {},
-            "source": [
-                "### Export the labels"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 6,
-            "id": "gothic-investing",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "export_url = project.export_labels()\n",
-                "\n",
-                "# labels can also be exported with `start` and `end` filters\n",
-                "# export_url = project.export_labels(start=\"2020-01-01\", end=\"2020-01-02\")"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 7,
-            "id": "temporal-citation",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "https://storage.googleapis.com/labelbox-exports/ckk4q1vgapsau07324awnsjq2/ckme5v7aykpoj0709ufi5h6i2/export-2021-03-22T11%3A31%3A05.907Z.json?GoogleAccessId=api-prod%40labelbox-193903.iam.gserviceaccount.com&Expires=1617622268&Signature=VmqCl%2FTy60h8FO9q3E6TMmHpS5zgL5ZSD4YY%2BqBPBm2WCexOYnWsbCJ%2BHpqv%2Fy3y%2B9hMdSQiHVPbsScclza1UJC1xKCAdmNlzTnqZAaEkxoCSwKxNCtnKjRoMkYymlhjdrjxadxXeCmfnMGrGA3fr01KYweUdzUYX%2BzWoedno5Uq7aJNOB9HPjTJrltyJnmXbdQNdoKHr11xhzbqwdLFFZ8sW%2B5I2ZRiK2sC5LRoxazIlBu7om4clES4CzEwSSbggNb0A1ZtVg4MVp22XFzS7Ijdes%2FyjHbjm0HfXVzv4e6F5ag3eQ5oq3agUDJZsHw9m9PSbDwnDCAjUT4lRH7mMw%3D%3D&response-content-disposition=attachment\n"
-                    ]
-                }
-            ],
-            "source": [
-                "print(export_url)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 8,
-            "id": "sustained-retro",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "exports = requests.get(export_url).json()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "biblical-insured",
-            "metadata": {},
-            "source": [
-                "* To get more information on the fields in the label payload, follow [our documentation here](https://docs.labelbox.com/data-model/en/index-en#label)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 9,
-            "id": "human-beginning",
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "{'featureId': 'ckme60w4306hv0y8d7g7k64ky',\n",
-                            " 'schemaId': 'ckme5v8wt01n10ybafw48f72g',\n",
-                            " 'title': 'org',\n",
-                            " 'value': 'org',\n",
-                            " 'color': '#ff0000',\n",
-                            " 'version': 1,\n",
-                            " 'format': 'text.location',\n",
-                            " 'data': {'location': {'start': 32670, 'end': 32690}},\n",
-                            " 'instanceURI': 'https://api.labelbox.com/masks/feature/ckme60w4306hv0y8d7g7k64ky?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJja2s0cTF2Z3djMHZwMDcwNHhoeDdtNHZrIiwib3JnYW5pemF0aW9uSWQiOiJja2s0cTF2Z2Fwc2F1MDczMjRhd25zanEyIiwiaWF0IjoxNjE2NDEyNjY1LCJleHAiOjE2MTkwMDQ2NjV9.BjsyyZebUwFqfv993ePUXl0DNAoNlXKwLYzgH1s7JUw'}"
-                        ]
-                    },
-                    "execution_count": 12,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "# Print first label\n",
-                "exports[0][\"Label\"][\"objects\"][0]"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "adaptive-format",
-            "metadata": {},
-            "source": [
-                "### Using the data\n",
-                "* This one data_row dataset is pretty simple. \n",
-                "* We are just going to look at the entities"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 10,
-            "id": "crazy-swing",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "text = exports[0][\"Labeled Data\"]"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 11,
-            "id": "separated-girlfriend",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "people = []\n",
-                "orgs = []\n",
-                "for entity in exports[0][\"Label\"][\"objects\"]:\n",
-                "    location = entity[\"data\"][\"location\"]\n",
-                "    if entity[\"title\"] == \"person\":\n",
-                "        people.append(text[location[\"start\"]:location[\"end\"]])\n",
-                "    elif entity[\"title\"] == \"org\":\n",
-                "        orgs.append(text[location[\"start\"]:location[\"end\"]])"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 12,
-            "id": "advisory-recording",
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "Counter({'Robin Wensley': 1,\n",
-                            "         'Jones': 1,\n",
-                            "         'Frank Cass': 1,\n",
-                            "         'Robert': 1,\n",
-                            "         'Armstrong': 1,\n",
-                            "         'Kotler': 1,\n",
-                            "         \"Adam Smith's\": 1,\n",
-                            "         'Philip Kotler': 1})"
-                        ]
-                    },
-                    "execution_count": 16,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "Counter(people)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 13,
-            "id": "revised-applicant",
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "Counter({'Wikiquote\\n Marketing': 1,\n",
-                            "         'Wiktionary\\n Quotations': 1,\n",
-                            "         'Handbook of Marketing': 1,\n",
-                            "         'Barton A.': 1,\n",
-                            "         '2014\\nWeitz': 1,\n",
-                            "         'The Rise and Fall of Mass Marketing, Routledge': 1,\n",
-                            "         'Geoffrey G.': 1,\n",
-                            "         'Richard S.': 1,\n",
-                            "         'Tedlow': 1,\n",
-                            "         'Vol 25': 1,\n",
-                            "         'Periodization in Marketing History,\" Journal of Macromarketing': 1,\n",
-                            "         'Dix and Farlow, L.': 1,\n",
-                            "         'D.G. Brian': 1,\n",
-                            "         'Kathleen M.; Jones': 1,\n",
-                            "         'Rassuli': 1,\n",
-                            "         'Stanley C.': 1,\n",
-                            "         'Hollander': 1,\n",
-                            "         'The Emergence of Modern Marketing': 1,\n",
-                            "         'Roy and Godley, Andrew (eds)': 1,\n",
-                            "         'Harvard Business School Press. ISBN 978-0-87584-585-2.\\nChurch': 1,\n",
-                            "         'Christensen, Clayton M': 1,\n",
-                            "         'Grid': 1,\n",
-                            "         'The History of Marketing Thought': 1,\n",
-                            "         'PLCIn': 1,\n",
-                            "         'PLC': 2,\n",
-                            "         'SBU': 5,\n",
-                            "         'SBUs': 1,\n",
-                            "         'SBU)': 1,\n",
-                            "         'The Marketing Plan': 1,\n",
-                            "         'YouTube': 1,\n",
-                            "         'Snapchat': 1,\n",
-                            "         'Pinterest': 1,\n",
-                            "         'Tumblr': 1,\n",
-                            "         'Twitter': 1,\n",
-                            "         'Facebook': 1,\n",
-                            "         'Marketing Communications': 1,\n",
-                            "         'Target': 1,\n",
-                            "         'Capital Assets.\\n\\nResearch\\nMarketing': 1,\n",
-                            "         'Logistics': 1,\n",
-                            "         'Company Policy': 1,\n",
-                            "         'Inventory': 1,\n",
-                            "         'Labor': 1,\n",
-                            "         'the Media': 1,\n",
-                            "         'Suppliers': 1,\n",
-                            "         'Macromarketing': 1,\n",
-                            "         '4Cs': 1,\n",
-                            "         'Place or Placement': 1,\n",
-                            "         'B2C': 1,\n",
-                            "         'Walmart': 1,\n",
-                            "         'Mattel': 1,\n",
-                            "         'B2C Marketing': 1,\n",
-                            "         'The Chartered Institute of Marketing': 1,\n",
-                            "         'AMA': 3,\n",
-                            "         'the American Marketing Association': 1,\n",
-                            "         'The New York Times': 1})"
-                        ]
-                    },
-                    "execution_count": 18,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "Counter(orgs)"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python 3",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.8.2"
-        }
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "db768cda",
+      "metadata": {
+        "id": "db768cda"
+      },
+      "source": [
+        "<td>\n",
+        "   <a target=\"_blank\" href=\"https://labelbox.com\" ><img src=\"https://labelbox.com/blog/content/images/2021/02/logo-v4.svg\" width=256/></a>\n",
+        "</td>"
+      ]
     },
-    "nbformat": 4,
-    "nbformat_minor": 5
+    {
+      "cell_type": "markdown",
+      "id": "cb5611d0",
+      "metadata": {
+        "id": "cb5611d0"
+      },
+      "source": [
+        "<td>\n",
+        "<a href=\"https://colab.research.google.com/github/Labelbox/labelbox-python/blob/develop/examples/label_export/text.ipynb\" target=\"_blank\"><img\n",
+        "src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>\n",
+        "</td>\n",
+        "\n",
+        "<td>\n",
+        "<a href=\"https://github.com/Labelbox/labelbox-python/tree/develop/examples/label_export/text.ipynb\" target=\"_blank\"><img\n",
+        "src=\"https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white\" alt=\"GitHub\"></a>\n",
+        "</td>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "employed-baptist",
+      "metadata": {
+        "id": "employed-baptist"
+      },
+      "source": [
+        "# Text Data Export\n",
+        "Export labels from text annotation projects."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "manual-parks",
+      "metadata": {
+        "id": "manual-parks"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install -q 'labelbox[data]'"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "supported-shield",
+      "metadata": {
+        "id": "supported-shield"
+      },
+      "outputs": [],
+      "source": [
+        "from labelbox import Client\n",
+        "from labelbox.data.annotation_types import (\n",
+        "    Label, LabelList, ObjectAnnotation,\n",
+        "    TextData, TextEntity\n",
+        ")\n",
+        "from labelbox.data.serialization import NDJsonConverter\n",
+        "import json"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "id": "nominated-press",
+      "metadata": {
+        "id": "nominated-press"
+      },
+      "outputs": [],
+      "source": [
+        "# Pick a project that has entity tools in the ontology and has completed labels\n",
+        "PROJECT_ID = \"ckzdefhtd5v3u0z80gyn2gdf3\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "078de7d7",
+      "metadata": {
+        "id": "078de7d7"
+      },
+      "source": [
+        "# API Key and Client\n",
+        "Provide a valid api key below in order to properly connect to the Labelbox Client."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "id": "aerial-general",
+      "metadata": {
+        "id": "aerial-general"
+      },
+      "outputs": [],
+      "source": [
+        "# Add your api key\n",
+        "API_KEY = \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJja3R1NGZ0N28zeHZxMHk2dDd6NGtoa3R5Iiwib3JnYW5pemF0aW9uSWQiOiJja3R1NGZ0N2UzeHZwMHk2dGd2MjRkOW13IiwiYXBpS2V5SWQiOiJjbDFmNG92aXUxMGpjMTAyYTc0dThldHl5Iiwic2VjcmV0IjoiOWU0MWU2ZDMxOTg4MzIxMTViOTZjNzFhNzAxNzZjZWMiLCJpYXQiOjE2NDg3MzkxMDAsImV4cCI6MjI3OTg5MTEwMH0.z1YpPTUOv9IXGxy5QMKmTdJ1lWhFw13ZQM92AOX6XG0\"\n",
+        "client = Client(api_key=API_KEY)\n",
+        "project = client.get_project(PROJECT_ID)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "finished-helicopter",
+      "metadata": {
+        "id": "finished-helicopter"
+      },
+      "source": [
+        "### Export the labels"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "labels = project.label_generator()\n",
+        "\n",
+        "# Old export format:\n",
+        "# labels = project.export_labels()\n",
+        "\n",
+        "# labels can also be exported with `start` and `end` filters\n",
+        "# labels = project.label_generator(start=\"2020-01-01\", end=\"2020-01-02\")"
+      ],
+      "metadata": {
+        "id": "qPGucY8V5WpG"
+      },
+      "id": "qPGucY8V5WpG",
+      "execution_count": 17,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Optionally, convert to a `LabelList` for small to medium-sized datasets.\n",
+        "\n",
+        "This is more convenient than the LabelGenerator, but less memory efficient. Read more about the differences [here](https://colab.research.google.com/github/Labelbox/labelbox-python/blob/develop/examples/annotation_types/label_containers.ipynb)."
+      ],
+      "metadata": {
+        "id": "jCPjiaBIacpv"
+      },
+      "id": "jCPjiaBIacpv"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "labels = labels.as_list()"
+      ],
+      "metadata": {
+        "id": "8nvKKLnTavzS"
+      },
+      "id": "8nvKKLnTavzS",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### View the labels"
+      ],
+      "metadata": {
+        "id": "VlwIczrf9G7Z"
+      },
+      "id": "VlwIczrf9G7Z"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Print first label\n",
+        "label = next(labels)\n",
+        "label"
+      ],
+      "metadata": {
+        "id": "eFFgijvQ82_F"
+      },
+      "id": "eFFgijvQ82_F",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "id": "biblical-insured",
+      "metadata": {
+        "id": "biblical-insured"
+      },
+      "source": [
+        "To get more information on the fields in the label payload, follow [our documentation here](https://docs.labelbox.com/docs/entity-json)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# View some specific fields of the label instance\n",
+        "print(\"Label ID:\", label.uid)\n",
+        "print(\"Created By:\", label.extra['Created By'])\n",
+        "print(\"Created At:\", label.extra['Created At'])\n",
+        "print(\"Media Type:\", label.extra['media_type'])\n",
+        "print(\"Reviews:\", label.extra['Reviews'])"
+      ],
+      "metadata": {
+        "id": "uhgmI1Dx9LBe"
+      },
+      "id": "uhgmI1Dx9LBe",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# View a list of the annotations that comprise the label\n",
+        "label.annotations"
+      ],
+      "metadata": {
+        "id": "fJrUrglt_YOG"
+      },
+      "id": "fJrUrglt_YOG",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Grab elements of the first object annotation\n",
+        "print(\"feature name:\", label.annotations[0].name)\n",
+        "print(\"featureSchemaId:\", label.annotations[0].feature_schema_id)\n",
+        "print(\"start index, end index:\", label.annotations[0].value.start, label.annotations[0].value.end)\n",
+        "print(\"classifications:\", label.annotations[0].classifications)"
+      ],
+      "metadata": {
+        "id": "ciKIKTGtWzIj"
+      },
+      "id": "ciKIKTGtWzIj",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Convert annotations to NDJSON\n",
+        "We can utilize the `NDJsonConverter` class to turn annotation objects into NDJSON that is ready to be uploaded back into Labelbox."
+      ],
+      "metadata": {
+        "id": "ptyrc9BN_RLE"
+      },
+      "id": "ptyrc9BN_RLE"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Run the converter\n",
+        "annotations = NDJsonConverter.serialize(labels)"
+      ],
+      "metadata": {
+        "id": "921pcXT58Le1"
+      },
+      "id": "921pcXT58Le1",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "human-beginning",
+      "metadata": {
+        "id": "human-beginning"
+      },
+      "outputs": [],
+      "source": [
+        "# View the first annotation in NDJSON\n",
+        "annotation = next(annotations)\n",
+        "annotation"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Grab elements of the NDJSON annotation\n",
+        "print(\"schemaId: \" + annotation['schemaId'])\n",
+        "print(\"dataRow Id: \" + annotation['dataRow']['id'])"
+      ],
+      "metadata": {
+        "id": "VCkINPObA7B4"
+      },
+      "id": "VCkINPObA7B4",
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.2"
+    },
+    "colab": {
+      "name": "[REVISED] text.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/examples/label_export/text.ipynb
+++ b/examples/label_export/text.ipynb
@@ -81,7 +81,7 @@
       "outputs": [],
       "source": [
         "# Pick a project that has entity tools in the ontology and has completed labels\n",
-        "PROJECT_ID = \"ckzdefhtd5v3u0z80gyn2gdf3\""
+        "PROJECT_ID = \"\""
       ]
     },
     {
@@ -105,7 +105,7 @@
       "outputs": [],
       "source": [
         "# Add your api key\n",
-        "API_KEY = \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJja3R1NGZ0N28zeHZxMHk2dDd6NGtoa3R5Iiwib3JnYW5pemF0aW9uSWQiOiJja3R1NGZ0N2UzeHZwMHk2dGd2MjRkOW13IiwiYXBpS2V5SWQiOiJjbDFmNG92aXUxMGpjMTAyYTc0dThldHl5Iiwic2VjcmV0IjoiOWU0MWU2ZDMxOTg4MzIxMTViOTZjNzFhNzAxNzZjZWMiLCJpYXQiOjE2NDg3MzkxMDAsImV4cCI6MjI3OTg5MTEwMH0.z1YpPTUOv9IXGxy5QMKmTdJ1lWhFw13ZQM92AOX6XG0\"\n",
+        "API_KEY = None\n",
         "client = Client(api_key=API_KEY)\n",
         "project = client.get_project(PROJECT_ID)"
       ]

--- a/examples/label_export/video.ipynb
+++ b/examples/label_export/video.ipynb
@@ -84,7 +84,7 @@
       "outputs": [],
       "source": [
         "# Pick a video project with completed bounding box labels\n",
-        "PROJECT_ID = \"cktu4ft8q3xvy0y6t41p5dh9g\""
+        "PROJECT_ID = \"\""
       ]
     },
     {
@@ -108,7 +108,7 @@
       "outputs": [],
       "source": [
         "# Add your api key\n",
-        "API_KEY = \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJja3R1NGZ0N28zeHZxMHk2dDd6NGtoa3R5Iiwib3JnYW5pemF0aW9uSWQiOiJja3R1NGZ0N2UzeHZwMHk2dGd2MjRkOW13IiwiYXBpS2V5SWQiOiJja3Z2Z2ViYjUyZWpiMHphejNqOHVhNGt2Iiwic2VjcmV0IjoiMGFiZWM5ZjI4YzY3OTNiNTE5Mjk1MjJmZThjNDBhMGMiLCJpYXQiOjE2MzY2NjU1MjcsImV4cCI6MjI2NzgxNzUyN30.F61IZPYWCBAtXI30W2h0NgKRFkOGm4LIJwd0aJ9EZ-I\"\n",
+        "API_KEY = None\n",
         "client = Client(api_key=API_KEY)\n",
         "project = client.get_project(PROJECT_ID)"
       ]

--- a/examples/label_export/video.ipynb
+++ b/examples/label_export/video.ipynb
@@ -1,381 +1,461 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "id": "db768cda",
-            "metadata": {},
-            "source": [
-                "<td>\n",
-                "   <a target=\"_blank\" href=\"https://labelbox.com\" ><img src=\"https://labelbox.com/blog/content/images/2021/02/logo-v4.svg\" width=256/></a>\n",
-                "</td>"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "cb5611d0",
-            "metadata": {},
-            "source": [
-                "<td>\n",
-                "<a href=\"https://colab.research.google.com/github/Labelbox/labelbox-python/blob/develop/examples/label_export/video.ipynb\" target=\"_blank\"><img\n",
-                "src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>\n",
-                "</td>\n",
-                "\n",
-                "<td>\n",
-                "<a href=\"https://github.com/Labelbox/labelbox-python/tree/develop/examples/label_export/video.ipynb\" target=\"_blank\"><img\n",
-                "src=\"https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white\" alt=\"GitHub\"></a>\n",
-                "</td>"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "employed-baptist",
-            "metadata": {},
-            "source": [
-                "# Video Data Export\n",
-                "* Export labels from video annotation projects"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "located-egyptian",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "!pip install -q labelbox numpy matplotlib ipython"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 2,
-            "id": "supported-shield",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from labelbox import Client\n",
-                "from matplotlib import pyplot as plt\n",
-                "from IPython.display import clear_output\n",
-                "import numpy as np\n",
-                "import ndjson\n",
-                "import requests\n",
-                "import cv2\n",
-                "from typing import Dict, Any\n",
-                "import os"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 4,
-            "id": "nominated-press",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Pick a video project with completed bounding box labels\n",
-                "PROJECT_ID = \"ckqcx1d58068c0y619qv7hzgu\""
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "7457a04f",
-            "metadata": {},
-            "source": [
-                "# API Key and Client\n",
-                "Provide a valid api key below in order to properly connect to the Labelbox Client."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 5,
-            "id": "aerial-general",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Add your api key\n",
-                "API_KEY = None\n",
-                "client = Client(api_key=API_KEY)\n",
-                "project = client.get_project(PROJECT_ID)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "finished-helicopter",
-            "metadata": {},
-            "source": [
-                "### Export the labels"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 6,
-            "id": "gothic-investing",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "export_url = project.export_labels()\n",
-                "\n",
-                "# labels can also be exported with `start` and `end` filters\n",
-                "# export_url = project.export_labels(start=\"2020-01-01\", end=\"2020-01-02\")"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 7,
-            "id": "temporal-citation",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "https://storage.googleapis.com/labelbox-exports/ckqcx1czn06830y61gh9v02cs/ckqcx1d58068c0y619qv7hzgu/export-2021-07-12T06%3A09%3A49.855Z.json?GoogleAccessId=api-prod%40labelbox-193903.iam.gserviceaccount.com&Expires=1627279880&Signature=ehFSQH0BRl%2FNSA2CWf3pWzNxmWLmSnl7AKWo8mdLwLjcYWotziyeEyALA3Y1ev29lE56ovj0eo5g%2B22MyHxc4t%2FDDPLIMGhEFKLrK2bKBHtfCeVmgDkM%2BwgUAAKeW2pne9zMoD%2FIi9xS4DkfRO4EvHC2KEQRj61Q6kum4HnHZpWt2G7FCQ4GgqS2mSd6TMkWb6ln091f5qJpbpo%2Bjwg8v1Fkcald%2Bxt3P0bLrpXj5ZTb3PTR6zEjfk9JXtq%2Fe7sE%2FXFfjPBIgSphVo1vLCcfkjnAvt7rrqpRgq6Mj%2FZzfCAu2IgIHPmsxCm4ebyAKQ4OfbcRzCOEFeclyYymUVPS3w%3D%3D&response-content-disposition=attachment\n"
-                    ]
-                }
-            ],
-            "source": [
-                "print(export_url)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 8,
-            "id": "sustained-retro",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "exports = requests.get(export_url).json()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "crude-sender",
-            "metadata": {},
-            "source": [
-                "* To get more information on the fields in the label payload, follow [our documentation here](https://docs.labelbox.com/data-model/en/index-en#label)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 9,
-            "id": "human-beginning",
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "{'ID': 'ckqcx1dae06ez0y61e7dsh65i',\n",
-                            " 'DataRow ID': 'ckqcx1d6f06c70y61dcap7u95',\n",
-                            " 'Labeled Data': 'https://storage.labelbox.com/cjhfn5y6s0pk507024nz1ocys%2Fb8837f3b-b071-98d9-645e-2e2c0302393b-jellyfish2-100-110.mp4?Expires=1627279789894&KeyName=labelbox-assets-key-3&Signature=Z-4fGzE9VlnKInZv_aLun9IxrJM',\n",
-                            " 'Label': {'frames': 'https://api.labelbox.com/v1/frames/ckqcx1dae06ez0y61e7dsh65i'},\n",
-                            " 'Created By': 'msokoloff+11@labelbox.com',\n",
-                            " 'Project Name': 'Sample Video Project',\n",
-                            " 'Created At': '2021-06-25T22:38:27.000Z',\n",
-                            " 'Updated At': '2021-06-25T22:38:27.997Z',\n",
-                            " 'Seconds to Label': 15.206,\n",
-                            " 'External ID': 'jellyfish2-100-110.mp4',\n",
-                            " 'Agreement': -1,\n",
-                            " 'Benchmark Agreement': -1,\n",
-                            " 'Benchmark ID': None,\n",
-                            " 'Dataset Name': 'Example Jellyfish Dataset',\n",
-                            " 'Reviews': [],\n",
-                            " 'View Label': 'https://editor.labelbox.com?project=ckqcx1d58068c0y619qv7hzgu&label=ckqcx1dae06ez0y61e7dsh65i',\n",
-                            " 'Has Open Issues': 0,\n",
-                            " 'Skipped': False}"
-                        ]
-                    },
-                    "execution_count": 9,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "# One export for each data_row (video)\n",
-                "exports[0]"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "adaptive-format",
-            "metadata": {},
-            "source": [
-                "### Using the data\n",
-                "* Each frame's label must be fetched individually."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 10,
-            "id": "crazy-swing",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "https://storage.labelbox.com/cjhfn5y6s0pk507024nz1ocys%2Fb8837f3b-b071-98d9-645e-2e2c0302393b-jellyfish2-100-110.mp4?Expires=1627279789894&KeyName=labelbox-assets-key-3&Signature=Z-4fGzE9VlnKInZv_aLun9IxrJM\n"
-                    ]
-                }
-            ],
-            "source": [
-                "video_url = exports[0][\"Labeled Data\"]\n",
-                "annotations_url = exports[0][\"Label\"][\"frames\"]\n",
-                "# View the video in your browser by clicking on the link\n",
-                "print(video_url)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 11,
-            "id": "thermal-conditioning",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "with open(\"/tmp/sample_video.mp4\", \"wb\") as file:\n",
-                "    file.write(requests.get(video_url).content)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "legitimate-poland",
-            "metadata": {},
-            "source": [
-                "#### Turn video into individual frames"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 12,
-            "id": "framed-harris",
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX0AAADrCAYAAACFMUa7AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAEAAElEQVR4nOz9abBtW5bXh/3GnGvt5jS3e/3LLDKzGsCFwIXpHLKhQHRGhIzDYSHsUAOyA8k2VtjhDiHJRkjY2B8URiZCMuEGC9nCkiUZbFcIY4siQAqskqtKZFFtZlZmvr657TlnN2utOYY/jDHnWue8JiFLZN5Snhmx7z1777VXM5sx/uM/milmxm27bbfttt2274yWvt03cNtu2227bbftW9duhf5tu2237bZ9B7VboX/bbtttu23fQe1W6N+223bbbtt3ULsV+rfttt222/Yd1G6F/m27bbfttn0HtVuhf9u+rU1EfpmI/LiIXIjIP/Htvp9vdRORHxaR/8a3+z5u23dOuxX6t+3b3f5HwF82s3Mz+xe/3TcjIiYiXxSRtPjsnxeRP/NtvK1fUBOR3yciPyUiVyLyZRH5jd/ue7pt3752K/Rv27e7fQ74m5/0pYjkb+G91PY68Pu+Ddf9ppt4+8h6FpHfDvwvgD8AnAO/CfjKt/j2bttz1G6F/m37tjUR+XeB3wL8KRG5FJFfKiJ/RkT+JRH5IRG5An6LiPxuEfkxEXkmIm+IyB9dnOPzgc7/QHz3WET+cRH5dSLyN0TkiYj8qRvX/UcD+T4Wkb8oIp+7cWv/S+CfFZHuY+75N4vImzc++6qI/Lb4+4+KyL8hIv9qUFZfjOf6J0Xk/bjH33HjtN8jIv9BPN+fF5EHi3P/Z0Xk34/n+I9E5DcvvvthEfnjIvLvATvguz+mm/9Z4I+Z2V83MzWzt8zsrU8Yktv2HdBuhf5t+7Y1M/t7gL8K/CEzOzOzn42v/mvAH8eR6V8DroB/GLgH/G7gvyki/6Ubp/sNwPcB/wDwvwL+KeC3Ab8C+L0i8oMAIvJ7gD8C/JeBl+L6/9qNc/1bwDPg93+Tj/b3AX8WuA/8GPAX8bX2GeCPAf+bG8f/w8A/CrwGTMC/GPf6GeD/CfzzwAPgfwD8myLy0uK3/xDwB/G++trypGEl/VrgJRH5koi8KSJ/SkS23+Rz3bb/BLRboX/bnsf2583s3wtkejCzHzazL8b7v4EL6R+88Zt/Lo79f+FK4l8zs/cD1f5V4FfHcf848D83s58yswn4nwE/cAPtG/DPAP+MiKy+ifv/q2b2F+P8/wauXP6EmY3AnwM+LyL3Fsf/WTP7CTO7iuv+3hDY/yDwQ2b2Q/Hsfwn4D4G/d/HbP2Nmf9PMpjj/sr0C9MB/BfiNwA9EP/zT38Qz3bb/hLRboX/bnsf2xvKNiPwGEfnLIvKBiDzFBfeLN37z3uLv/ce8P4u/Pwf8yaBLngCPAMFReGtm9kPAm8A/9k3c/81rf2hmZfGexf3A9ef9Gi6oX4x7/fvrvcb9/udxi+Djfnuz1Wv9r83sHTP7EPgXuK40btt3WLsV+rfteWw3S7/+n4G/AHyXmd0F/mVcUH8z7Q3gHzOze4vX1sz+/Y859p/CqaCTxWdXy/eByF/iF9a+a/H3LwFG4MO41z97415PzexPLI7/xDK5ZvYYV1zLY27L6n6Ht1uhf9t+MbRz4JGZHUTk1+Oc/zfb/mXgnxSRXwEgIndF5O//uAPN7IeBnwD+kcXHPwtswrnc41TJ+hdwPwD/oIh8v4ic4Jz//zUsg38V+PtE5HeKSBaRTTiSP/u3ce7/A/DfEZGXReQ+8N8D/h+/wPu9bb+I263Qv22/GNp/C/hjInIB/E+Af/2bPZGZ/dt4COOfE5FnuFD/XZ/yk38ad6LW3z+N+/nfAm/hyP/Nj//p33L7s8CfAd4FNsA/Edd6A6iO5w9w5P8/5G9v3f5zwI/gyuqncMfyH/8F3u9t+0Xc5HYTldt2227bbfvOabdI/7bdttt2276D2rdc6IvIf0FEfibihv/wt/r6t+223bbb9p3cvqX0TkQ6/Czw23Ee9EeA/6qZ/eS37CZu2227bbftO7h9q5H+rwe+ZGZfMbMBT1T5Pd/ie7htt+223bbv2PaR2iJ/h9tnuJ5M8iaePv+xTVYvGtvXYdx55LJskfUKmLBpD2UArTkvH2OxfEMjxgDxiG8TWuh3+7OeID6wm7+NDz7WWrL4XIGyOF4Wv//IE9/482NqjdnNP5b3CIjc+Hup1xfnt5vn+KTOsmv/+TlSnHvxhRDXWj6D34tIii7SG31183lvtno+WTyXIHe38HqHdXF9+cQTfPQRl6+b1/64U9yMcNfF/8smfHRI8Nu2+t2NLhYFGw2K+BT5yPUWb7IgHZgu5lAdXsGnikVfiMBY4O0LmBSv7HDz4nVeZJAOco+cruBuxk7w9LBP6ogYe/mYr6794uOyA+q8s1hPZnNftrGRTxi3xQlNri+lm2MnNz5bjs9o8ysBK4FV8q7cA4eJcnkBuoeWU3ftyW6c9GMG/m+pLQZwMb/bd3Lj2OWa/chcvXHt8vaHZvax+SPfaqH/DZuI/EG8lghsv4v+N/475Cc/y/ErV6T+V9F99+ug7zA+/El4+DXscAFqQAG5MfpmYDdX57KZd7YIWI+w8t9ng05BDDEQS5itgAxmmBXMJowJzJDFNeq4JFNMC6Y7sB3YAWHw+0T9OqY+/5NxbRmFEJO8jsXpqzqJgAqmgtoEKGY6TxjJIIkkHeQO6CH1mOTQYRmJazitZxgTxohYQdSuP0e9meL9IpbBNiAnmBgmI+QR0giiiPRIWiMIJhlNHSmtSbJGywQcMB1iTBI+/bz/5wKR8+Q3OiytSWmDiZByj3WnbP+LP4D+kTOG+4qlxfN/3PBagmLYhL8OQjr6Wjaiy/Ks80XEp4PFdArdnQowGHoAPSocBCl+rGSQXmJIjaIx9xKQYvGqgRqShJSEdIDyrmLvKewTMiSXLw0fGKhCMegFuZNYPxCOR8WKQBKkB1aGbEBOhVIBxjpzeigc/uhfQ7/0NsYzHDX5qIoksmyQdI9y+hLpC9/D6gdfQX/jCv3lhpzD1BkWgEFiprjSFsSS980Cz5jZR7DPtRHReLc4TkZ/2dGwQbEB109jRkbx/hj8GIoLacOQAmLiY9Yma1Ui8+CnlFCxuiywBGQ/To4gz4xV5/04mKLv7tAvPqZ/b6B88T8gHX4a02eYGbIAOVK1lIGJTyzvo1CwRsxvW3RC8nXRfphA1ggnkDMiPaQOSKikWA8ZjfkIgpQYBymIXNeKZvX68fnT/+m1OkzL9q0W+m9xPfvws/FZa2b2p4E/DSD3fo0hGdnch02PdCdIJ5QRTFygm2p0ZUXW18626PTFDFmiVrveeW3yhFxuh5t/J2SwKim6OFDjp+KTQ0BIIAVYgZ2AHsD2eGZ8lUAL2CjzvZuJK5wyUTW+JVDrSCGlkgimGWMhsfCJYnSgCRHB1DBRDJ92VoVrs26S3yvqkyb6Q0i+6PUcymsh7BOSNpDXGIrYBNOA5QtIoysCO5IEkBWwxmyNcoqVBIyYXbjykymuIzMIE4n+rkow+qcqNhEkZ7oXO4YVaB275TBfG+v554QAYQSdcAG8EBSS6iVCKNni0gpSBBtiCIcEx6azkQwJQ3qfGmQLIBLzFIEOUkr0gAwwPgJ7KLDPyCSuhHWBfsHHM83T1EG8zNO3PaKREHJOFEJAnff0v/Rljj//DpTay9mtLjo0v0x6+XVWv/6XkH77S0w/kNBXwTaKJJ3nlMlCAQoyucLUAjpZMyKk9rMs1tcCvFbB689iLsi66J8kSEpINmyMaZyAI9H54jKyl3mJlrpW6gcG08KCIOa9ozb/OIlbTH1CViAvCFpAPjTGrz+Dd5/B25fILoN2cakU66eui6W8iLW/HLL20Gkxf0MeICEXMpIyyBrSBlLC2th8AoDBQslVIW+xhJemUEUMn96+1UL/R4DvE5Ev4ML+9/Gp2ZWG6pYx30c2aygbyIqWghUQuhAUCw1n80DMFMSMoK1iXQNQR+masGQgiiUhSWrIxADT4rMsBK5I7wJSJqBgUq+fSXRNM5MKSAe6AtlgdkKyI8YB0QFlQmT0F2O7niMCX1mCoAlMFfMljaRA7rl3JGsdJhk31es9JiSEOpYwDJURISMV3oo5etdQoAyBFgSxNWl6HfSz2OoB1m/RTsjrROoTSQNtaaGMe6wINirYiJLAVtBtsLzBsqMZdAK9wsoesScglyADlsboK39OdEQCIRsjljJIH8owY/cSJRkmhqj3tWma9WY13qo+nQQbXdgygpX4XQhkm2WJLySNY0xcn09go2FHHHkOYKPENPPFWAqkU2CFr6q29hTJHV0H3QTlAsb3DP1AkAuBg7oAm2ZF4fIhzcKvm6d26kCLugIOBWBmaIHUgyQXUkPK9N//AP7fgkzm8yFtsHSG9A9If9cvI/+OV+A3rTn+Up+iKYXli5+7Pj8h4G0qMAk2mVNSKjPSr0tAFj0pcb7k1rMlC8vIQtinYDAVcsKm6N/ekbgL2gnr/DpWklujGlZAvWYxv48kYVEJaYo1n1z4BxLx/pwCRAWYYi3k0zPUDJsMVaA7xYb+GsJ3y9rvKpnRUH3j72LwmswOEBUWOhLWt8QrdSAdVtF9G/D5Z6nJKltYW2W+hi5kX5Nzny74v6VC38wmEflDeKnZDPzvzewTN9AAUBNSWsFGMBMXStPkC7gE2jbBzdeFwPcLztTf/M+CDoxRD3rAygbRFXW1SRJAMTkQUgIziQWUw8RMSCNkMz6o1fYogA8sUhBz9IutMQawAZMR4QB2ACtBFVWMQaAoRzAWg2ka6AddgPwEqXOhbgksY43Td9yugRDMDElVSVqglyU6FkxfAv0eWL2CnZ/C1iAZhRFNxYUOiSSJTjYIPTatsGmDWYfmRFolus0KercarBhME3oYKbsdHAa0HKGMzq8a+ELao2mP5T10V/4cChRDUodtE5iQLJR4IGRRWVgJzABoEp8eE6TJsFDoFZ2am0Ezwi/MqHvCEf4BtxQmSJMrhWtrzdy4sRXQOaJMAuREVpCnxvDQKB8oXGQ3+AZceE7i/9exT/WE4hZI9tuZCuS1MFU0vBgyVSOJkDqhiFM9p1+4y2F7gh12IXtfpJy9QvcD3036B15k+nVgrxj0/tAqDjiczsT9AaMrOC0aPHhIy7rM1BWoNc0prT9IYQKIjxehaEXE+0hwlJ99EkvvFhGjLxuyuW9hVLcoJrAiTgtlmfFdo/iilUDFSqD/agr6mFkABu9foesgvdyRxjvIYQ3vHZHuAWZnYM9ifVT6OAZdKoJfYut4jmaOOBBREiYrRNY+SVLnQAZx66OhlCq0K2K52apsqGu2TvJr03A+zye0bzmnH9ULf+hv7WBx7S9rtIf1NiMyQjmS0xpNdwKlHYEjolMI2oI4BHSBKdc7pplf5sLdrINyjoyvYJxjaYPklVsUaYJ0haQ9wh4oLlgSjiI0ECFQzWcJB6xzoqVRPUYHtkJ0jZOZg1Md1mOagQFhctqE5M8iiyG2eu8uuJGRVB21ZjNcjQnFtd8R1FScox5rhpnOE5UEbDB7Edu+QHrhDukekI6gY1g9AlrQMqGaqBxH3nSk1Ql5syFv/FRVNlpcN0vPSnqknFBGw4qho6H70oS0lAk9Dtj+AoYnUHbQP8as+LOdhlAyt2akuAAwtUbLCTjKrwt/DMFfJIS9zd05d+tC8AeaHfHXAeTgqL8pE5iFb4nvJu/1tHahr4MxvTNibwKXPRw6VyolaKQis4A0FghfqMYb2a8zjUbaCNJJZRsd7cf9qA+DA4Is6Otbui+8yvhkh3Vr5OXPsv6t3036nfeYfo2gD4pbWBrrhLAOiyCjoANYWEaO6rP3o4RgE3M3l1QrZbaom9LK4v4Y8fsSCS4+hJqlquTCP7KiWVdyFOwgTvMMwCAwmC9bdaoJNcgJkiv8No5K3HNajFcVrHbtVrWLU7yUUTnBNit48jJy9To2PgW7cA7djFkYW8gP5vft89oXOcBRhrSGEPpujc39qDd9Ukt5HvKrofz6lVlb4b7Gbe76xSk+rj13jtyPtEnQvIbTjJ0ITEfQQl5lOLmH5HN0OmDTAeMQsGzAbICkLkQl+GrqfAxKRNdQzmB8DfQ16O7B9gS5s0I2iVSGhoytHLDjM2x6BlxB2pNWByh7dNS29k0USZ2jYCSY8sofVz9A/d5/5eMq6NSDDphNiCnGEZMS83SeFFLhaUVVlVi1CeghFyStMOnC9xGT3RKNWG2O0+KCvxJLksG2SLcl3VmT7o+U7gqbDlAmTJVE0EoYSgY2oCuXk6kgvcI6xbWZX6ou7/rsYCaJO6eBRG7ccbIVWU+w8S5cvMj08Bn67BzKY6TfYHf8uaWEwC+AWgBltwDaGinRPVWATbirRWeMNnfvAmFVNDtBOoqj3GFhGVTlkqNbATsqshYyAoHOy07hQ4WLHo7SDFKZgKNiYzj8cnJkW2VFCHrLhmUJGqSgKdOdJMZB0UwII/zGNJR6J1gHx3Oh/3WfZfy5Hem7Pkv63Z8h/a4Tps/BdFYcVKjbgc6SCjZmp7Eck/jzm89dpzbiwZPEFIr/o88bxxyo363l5fc+Vj7QIH1VbkHBZJ8XJiAnAoNge0EOCXaC6RgRezJjF3PBWi2GZs2G1WQltQip5j8JRG6ADeLuk07gvnkQxOE1bPgB+KCD4ScR+yDWSnX2SQONzadYKa2Y0UjC6EEyKa2w1AXqr7fvgLFOPepaJQJIYn6qje14a51ZnclL/1cAgE8V+c+70DdgnICOtFqRc2aaJnQaGNWQLKRNTyoJK1vKeHRhryOMvspNBkzdaYgMIAVpzs57MHwvpM/A+R3yS1vSS4KdGEZBxw0V0DCdkPZ3YH9AD1fY+JSijzF7CHII0a6hdUckrTESkjssHDTOkUrATwNRxDKmHao9khNIB2mKCCG3FALGxiS4Tl+J+L264C4IBS0FsYmU+kVUTELcjegCv8o3yeEPCLRmBdRIfSGvB4o+pRwuYSokLbGePZJJSIj2WEpI3tBte+xkjW0SuiFCDKVRMxQ3w0vjjpVihGA2pxNCIFfOPa17+tdfwM7W6JMz9CxTzsRldiBxm1zg18ik5lsPfzmjc/qVnmn3E2uj6dPFovO30hQGo3j/FGaETlxXDDqDlfrcimEygdxndBUWYSgcDVqWktu1KkUnVehLRcFlVu6dUSis152zFgSNIX5vWoLpiGcae9j+hhfg7e+i+7t/Cfw9K8prUE4VtdIERjJHrTYk9GDIYDAJqUhYInNfkVKzMOptVf0ptd817gm3EgRBtWrLGWlLckteuoqFDO0M6cTXQgbZZPcHrJz+SX2m7Aq2mxGuTeJRbJZI5k7h1IcynkAnh10+dvM8bM5zSWgSv9cEcg7d920ol6+jOsDDgg1CKo+cVZCK8kMztxbvxVebhukiKYe1noJatrp8mbXhLKjlGj2zCBQJxWILJCWLv+dT/KIW+gaDd0i/yqgpOh6xacSKOjcYTq+UIOctZmtfUX3BdETHGsuvIAUz9YU6nWPj57D+s3Qv3SO/1JHuKmV7YLLRnVVdhw+kQC+UTY+cd6TjFo53sP1dyv4eTO9iXLhS0dGRvRmSHX0kSag6CtBwnpq50MQ63EHbYZXDBcR6TDswF+RCjecrwOiCnhh2A2GOYpJAfqYTSXrcMde5mSiz/8EjE8QpEzVg5YsHw/JEkaeU/ROYDs2vIJYghbeNzgVHyVgulMkXcuohbUE2Hh1h6r4Zs9753wrUUpBTgaj1mGBUF9bDhIwFVeVYFFkluldfRL43oye0SFwLnpd6zmraezc5D3wMJ+xECDIWwinogirBZP7bmrCr6DC+L8yLdDIsFQ+dXAvm3e3CLAR4vtcxPSrYvgYDhIJdXi9ByjFHMlgPshJSn/z+ekfv1qvTEdvEdKxUW1hyEVkjcRnrjKtfvUG+9wtM9xO8oLCqfq45oME0IWOCAzAoNrkF5RSyc/YaDvPmJ0uuYEwEMau4JCwhmQFvVU5F45mjn7O4Y7f6JSec5+9rnyqSnA4SvF8lgZxkunFDORjlqsDVBJcFjgUGQVOG0oXslbZGmk/B8AGqSigsUCsE5ZLIK5C7gn3fllReRbVgD4ViP4PoY5w+9sGTyFkRPNjAfW3JAUsK+rhZJS6kpZk8FVx430oAoRlpxp8NnWh7oohgaKHXLvSvK49Pas+50MfRXwbpEmo7dP8MpikmUI6+U2fag/IQS44KyKRu3RasqmHFLQemzyCrz5BeOqP7QoduRopNWBmxccCGoIbSGlIiScayO16mnGC7IZ2vyftz9MkWO77ncXh65beuFc3UeF2HYCmJo4CSsJIRKTGbq42cUItY8Qr5JCHWASX4/uxWzLUJMqMxVxL1M8VXgKIyufBPoXTEkb8gIF0gXpeIapeI3sHKAaZdcPlOMIt0WJowVpEs1EEHujawEbrUjF7ppXGPam7Fl3n4AEiq5E6YMGfACtg6k+lY5YyOheFqZByPdPc7j4At3qXmAVRhGcj82eQ6mMGCD45XrIvmLw9Koep2icUJNK48hsAfH5yGqQeYIdno1tkFtHjOoBVDk7k1dAr5lYweCnY1wRTjLSH4gyoRMTS78uAU+hOf9xVUWpddj4mSu/BJTRVhh19jctljmxBcp0Z6JTntloMKKHI9OmdM2BF08L+lRuxUn0j8X8GmqM81F5LRF1WJWrUMFkJ2+ar9zTJUF/fXqCuwGknngKkGJITQFFd+eibINpPuJdIe9FKxqwm9mpxGmzwir+U0NGvOB9km8QdUHPk31A86JWQD3csZPdyhpdc8HbAxUX172BTnDmtZU/Pp1VDda9E/4h0lFbBUi6cJu2oFLTvserRhO5dd5/J9DGI+1sM/oT3fQj9at14hHUzHS2zYw1jmKRMCU1CfIOb61CkO3BwFkiSyALqBvoPulH57xvqXrtnd2TPuL0lHD29jKv4SPLomZQ/NT0LqMiJCMadQU3dCWr2GXZxgF6fY/l2wHdUbLyRIhlgiJUVkckPPFFWPgLGIr58DEASziWanIwEMQ/qgTtvYhDbYuiBWhUDsUBWJmVNPPjlzhItNgUKyo6rG7YLZBUxXCIpNE5QRM8/e9HBVv0/owl+VSKsQAlOhHCJ/oLM2l7XejoKoh96K1iQ2ww6FMqr3vSlTXiGrLd2qZ9WvGAYh3Y3rBT9fOXIT94WiEV1zBD2Yfx8OQM+lC4FUlU6dRg3d14/qDQuWjbyRWFRgoyBHyCo+p1L2PKpLv64lw/rJI85WAtnID5xXLm8pcoEL8TJbF5ZD4G+gOxd3kwiUcXLLtIN00tGtM0UVy5BW4rkKaXbYi+I5efdBzsD6Quk0EDORMlQRbnLqazAYPCqGSWasEP3ZKC1zZUbRAMmVh2KmShp6ZiH0KxrxrGLC0iDwgk/hFIERMSbJlV3AtYVLK/xPYkhOpJTJp9CdZBh6dKdMV+a+lKPAQeHgTy4iLg6y51yoBBU3MTvu4xkLIBshvbIi7e+670US9tRgehts7/0utPXrDunw0wVS8G5baD9L8b4+qDbSpmnAJrarRRDP3QR8M1nm1n776QIfnnehbwapp99mSEdsugoYFYjFydXQemlOhAFS9hg8JSaoqKPuVJOWRo7Tkdz1aJ6wMmBTgim1jD9UMZlQ8+QXkoTjJXg8Aet6d9ymFWl1Snkq2PEd0KNHECVHJx0g5vH+Ok3BQdYBn6Nt5tVSXLJJDReposj8vBYeygprgUphBcEd/aLzpKtKxDrn4nEOwkNQ3fcQOgDsijTukZwCCEnAa5glJkhOSN+R1onUF1QPlP2ADB2y77Gu9zjr5H3YfM+lMJV9UHUjNhVkKs7tV2pBJqY8waqnYGifSacrtItHPhLx2fFoFenWCNgIs7TB+fRrseSCI/e0EP51TC1OJgIrR+HJcIE4AXG+9NQoF0a5UkpncEfgpey7365T0I8GW3MrKAI47I0JHuVwQldTQrEtdHcz/cpdWdPeYIqQxt7vK3dg61TZLBfathiWzoV9PgHt3QksKZPEufvGJ2vyyJZBWsKaLGLuK9pvU6ch+dR4/sYtV7+NLgW+LToVKm/puQUes09PUxjSkKvMilhrZFK9DvP5xSmgkgTrXZmkFaQ+0Z3589jO4MkEFwU7Ghx7imRaNmv4zlWz008VZasrwS65krAHPWU4B32JMn0Oe3oA3gtTElpad1A50oT5UvxW5M6Nz4KmaX1VAizGqRfRQvOvXVYs0/Rc5n8jjO/t+Rb6QF71dJ0w2R6OlzO1g3iES31GmSehVORhhPlVBVswamZRRoBIrJpgKuhk7gjTBUcpjqKVsC66RMqdO1A1EnNEkFVPyud03WeZnozY/gPgSOXexSZMR6wMLvT901golT+IwZRwNBMZvwJRXCWieoLP8OItNI6jeik9PAWjuGO7ZvwGapCgwBw9hB6wEZMuzFH3gJXxEpHtjNSqMCRFv7qvIHU90huqO8oRbOwROpSVx4Bvek9PMOd2k6lzCccrGEe3IqbRrRsN2sKyRwvJjrHroO/hbENan87O3xFqaYOWo+fRu464j+LvR5v1oNOs3rV9rVYh4WuJuVRDJjshZfcDpL1HjtoAsoPy9QH9uSPsOx+7FzoHFWcSNYGSz5EMskr+/BtBzjJyT7E3C+mtjD7FBbeAnGTSiXDcG+WiRIgpkBMpwlLHBP0GNJkr4sycINWDnEN6ALpxy6GmofgrwIqq9/MkaJ0+OkOO1g112CvorJQN0DLawkF9LZu4CutYl/XaJoaqRfz+bF351PL16obDwnoohkza5KMt/SkImhTtBVZhvApuka9cYaeTHjsYelHQZwUuC3bMcBRkSHUVggl21KbAbIJp54Atr4HzjNw9JT17jbK/wI6XCAd/jpQdMNX7rme19mS1A5tca5g8dGNF8RJm66wEliHh7YfLP9pbp5VufP4x7bkX+h7RolB22HAF0wAaiefhRPIDY7ouIw2gmVwthVkgSUYtI33nyRERNSLhuKrKY044qSbthBqk3NHnxIhFolRC+oTmBN0DurymPFlju3ecJomMXtNKkzhOs1YLp/L+sTqRWXERySxpdkslm8MsJeoAhUcT5/3DGWsRYM7Rz880c/3h0G3YwABqxJCRZIDpGSlntMWY1azB4PbpEMluoE6Dx9pnlzKa3NOXsnr3HYIyM1BR0jTAYfAoq/EI08gyBz+lFeQtFiGYSSOeeSVz5M0ovkhDsNlUhb0hNbY7wg8xsM7cWbgCVo6Ka9kEl1eO9HJOpHVyIXiA8qExPTbYCznDusD+A4X3zBfaSUcuyYXfJExjlV6OFKVzgUQPnAicJewVsM8q6csFe1uRKbvjW2A6TnBUGHPQHtJoXhXD7sH6BWF46gCzGTD3QF4ATkIpZJ87kuYxdid3hkncaF4IfGi3TZsStvhdXWoVtCqeiR2YYq7Dc20FX2ctlq8U1KfQLIE6I6vl5gI4UL56H3t0VJ2TAgfzyJ9ViXIOebaOeuh6QU46yr0Iod0ZelmwCyj7kBEp7qfmZRRz6iwAWTpJ6AsnyO4FuHodpqeY7TxvCA/W8MNrZ9VnWXQi838fbdr6rgVkzETj4lxzvzaN0Y6cfQifhvefe6GfNkKRgWl8CtOOGg5iZljqEEnNQAKgJqtESJmF7StI61CX/4ncBwW0N19ghYa2mywO55IkCQegoVOh7zJd6tz5CK1YoWrG8hl9/wXGh4peHEAnipr7/ywBIxrCtSFrv3mW3v4F43BdGbScA4ckol2EV/hrzjgtwAGzAbERYT+v3ji5xzj7ubWuXkuIjNh0gaYOyRvCqRGCfoXRef2QJK54pjFI6M5LLvSdh1tuOiYbveqjJugzmFKG4rHv1Ydie5Lt8eiJntwPaN5j0pHZkDlhCCPAo1itsWAVdeYRbDSnKmoGZxUYGVgLcuqRRXkdoduNilBSl+l6TySyKJlQPsCF8oULz5LN8wuuOh9r70Q0Q+fuFhdMIWhTpZ5CFsgWdGvYmcL5gDzIpC8W5Kudj4LitEsRn5NRWKyYR8tgxrQ3ttvM8dFEls6V1gbkPnBHKGtzXj/QdSMIzLOXrUYB16C2Ko9SFagLWqEpgSWSJwS+NR6/RWO2JKa6jmKuJQnrStzPE7kErrDlOkI1gmO3EMLZz1kERvUMbK2WMW29WgbLBtmQ3mAl2MqnpHR4H60Tcg7cSdiFYc8MWxvsQS4SchUMwNEi2iC58D8Rz0kZ7sDFazBewm4APnSwUpw6W4ZT3pBkVTy5/GpYXtrksFox2GQmb9IiLLTRN1VmLMNF4+03KMEAz7vQT0LeZEz2Tgc0NBtIT71WjiwnzM2Hblo3tW6+GTNrE1G6YObX3NGkbaLPSU5GmSaPcshdqxFDDcDJoEmY8il9/hyjHtBnbxPVo+pN1ptbvIu07IW2/ohybyze/By1zo5LhFByuUI1I+naEb8NczhrhHOCkpep5c0K8P+TFXTaIzm3r1uhg6gEWLMrJYwHA+gSeSX0G6PYpUcjpTXSdUjnCUSl7xxxKpCVrHuER9RgpzLAZIaxYcp3yfIiOp542PoYXTCJW2j1cSstV5muoB3SBvIZdOfAdpYXanVhC1myGykq6M6YLkAfA0+Bg3kJZMnIyp3qNoY0lBKCzM9bEXClZrQqpuKyQUanuAyl22Q4y6TXBHvD6Htxf0X1TFc9nvyZNMbGxoJIRoYR1YycOsrPDwQ7gxKVJI1AngLJpBpz2OjLqVUPqTPKFjMhQPRc0Iwm8FuUYHPWVmE0K4q2Dqts6kE6F/i2IiJ+g2aNqDuo57TwedVz+/Vd2BuU5GGlNofSSgA9kvsLNHuYL51QeoONujLIUT5k6052OwW7q9ilYlcFewo8A7kwbK+ROe2d0W2h3Evw4l1s9zIyPEWmJ7hZGesAu6aL5v/mNek9enNxhw+oIvza7zXEjaoI4vMb8j5OzqziP7k990JfV8UR5zRCKbQgbwMzD030sMil4F90T5JrMs0AteSRKEarY4MkF5YlLWgzd4JJcv7AUpXsyblJCibJw+rAqe4eUEHHTEn36F/5bobpgF0+DKUyOSRBG5ry+Vo1+Pyff75QEPZxQ+r0l1THatNNfmTKXg9IbIPpdi4epy6JbAn5aunIWh8FA9t7n8hp7RSEgqWE5eizRPhGFElGvzG6zRGdLinDgOUNXe/cPymSyLaK5IT1bp7r1Z6yvwSNKqSAk9Rr2Axov8WGIwwRjbGS5sKoAqrl/ywFv8VpzsBO4idmc7JQyqQkSIHpEriyWgnb0d8E6SRjxchHv8Y4QDlWzSPNqhQLx2wNo5S5a1vugPmY5r5jLYLuYLr0AoLdCsY+IP0yzVXrIpfG5VRna9kr/YPsPP45lJ7wndhclVt8TtYkNT2aZ9tWHr4pcqJP4tK6mIg3sYH6+rz22TXwhXP32RWirOpL3NrLVo3H+Fn429TcAswS9ZjSHApaL2U6+w3CUpGmpboGwuxIK31lB5za64Spg5Q9uVN6kPME24TcMfRc4MLQpwUeGzw1GGO+d5Dugb6ygt0L2GGPPPuQWkPLZXVVgIt2c9FeO6QOEE1RCsacNZyu/VAiB6CewBYgt2Xqf8wll+25F/pD2iF6iRyOnoAx+YBLTNYWaxt1LuqEtXk2hZXpnWtF0CnB1EPOKGPTqoJn81VnVUpBfQhOI8XLaY1MzplirljcYFMMD120DqYxIasX6fW7Gd4w9HCB6Brj4GSxTm1huoywj6D7FpmxRFH1O1lMiFaaAerdmBkl/AQpJVKecxbMcMVVqllpvkp0RCgUMxfuWrDpiKRVXNNIXefKLYpimUwYRywbq60h3Z7peKAMIzplSGfoOrui6QsizxB9Qqocvu7RMoREtXiOKlAnbH9EbIc8+wB7+wHd5QnTGYtgonjiZcRJjvuLcNBhigS0rkLgmDMIHGG6MHgGXOChfjUq6K5b2OUUpkc2Z+hagdS7E7kL3KbmGcIJL2iXaGUiwnfpaLcXut6vOb5f0K8XZIAp9UydQi7BM8/WpqSgQ7LAITF8YKxPNuwOgzsy72T3WVj4maJ0tOTU7ksGVxI2yDWBfl3+WDjHU0RaBa0ZoKMqueaGym5htZNEKWNJQlQgcCpnjftSetCoD1T7yPMU3P+hJkifsaOhYb0mU2fgcih6icGxQMwWfc/iuepaynFMlz1xrg/GpBM0EumkPvva71lPcYf7FrSf4AJ0LFiXPIxzBH26xq7uYYeXkeMeS1ctaKIt0QWOW0p6WURRzZB96VS2GQTOCQaLkwktIs9mdC82X/sXrdB383KPlQvkcAXTGMJ+EWDd/g0EW2uHR3U/reVzKxTXhGjGpGN1JzOlAVMjSUJqhmCCuZxRRP+kcLqG6SlWObpQCp0nbpkZmj0rVTOMRVi/+hpdGZk+eNeV17DzhCe7opjXBmp2PARcB7HU5FOTge0DQrm5UJhdR77YU1sLrhiLxLFSn0foskDXYfR+jnEdyWvV8+l/WzxzCsegC4ADqoqwxuggr0l5Qsc9OhV0GqJcsCti0xUqRhLF7CFl9xZ2PCLlhDwmKCWeMRSwGFjx59cBHfeQM+Mbj5GrE9jWsZiRYtOQtULj2vuQDci5kM4Ei/BLrRTHiAv7x8ClwV5cqINHhGTIDyCvhHIO5RG+icq6g5X7JxwniCctjbQIklaQKTtFYDoj22kH5cmEvT85l2yCFvOs3CTuEO/EQ4zxkETpcMS5E4Z3lbufzRzuCOkuLqziuVDmaLVagXTy59VBrtE6ddbM0sLnRo2KagEQVYiGs7stv5TcUVznZJ5fkiWEvnlGcY5CJZG4aEvCwqIOTfLJnnp/BjdEE0w3ePDqsDRr4aVutYbgr9m/kcPgCW6GdbE2QgFI+OKs941jBHHfTwZZd7AV5KlgT33cRRJ2DtzvYHcPu6xF2Xa+fm8u0I+Ta01qzaCtWvRS13qAUF0yAHWIGq9Ww0JrFv6nifq5PddCH5Q0PEMvnmJXB2p105nkmAf+mv0Z9TfmMMjaUtAdvktRt8WLWVXhQZ6jayPME9zJZCJhuuHa1aLudpXTCSSniJrABcYGyiSM1rP6rtcpekQfe0SMTBts3HqhOD2Q8N2nrtM+SstnrZFE17ifqumhEq0ejsr8eW1m7qilhtBVAZ7mkNaVkDS5IDfcAtDeo40iFtkkOZIcDpAKdIpJD6okm7xiZot3dWI7dR29jJgdKbs9enyC7T6EYXChyoZSJi+twYSgUa/cgkZWrBzdoffWh8j7r5Dv9S3Zy6QiRmaBn4W8cspEKsJMtKrFVSmWI+gOuBC4wlF+jKuYO3P1zMMg833gfWBQ9BnuaJxqiKZjDhuYEWaCYBGRURG8XAgDlINhzwQOVfIYx2eFkzs93dmK6RCavDrlcyBhMYoJeiXsn0J6uSedu6XTqnSox6tH+L8L/qkNB9eEfJ1LtQktzBmjlU2OnMBw3sbcq5UtYfZptTo60qi/Sv81KqJerzgNVT9UCcd31d9a5/Xy/gK0kCKtyQ9pSXclzUot4t1bVI24BaYBDCQsp9IbrIzURxmNyCu0LaTOM6o5E6d6jt4fPOjdt/T0Pnb1MnJ8CvbEKapaywpbxNkvu9vlSrMwFsEmQJRbJpzbLTbLX0Ef1cJ2Teh/5Cqf3J5roS+myP4ZPLuEUUlaUfzyKAs+t7TOMwnT1mrCBNSoFI9FHyHvOB6OXumyFMw8ddoSLWGmOn3quGjd5ELVkYcEmogJKn0gwhXoOiaVCjoaY78hv/Yy08UVOgjSrcjdFikFHa8owxVMB1KOXTokwtaaJ7968W0BEOz6Kyge/eg8i2MUwb2t1WS3a/0Z5nRKeGVAR02iUQ8/YIhIjiz04tm6OUE6uoPbAp2uRkgfYGWgSz2JU467PTpMiB7g6gkcRmy1wdaRebRQFA4sFRFFEVLak9IauRzg5y9Jn7sHa+b10PhrF0bSga0ikiUYDttr1HICsey1TvegT8yR/qEqVoK2Ab0y7LF54tVnQLY49aF4zaFLH3dN5oK13ou5AKm6WYqRssHReXzbK4wuwFIOf8TOmK6M9Z3MtNdGdxnZnZN1hMIBfTwa3UpcgBn+bFqcQoogewmBr4N6JrEtcFBI1+uh3T4ftLoVIg2hBofVmjxWk6g05mMnWI7SCblm05rX5gmBZs1aSFVS+/VNWhizhkD3ktn4tomjBuBLAfL9nCnGdTZ7A+Qt6NqmqOoqkJrgCHSxeVKt+dMBvcUeJxKVkz0QoIh/JkdgDaqx6cujDTx7CQ5PEfUkDl+rtcPq+lx6zQPIia85aSCt3melbqA5gpAoxTKvZxf82hLbPuoc/vj2XAt9swm7egyHo3vsq9l6zbzzYz3sq3awLhwqISwXYR1ednlg3B04sXNPrjCNDVvcOenAOiIIYpeilK1VEDQ8dtySeUnaKu9WkHuo+6UAHhM9Qd89IF/sKF9/FxsmSsrk1JFSD2mDDjtUr0APiFRodiMczp+2GY8fn5X3cZ1Zbe+6QIiFVn8zTzhVRaSllbmgjzBZipA7J0YNp4a8Yql4P2VI3ZG8esp0eA/bTYzjFuPUC8iVTM5G0RH0iI07NJ+2aA0zHx8zI6c+7mrCSkHHA+tLY/yZM7q/65z0ep63TERa+B9C1Fw3yjGAABYlGQwmRbrk7z8A3jF4Egi/8uZCRHWBHIW8g9Uo5HNDX0sMX09MNVrLpxy1mCsxLpZDaZv3vw3hSB3NcwzMUV1NGGQUjg8Ld17tOLufvMLLlcIwOVMcdAVJoVPkLFE2MbSRqJayb6RS8zpEQQ+GHq2VGXCt52P+iUmcQuzdLDVWwH/WSavDY8t+z0DKzbiuxb+kzt86awNsENP52j4IMTfNogDaoG5JjdaK56Fp4eeSpkNaGRLV5RSf10MFzCZNMZjgln5nYcgKybe8cDote/QxAeC0bhgfliOyguM5HA07HrGnE8K7OD8YTtf28NUBtVyf9aYqOTtbPbOFM/f0vF7nvqwGQBvXesCntOda6KMj9uypO3AjS00t6I+WAReIQ+bBlnDy1MGVuuhrtmpSkozYeAnDGalbUY57R9epTsKgSlBSiph0ySE3vae1mlhqXkRLjSJGf5pgK5RtLP4RGIVpndl87+sMBco7D7FJmepCzSfk1Qqb1ujxCpuiRHSEqFyX5VOrodIcs0SVzUpyx/E13GyGoNFm23KhSyRMT5uFVfVZOI+CUSiTeX9k330id4bkidSNiOxRvWTaPUV3z2BaQTmS+gOStqQu0ecdZgfEJldy5byZ9Gg40s1LRDty33vYbtkz6YT9ZEF+2ctsz19gdyZzSHgS34rPO8Rj9M0iGUu8CqYBUyLtBH3XmL5c4C3z8NEuzdsdRhAIA8gV6IdwTMbmFeCZUd4u6CG3/QAakFvUcPETWHNW+j3hzmo1h6pV3vk2W9gVXHy9sLmfODkTxlXi8CSgd1AP9AKnHfmOePdSyxgYuZdWmhkDHcx9EFN0sNT5y2J8QzAHpTZngIZDMYIBGsBoQrchruZzmvMZZyQPizj8xXWavKtVQuur4NU+B4ndusyFf1lcu4LoCorr9A6QnUhNblrl8to90fZgcCvRQ781nP9yCJonBD8THhSUcestsFNCkGENF2fYxavoMGCHI8iHeLJGXWyzkm3vrxU3qv1RNZXOx9psIcyBHuLrROZvWsd8nAK/0Z5roW/TBFdHpOTmkGlIwRYZpW2BpUCl9ThpA+1zrriykAFJl1gRxv19upM1RTxc0UyiDKyfg5RmWid5CQaLC1tF30azh2VS7GjkBBomonT4/ugjjLln8596nb0V9P1ncPQsX8WQLpO7U3K/Ro8TOgzU/AQLrtsrjcUGGMwV9dr/TcHFwq7CtIXXXQ8Ba8YM1s62tB5aCJjhM9/W+C5AzkNLf4WkAbMD4/HgSVrj0cNrS2SU2kQ5HpH1hm5dKNNjynhFVgF2WHkG3TmCe9RER0+VFHWLXQ0vaXF0Suk4Mf6VH+f0/q9n9SvPOW7roqZxyFXe0glscWdu54DALqC8BfbTCl9VuOygT8iaRhO1wK8iyFM8muQK9g9B3z5i7yih1WnFxupNFDwJSkIw9cTeAnhxswXdgISQC3SOge5Gdmakk0y3FmTjDtl8kkhrKGuBE7DYncyvqqSVIX11XBDlqh10iAW9UrfnuzG+rf+sbvlT5wuzMzcWYPMZRV6LWAoaZwkQ6umXaKXOr6rgQUr1uzmdYwVH9kOKfQyCkoucDFTDnya0KqFI29AFZgVUw2arGGh/LAWjxnjU9ZzTrDwyrggOoL16365xo6ID7kD6rNAfNgyHU9i/Ah8OXlpE3qfVzarKpgExY1kK/doxDZxaG48b3Ue9WYvBabWE2kG/mJF+UeQ4Oe9u6s7UartLdZJEiFo4kiof2DIDAxY4glXPHlUwdgiZaXdgdXLPUes4zr4Bh45xI2FyWuyQJQmVMiPouFbbyzYSYGo9verUI8OUQfqe01/5Wa6++Cb2wYWXgS2+1WNBkNyTNiuk20RuwoSaemSN7sGEYhOJujNY1DSpk6ZG2OALUJokq6nd3kR86l1DJAuUsXSae79vgBNS7ulWYKsDhWeU4codrUUDqYdZm3p8wxpDx4G8KmQGDvsnXjNdY+feckDyKu5thVcOrVXT6m25sislkXJCv/TTDH9lzerkV6Pffcp4QlussibCG/F9V9fmXG0mMjwFfU/hzQKP6v3imbaxXZ+EU1TNkAjMSBfmaPtpB4cJkqFJZqAxeZ+aGloMcprj0IOir7kDbQEvggHalMud13QPxsLEkG2Cc9Azf57uFHQtSOcUo2TzMNocozVBOZorGa2lEBZCcSknjFBEFTK3GRI+23g+rQAgLMzic675elLyiB0JhSepurzaPGqmQChKMU92o5j7CyYfHxnNd80axR34ozi/X+JeQ1g3GjcSEmttJb+P6gNxKxDM99iNteAUYAxAzawrcY4QpKWDlMXnUWzYLgtLUM9h+nyiG+7C0FFU4fEBpgHjiU+4KquW6+ymnF4MRV178+SP7yrqt/CxVQd7ZTtunuwT2vMt9D10A5PZ+bjI5mje+2qiYsU7pirOGpVS0QcZ37DEY3RSyuizC+zePaRfYzX5a9mB4UOo5q+XFZ7rfDcEEWaXiVDM0CP0xfn9KW4xGVgOIPDSiu2vep3dF9/EHl75JK+7FFE8Rnkl+NaKHR0Cpui0oYxbGAZUDwgHhNF9ACK0vTODg/fbihDMeUo1c1tS1NExl0xmgkW8r+cBBK9uPdKd061X5P6IsaOMFx5KqWOcvkopa4rZqj+geDa1Hp6h+wnY+u5NRUBGJI0gK0xWOJq8msPQmilnzveXK7g6sP+xH6fPmfXv+AH0u7eU7JVUZQNsgKi+6LkEkFSwK0MegX0A9tBgJy3apxa/E2hpD1WBI8X9SmMJPj7I/KrQgbbvbYXfR/8uRzRIaTo1FEWlfOInnsTkAqbrfaym0UGIpUTZJNId89o6a8F632mKvsAqeeSMGIwJPRS07elrYcH4s1Ww34Bky3WpQr+up4XFFC4xMw0gYjMVndT9YG5SemVPWaxPxDOCm/wS6u5oUoRUXElqUGO1hpFbTMkrjcbOZ2kEncR3S5vEw4JNw9eRPPgiaBjpaDltEuUoNMUYt77P87JYCs9a3qNEvsAEMonL8IxnFPeG9cJ0B7rXBXm6gcNdGF6By8egV7Tkkebj4IaArqDK/zWtlnZ9pcW6rT+LPTmk2TYxbqUpq09rz7fQj0cyFFNdIIcbJoy4iSMQjr2YgKpY0haC5qGHlW8RVA5wuKQ8O9DfWTPmg0flNDPr+n1cuzNZoKfKi2aQDcipwMaBr4A7h+I3qffjhgnKSxvWv/KzHP/G17APL0hVkbNARsxTQ1JCVmtS12HdhB07bMrumI76Otb8HRrmt1fglLZCidT3eJ7Yi2CuyuWfmSWf2XbHHyqvyVshrZ4yTc/Q8YBNIbQt0yInqjXVIN4sRITCtL9yoZlWkMYof1HHCsCrVZqtMIutWHxboxBABbWDh9NePGb8D/8m+TBx8oO/jOFX3WdcC7b2/q8sByb0RyG/PTH8jR325Q356z3TZXa+OBKS0OSZrCpBi9m89orXXrd9nQ4zp+pI3s9hsRINYPQIQt+7dabi3CSvB1nkeETFzw40m7uxJq/+SgrwUUMiV3iyUyQX0aegh4Di6NiC1mlJS9UJLITCtxYwNRt3EoLeFaBVRB2FhFq4Zt0QvOriCqkdl1yjG9o0u5ZRG31VaAXf6jaZjOYO9FrGegrMEnENEpvhSK3PN8U91tyByHOwXj1jPKZlzrQtFC2sYYAWXVn/hxo8Nj+A+nV81700R0tpOMs7SPdBP5NJu1P06mUYHsPhiT9cjUqr6N1R2ULZ8PHtGqBcNmlDWh/bDw+k8g3acy70Q7gGBwbEjlQSCyfNC6wev/xLaBrW12/BC4ypJyqpwXRJeXzJ+s4JZbWKGPMSkzR+G+i+djJh3qagUUzwpI8zyC/7/uq29clQAEnStmZNScjJWk0teXXDJn2Ww499FfvgyiNL4oGa9g8n9rV+WXXk7hQ79uh4gGkKpWbumAqvl2cJHjEmpHrClq0+3wKVSctYOUO6e9hqEzT+BePxEh28uFqynnkTmDouHhYqFok44pvbkDyRyZOFcjxjFUIzzytRDkOIshEt+HwKGSM49x/JUFfPGH/spxk++JD+je9l86s+S/e5O/BKJq39V/p4wH7yCeNffwv72kDffwHWL1OOGSuj15Rvm3n4q+1JUz8bFTuM/j6H01fcvM7WZP4sgAihlaJEb8HzBSoXK3Uau7CWGhpZC6SJBmXR6gW74OoquHU/lWd/J6hRZHVD8zE48gV6rai9yYVaqqLFgtbvjTRJZGtriz66pkCWy8xCkFYFr/PabbO4XreF5uLAokU2SmwNEUg/BL2M5puZh5DXQZGjIXWj+8Gz7KtyNrFwdtP2S3BAJsgKuo2Hk5Z04zHCH+GuuQCOpX1JEzQVuNe1GUp9OgN5TcjHNXZ1F7v8DDI8moMJ2jy+ju5rHH+d/9c6tg5ccw4tv9Z23Ow3qWv509tzLvRrL1f7Mj5dmIkSXrsmpOvny0CVlu0WKeUlnKCSgD16+Ri9uke6v6HUrZgiptnnuVCjh0wV6VzAGel6wbU1pDNB1sZxB4KRTj3UM3dB+xh0Sei2Rum8orC8fso2f4H9j38de+eZUz0AtTwC4ayJNWehCEtO5JM1qXToNAU/GXZQmOA2edll02khQPe0UIjWx/6cFU2LdKR+jaw62BS02zMdnji9odmpDmo/+LNKjJnR+XtRvERCh6hQJkHZAB2mA1JLk+Khl767WUcSo9gWTVNYeIFi0GZhuUmbkLGAHklfe8rw6CfJP/oG+tJ95MGWtIbx6sD4xhPSZU+aVn4PJxf09+6Fo9kHOQ3ioXo1QqRON/OqCFwV0uUOOTthEKMS8bnquioYl047Fa9svTesM/JpQlbefea76nguRAipshRUzMjcEawPXdmZOzY7iSRAv1nRhE0+b+0YxxSomwZVS0kI4FQCuU8RJx9ott6/VlqoPo55RIxTdgHuKy6KUOqK+FsiV1Vqy0gekxbd1Pb7CYRfEXwtde7o3qL0hZDcoEWOKagrhaPNissAYpet5CHckvBQ687QLjkvHyWdYrdQB29hrGb8nqW5eqoQWCyX+hwq1AJ2pYd0DumVBM9W8PgF7OoL8HRA9Ip5IPVjkHvcuiQHSRHq6fkEASwrlsDnjdSs5oWmqNukfiOs/5wL/fpQNY2omkRNrdOqS0oNNTTnAZct4uyrKWoaKzqFw7A8YXz0iPULrzJtOqyUFkkwb2AtEQGR8CJQ4twhNKFfw7mOB9Arn4WlGJ1k5ITGoHj+km/OYAnGYpTPnLDafIHxR7+Ofu1DX7T19mVOoLGqACIvoVCcY5S5iqgUjeQcIfcrd7yph0Ba8VLMpseQVE7/eMG0FJPGMCuI7MmxMbcdd9jhECZtCHwsUD6hUDTYLrummG2RFCZ5haUVIVXwKVjDJWKjdgEPj92ABDMcJRm8uXUhMe5C8i00Lwb06iHD1y/C6T96dEhJsL2DnfTYaEgeKMMB095p0CzI0M30Qc3KrPpQwQZFrw5022185rShmVxjRxrlUQXEZF5WGqWUTL7rseyuwz0xS1yHzqkUHSwG3FuvTIr7Cda+faOuzTcQN7ckbDDsYMggDWHWvXBrTHwLDJkMiaSnFmZay1C3aKRwejZ1Xv0BC16h5kWYl0OQUGJ1njdJVdeSMZtFmtpeQIzMlE1xdK9F4978ezvi+/kOoQwifl8mWVBPtc8cXRugSXxvgYxHaYXgt5oMna1tPF8DLmIjrAgO8mesulgr8Kh9WmgJarwAad9Rnm7g8iVkuID9E9BjWw9iFSxZW7PzfxVB1FYvsgBnMXeWSZj+c/2oRfAx7fkW+jYL/Sr4F6PqqKNyqM125Vqn1Y0xJGqYWD1xPV4U6Q7oxSWyL/R3eobD0amJ6nQjOT0R2wo6Dw7VvNcOjxCJPWJtVBgn0rr3wmvVObUGS0IJtJSykDt8o/AC5dU127/78xx7Zfq5D91xFVZLy7mrziB0TkyqkyL6qu6bKwgaYU3SZa/rYkoqK0wHyhSJalEHWKJyKMENlrLDjgMyilsSxSOBBKFt+B6IJDqEGvbqLSgQPL5fREl5g3X3MM2YTVVNUQW5LwYPG/QCLFFEyjpC5RGZMW2SWEBlIyNTFT5eJsO3wRPKEBvJSIJyhQx7f68ZI7j8ZQ1+ZDb/FWxUdFC6wfM2NKJEdGkVxJxoz1zpk4P3p5lGhceMrFzh+85WVdFFTkkNCYyndNSZICvpJJHvAif1GBeeFkLRE5pCg1REulReFZlPFry5zTtullg7Rij3GZK2BNzkI1Wj5Sqj07yKKc7V1ldowcrZt/PHtWr+wBib0ESN/pawVfn0qpiGiEg6xpoaQCJHxqb6rAt0XiP+RDxeP5SqW1TmDuget95DERAh1tILOeoHVSUgBGUYg9NoGfNx0xOQl4T8S1bo03vI1avY+BAb94jtfB2wnDB1lGnSqc5rqBu5RD+KzpGci6Oljk9EH1zP6floe76FPtCgk8EceOutTsrqFKuJSNUPULMCPbqsVq5TqvfGOfCAd+OR4f2RfN7TYtoWRTo8a1Z8ksRirREXaQO2dXrAEnTnibHzWvvpBOwUtKdtGmHq92OGm5srD1GbCuhnetbn34MlRX/2IemgoOJRB6G8LARIU24x0cX8mWyhBEyj9nrqfKKIgHkNfsl9pMBn1zrqEkG0YHgpaz0ojfOI8EtSZt78xaCi7mYBQJMwYWVJUpAjkhKpP6EUj8V3hCyI9BFJBJMVKn1WVbwEr+rvq9fNoXGSDug9oioZJeIjXQ8lJ8Ilah2IwfEK3T1DVoKxhtR5aGYxZBTXgfiiT+aWkw7qRuHFQN9tGJJgdS7EMzSlIrPMs6kKtt6piD1Yp3TrVJOYG8AQdR7eC7ThlkTdWjCBbHwDEDsD7UO5Wuf3POBZt6NE5Ev0l+J8vwRwCG7epgSjKzop/swWETliya3lCmcFzzwXPJoFabL8OkJlUfm8zoNw1E/13LGWq1IKZSB1qwwV5/rD2StF5xj9QoRu+rJlTJ4/UcI/V1JTWNep7RCcKQXto4H7BOuMEmg/da4ALJL50jqsgwy2Btl6Apesow4Si3GuCiqDnRrpgZBeWmHv34OLV2B8hCXfxKDaTdfj9L2vDcN0olbMrEDXrQNtEn4OyS7Uml1WfQ8fxx8t2jct9EXku4B/BXgl7vxPm9mfFJEHwP8F+DzwVeD3mtlj8VX7J4G/F9gBv9/MfvQbX4i2vmdsd8P0rWq3KveI1lENFGpxcJ2o1zp7cqqhFMrlQDquPL48jZg4+SpkRHIs0hSVA5njwDvnDBGjSCKfQD5LDjY64MRr8mg1ewNZaZjfqTM/zhQFjtuO9W/+Ho7HkfLlx6QSMblhRrvCioncOIj699w3zXFGdWTPZnrlnU1y+KmqwFa3ZlRm5dH6zJVqJXUdNbrQXyaEtdkvFcU6eke9r7u8QtPKnaihyK1SS8YcNcMiyqXtXi6Lc+PQU/zl/pcaVeNCRaKSaC2t4FDtAIcP6CSj2VDxIjm12GmrTBmBF3pU7DhBEfRQyJM4AKi7Oxqz7Q++KM2i7IO4UIuiNzYZdjTKEWQ7z0SFmWsPpUO2CMMESUruPVFLe2qgFKkIEjl8jMnpjjDWRIOaU2alZLhCiMiXutOmo2qZHZVqs2DPEs6L9njXlxJLIT+vQ+o8q/6C4n2b6pjWTNxKpVZrA1dcVeBbjd+fQqFN/oxWuf/RmoE6WzYBOOIe5n0zljfneK9mTGsV8B2+53MvzclObMRja7yPt7i1RujF0Kc1GVPuZuzFhL1whj25A4dTmB6GzJ7XibQou+hLW2x3CizIw/jMx3FeybrQOPW8f4eEPj4M/30z+1EROQf+fyLyl4DfD/x/zOxPiMgfBv4w8D8GfhfwffH6DcC/FP9/aptDvXzFCrQCQ/Xja84MSR59Esje2gae1RkiSLLQ9o5W6z6zouI7M0EzCanUgzDvr5ppC8Hy7NjyWh5eeYCNc+4I7jRamVd+FBcm0yjY0XdQspR9okQpWQWOr65Y/6bv4bD/acpbu4ZM6nNca1VytH6qhHT0j4hz38lj/gG8xk1ppqJYTdrxSBCRuQhajc5xWRqcfqUkWm/FNDRodrBV/VCdfBNSBlK/oVutGcuBFhESlpXl5Ei+lsltkibRlEBKQS/Vx69jVOeK5+I7pSS+S5gVSCmKySk2XcH4DCGRdAvWoyru3C0206iGI+rUQ16ho/h2jInYX5d5FdU+qQqjBASU5A5bcQGmg6FXRtpK7CBVj2062jN6O+9AL6ls6DZ58a/OUb5MgtV9gAeC206hNH3cRFNzNEskDroQpu0HK1Ogf5W5hAQhdurz4MXJpCLlxdjP865ORqFt0BI5AFIiOkdjXTR07EI/VcdtifW8VAJlFvYUQ4srO4/T19g0PiwEnSde5cetzrGlLIm+nqk1Khs5u5iqZd6D7UH3hpzhO5VN4jV5amHFsPLJOI20BrsrcH8Np2fI0xeQ6SHIgFZLwxzVL0PE03LiQXTALPTnVqWBtmNuioVPat+00Dezd4B34u8LEfkp4DPA7wF+cxz2fwR+GBf6vwf4V8yf8K+LyD0ReS3O88nXCW6uljmuS3wp+GsXNcohzENTjd8SICccvWbhIfcFksSwXIIiCeRYbW+LsKwukdYxmD2+F2edHD1u8p0KtsV3g9pElCLmpnGXkGxtj4eUQcWTfbyev5D7WHNqaILp86esf/B7OfzFn0Ye7kPK1OUVkRSVH2xrL6BdXY9BD0RPIPRI6p3rb1mvtS8DsiBI6iPRWHFrqCKJOUwVLDLOFmhE6nSEZnkskE2Z9rTqpKm75tTydVlXjjnlVNNVUxfXBsiYdW6e1/uVBQdt0sa+3qcE1UXKJMloGSnDMyRtnQoqBaaETuYJQnH7/gh+r6w3MBa0hICs6+06LnH5YTBN6pEoiJcNSAkZghpJhu5w9L7CkbDoHGsfWx5KCqBxkrz0wipItAnsIOiRoDqYBWQVpuZCQRCPkKl1bcIxyuBZrq7krCHlllGQJMbXs2VF5iCCOizXAFjthIp82/3YjNaXC7Y5kfHtD6vFgXcFkwtzsarIamhVzUg1X+vVOtOIRAorwqpi0gUIgqB/td1K+03VC8lzNdxCMqfMMu5PKOY0UvUnjJBiC84UdX8q+JMzsPsJ7t4lP34JPb6L2mMwDfomwpes3kntntpBFcHH983Ymhd83TDpBp/1qe0/Fk5fRD4P/Grg/wu8shDk7+L0D7hCeGPxszfjs2tCX0T+IPAHAUgP2ufVOdhQ6VLkx6JzDFqRim+WsKxO4K9QBinQBoJqeMHKDi3nSNcHkvWaP3UzCNsYnEVo34qgK31x6Ilr/dwvOP/enbUqMld9jXvNGfIKCskrSKoX75KwIgz1HKZffpf1o88y/OUvO6KLJ4UFxeMdxyx1OmavXTx3lAk0WYOtELkD+QIr73uG5YKGkVhUrgwSYrktfjQmmYTHbmGK1jtraO+GR6kqXR0P1NLNVmmbGLaUO0wz2nWR+VmlQF6cM83vq1kbUTxtT9dFWGW7MYk9EMwwG7HpGeiavHqA9ttZiNftDo1WfM9Nlt43nTkqqU+xqTpcs0riOqaEII5Br7XnExgFDiCH7HWBBsir5MxG3U3KzOeBRgXIc8NOQ9mO+Fw44PRELeLW6F2LGPNAuo1ikZbwVEMka7IoxHc2P8NyRCEUg0V/V8shurvRXBU3LF+1L2pflbAEJry2TigEm0LQ1slQ8LollZ6KjWlqaWWa7y7OXWxh9csC9ft3Pn1koc3rOeqcjeeuIazNWxuKrszzVNRgS8vRaUX6Jj9eBa9acp6Quxt0e4483UZ4fd2kqDDH1c8rp72N+6qCfV5NS5QXzyLXfv2p7Rcs9EXkDPg3gf+umT1bblJuZiYif2t3Mv/mTwN/GkD6L5jkjrYdm8wogoo2LbojvPQu4BdavN3odQ3q6c5tjMnpCuwhurtHf2/DsZMZ+fSCbhXuJeQ+yAmO3jEo6pM/xcyfjDQAK0E7L9Wae3zzC6U9i4pvmZdEKIN5OKV2c1p/70LiuIX1r3+V/P5Tpi9+4PHkME/usEYkVSeWP3/rdN1AuQdyF7oeyRvoe3KfkXTBeGWwfwwykmTCaogkNR4+zZmtPkCtb7XMAqFOuCXua4q5Cop6nDm9Vvl+iIUcC4HUeey0dP5sIu2ewJ3RKbkzutIiEBvEC7FbmDt7605MrmwVz+hVvIKpgT3Cdi+R+1PKqq94oZVLbhRD8qQ1S4pOE0lzKIaINBFzB3f8qZNFuKZQk0Yk5qCYYFLgkJEjWER95RR+ibB+UI/Hlj5hW8N6HxEbzCtBHq0h/Fq3xjeiiXGp2bSVU69O5VpieqxLxWZEUoevbqQiNMRbQxRbrpIx/yae24Gr3VD41QKz2WcR5aVlkKaElmGXDdzprIAJRz0p4uoF2q44VbFVIW8pAhtmYW9q3j/NUomkz+rPqsog1XVVFaArmTSBHsLSrZZAAluZ+/ZGWriqilNhaQ266WG1gW6DTGvMrmrnLV4VtOnivubgjFR9cB/p0pva9Ru3X5DQF5EeF/j/JzP7t+Lj9yptIyKv4XsNAbwFfNfi55+Nzz7tAqSuxplrmOyu8WspWWtawDtNzRa+mioMLf6OibXsqGYyPsPKI8r7L9Kfbum6FZNOftpTIb0k8JogD6A7wyebCVoS09GQPeheKQdDtoJMCRsF3ULaWGz/BlMICaOgkkkr0NRhw4RNukj2CvQwKcOdzOkPfg/7JwfK1y7cDPYOav/PrLq2BQo9pudIehG5cxfOO2STYZN8o41hBU8KTB2UZ6gdgSnol4BakUHq6L8u6ESWRKJHpxGVkB4WHra4jzYhG/qKsgqV0yU3VdF+o2OstaDzIopntvs9AkNFSJG960IpCqJI+ANSOLhaIfjFomhRTwZljw5PSdN9RDbUy7amwFTiWilCQOE69SrtGmJCUiiTeq2NsYudmPyJ1MJlncRDLPd4/RwRr5JpgaCFtvmH0wXJ0eXR4JA8Zv1oEZ5pbUP2myAQxePfawRMRfqtamWVHgvBvOCprgVp2Ryya5UrrxaO+Qy8hvCqAvMJ5J8V3MIYQAYhHV1Y6mhzSYVq1ZvN0T51LMJq9rlgswWAztdQIMYptCiNslLFUvLvG16ollooDo15oxmyMwaSw5844eMmQDbn9EeZp/5kszISfE+N0w7ZnFBWJ6TjCmmJjdFJNbvWKgCqJifU/JdaLywefB63xfSD66Drk9ovJHpHgP8d8FNm9i8svvoLwD8C/In4/88vPv9DIvLncAfu02/E58eVSMmddBZxUhIhCdb4MG91Lac0T5pK6Fen7mzdVTPVEZUyYWWA8YLxxReQeysfuBXIi5n8oiAbl2v6FK/RUwq5S2y7hPTCpMJwUdAnvjVeDstwmoBs5HVsiB1cpYojhLwWJsme6j+JOyo73HpI7ogcXu05+W3fx+X/7Sew94bwOcSqThmJMEarMeImiJ5AXrO6f5f0mRPGe1A2LhstQd5n+u2LTPTY0yfY/hHoEVKhFo4QFKUEvx8KNCWKbVwAJCKTkxD6+3hFFuKS76/x9yFX2hjUaA5C0ZA8m7KZ3tpCNqtZ74oukK+IKyWRCCft/NxafR6+KYzhNc7niKISzpUjMg3uQ6jRPzUap1JakdFaabCmywLt1wVsISBAIwHDvYPJ3DJIFVEn4CheQbrHFYb655Ztth5O5sVtlYvf40laweW3ZPSyWAdViEd0jtQonfYy5gJ/8xDN1R2lVflswrtA3WfZFguuJnDVd0ujztcXtNj5qpym1CgqBtxqmeJ7mPWz0ABNrUbQ9OzM6y6uu7i4CZKT14iqm6tIzMkqOyTNgj4c4E6xpehPT3o0ZE76DKuqlouQ4velYcU0f9covr5PQU7O0PUd7Kr3YAKt4MiP9VtfausIQsHLqMu176T1ujUK8xsL+9p+IUj/Pwf8Q8AXReTH47M/ggv7f11E/uvA14DfG9/9EB6u+SU8ZPMPfMMrmHl99gXqkCg8pSbQYokrEozEhJQbT1cniIUtZtGJcyGpjO8DewZ4wZxyUcj3QM4y8kIi3fVDy1NDD4odFRkUjiOjFsiZtO1Y3V1xuskcFcolZDEiaIOxFozqhDQZGlEVEgW06KUhNQknXEp44tdoDJ0i33vO9rd+L4e/8HPoRTg5a85B67NTTB8AG3eKnq4Y7nfkVw150dGmjUYalbxNyIs9JT/ANlt4ehf2Ozg+w2wAnTDzkAqP5d+AdZASJluM3mP915HKaAXTEcYdlEfAY8QuMLmixRESA9L+T80ya8EVNiFRc6YtBsmxZutEqEohBBTWoi/8k4SlqA0fhXTcSR9VRXPICM1YKUzHA2kYyCU3C8TMIn48O1cbSkoiB6MW86Km5EcGaF4L3Wlm/6TOTd+T2W8jnM/F482pBdxK8PCxK1NzUDvb5fJnFGSPZ92O4tnFugjii8ne6JBQBG3TuIXPoq0d5Rpt0za+Z45gsr4+X2oI2pOV0mIol0InBG8Ifak+hkmcVjoaHBU7CnZIgfpTlFwwWuioEY5jGp9vQksbcVpXadsvLmkkC6HZEika0piFvnj6oru/bD6HRXl21BV1kshNCKumPZ/MdNWER2EZs2+EuG4PrBNpu6akDrGJ6oyRylYQlM7SJyX1fcCb6iyxpgav2VY3/QOf1H4h0Tt/7VPO/ls/5ngD/tt/+9cpTYB7WOScFeubnMejh4avyGBGAovJQEbS1HycNYVO9C6k+0g+h9XG50VndA8SdtflnO4n7KKQ9iAH81C50qN07px8ohzePzBsOrqznrwRyuiAJsXeuRScChpxOmcEofPFlsCSO610CjDb4clY2aAUht7Y/pqXODkol3/pS3BpHp4aaNbMkM5Y3+3JL95lWgP3Mul+orsvDD0ec/7BwPDujnEQ0r1z7Lyj607hzgl2OVE+PIXdlZcPsBKVHjewXpHXa/LpBjlfo+sE69SsaitGGQ0bC+nqZezJI/TqTZjeZOGFbq1GVcW7eXEuAJxFolXl5VukKIDqXBYldY55kjBX/LRmIfhiSc06anXRqoAoR3Q4kseeZNmrmJg/iwtkcT44J3KfXf7V+2/GjAvBcYLTTWI4WVOeOgQ0yxQNC0AKSG5lHzQSAoyM1e0ODSgFSZnUOwC2gaB1UnMSX8N3C2E/5xwwx7CX5TEhtEIGNqpjsWwaC1pmn0zNN3AULU0Gav28xsLXYSyB3kfzTecjkYwDyFHQo/vA0sHXS80faDuRhZ6u4ZDua5hv9hrqX1olGsEJy1YFe6V74x7nyCC/YBIvi6viEV+pJiPWDmolKIiSGq6cdapTOOYUoJacMcwCnUQC4iIeVZjpsmu7ArYej8dbjnRo84b4F8laYWV8Gu5/7jNy3X9RR9NDrUxHF/wAEvQPUT0TH4TW+VSHVJC1pWCVFLcN2D3o7iP9GdKfYf0a6wXbOp2jKHIYkWeD76C0M3QQh+ApOeUEPuGPBmP2ol4bD9VMJpRwBIkQOwGJb8KtiiYlWUJWjm4s0L4NwArSCiTl8M9OHNeZOz/4MudruPp3fh6eOvXg9coV44LhcGQ1XZJWK4b3dshlRi+2yL0ztt0ZgyaG0mEPLykHQV44J51lOBXsrEdXD7Bn58jgG7R06wz3evKDDCeCdk5VmziqtAl3jA8gB4HSYYd78OAO3dN76LsjeniXmV9oq2demDZP8uXYN7cA7tRSmyWZVXouFqTvpgRe8C3N6r6a282k8P8tHKVEjXgbJvQwkcbV9QmoOJdvi4UV8jug4GzEJKEMhaEktnc6Li+OLXLEJURIXnXKh4iNtyFhnXmQwDzdvQxAoFsbtdEhNVqlSZ+F8rFrf4fQrVFEC0U3J2TFc1UBEz6FpoTDkUtNRqGe3+a49IqEDbdSKjdfcwFqXZ2jOaoPBSa1QFz1UTS073dkQbVYlkiGdOTdwoYrQEiO4lsV3rouNUADQZ9VC6DWs7Lr24xa8OlSM4ZlVqxWEXbtiyr48Wmdwjqy2tcxR8qVOXV7HLAyzJYUiz5m/n8JU6+3+bjlMXNQR1WGf4eQ/resCc6nWmpd4lpxaqZNytq0sYk7+VDnt32XGR8s39ZNPUqmnADn0J0h61NktYF8iloPpxlOoGTFDnvkagcfjuhF9p18dO2LMblDTpswSCSJMgkCsk3kc5Bzt6b1YL6wJx8UGTu48vUhaw/jVMUDS8Is1BMhnYKs/LxFC8/Wic1vfoV7nz3l6Q99Gf2pZ1jB9w8W0MOR49ffxs1A5+SnPsPJinz3HtvXP4c8OGMYBTtM2H7ATrZw6l3C3YRMPflkRX9HyCc0isCOePbnAEnDxRprXJLnKaSCV41cJeju0Pe/hvG9n0Uvv4qUHdfKwla0IgriyWOWFK+lHzkTFOdZ8U1STNI1wbjka61x7hGf3nSKLYSRUmN5JaI4TAuUCR0m7DCSbEWubMYwxAPWbKzqp5t9BrUQncecG8NUOL3bsV8bZV/htLbM1pT8fsyAEpEmq8mTmCLkViJkuBC6ooZcKjP/vXB0Sv23ovlW2Kwi3EztDS/5UIMK/DyVHa7yvIUPm80OUUm1C/xqio9dOGwN2rE1Ushr4Cdk9LljR3WfxDE3xC/VAq6bCZUqUUMBJTyBUa1VIhWx8HsR+Q1x481/UDWfhrAnwMXsMPCg5HBCR+it4dl3EhK9Rv2QpcU3+AY616+tI54lPHl/Sk7kAuMFsNuFz+wZZhE51mJb63iFOJe6ZSXt+yrYpU36+l2L6gj6ksWvPr4990I/SdR7CYRyzXAJ4WFWHWTm4CcUgLQCXuAhfIJpgnKGhzCekDYrWCcsd55K263oHnTIulCmAbk6Uj44wJPJt23TDkkrL+OBoAqlxED1Cdkm9I4hdyC9IOQzoItp1uMLjUAKI6RJ0B3occIi09RTzPEIlL3AmOheEMqmQ1UpOnHoIH3/Gfde+X4u/u2fZ/iRd+CIL8pwIAqegZkIuTSNlGcXXH34BtvPf47z1++y308eyBFZhWnrt5aTVyPUldtP0w70wrAr9QJiU0IkoTkyRqvsEfwzgZwM00QpJ6xf+zyHty+wqwGxKUBzarDZLMd41RVdkVolcK1lctYkoepgazyRVSpo8n6Y4apPl4gCa3n/7ZwV+QbiP07YuPLtB2tdl9gD2VRRTSS8nIBSO9etSQmkp1qY1OhOM2UYXUDnRHc/w0uQzgSVxHRlMLhyTtsEW/HsTknzhikdvqvUqHMpglGYC5iFcApFREWpldJpCVs2S3RLLbCmQuZZKDpab6BRmK/TwKbMB8eWYFY3647rSd3xKtJg5OjROr7nTzz3IC2ah8GpNCk5gjWYE7bdZeTDHKWUpPp8oDnuW2uKKkzRONFcZt3avKrlUGYHf5wiaMUkXeRZ1PGW2UiNvrEDM7dvUMM8dQQOhu4+gP07UC5oXL3ZLMPi38bvGxi+IdHMR99s1+e3f/LpKB+ed6EvQkrOmXtijzaNvCABfCFKVGw0j3lPLdZbkLphqvbYtEXkReTkHDnJLuiSoZOg2pMfrOjuF0r3IfbsGenplv5qxXjEJ6RBSp5RpynCvwQv0PQgwyuCnAtyF+SeC00HEEbuvCaPKYyDobuC7jxLs2YHk6DLXmfftAp9n5D9CzBtEpo7ChNXwPhyz+b3fQ+gDD/ynpvTUcO5Khf1mMEoF73Bdj274zPW2zPWr3VI9rItbEHXsbYDYan5ZPatJKtpHxO2mrMKqXfLRyuXnIIu2CamUZB8Tn75s0xvPsHGqHApMMdIVjhXeU9x9O1D3ExX3w4z+EyLZ3URHMCpRluYf75YLM4ERez2sjKpFVCveSIaSHMIxdwsA3UlXAo6Crbu3I9ZI4ws4sorwi7K7mpic7fneFQPXegzq7uJ9a8A/QzYDnbvC+UASZJvgH7i/SejZ+rKyh9VInlJajZodc626KgF7VBBkjIL54pQQwnUnLe5hT3c0Hp0/Lwnny9JwBZvrGn6NI+J2VwLv3L48bIBF/a1NPI0f8YUTuigCysY9qQ2qcXuXWd3i3uyWSEQMqAWIMTqVp0WUW6LaJcqsKNMNpLDge7WJCyVQYq1RNToXyyHxc5eqHj2fuccPwOw26NP34DjO4hdssiiW9w0M6CtxRSbY+a6w/bGsLWxqPLvG7XnW+gDVTtLXjo7ojMq2jOl1KSLWPyCeSKNxQyxDsoDcr5PWt+Dsy1yhsfoDhM6Kdb1dPcTst2j41vY+x+i777E5uRzGJlpmjDJETmkvjn6CuRupnuQya9AeRF0ixdkWse4Hc2rIE5K6qDfCqutYF3HwQrTkwKH5Asaw3phlYXh6DSRlkIxt17Sy7g1YR1qyqEUjieJ7e/8Xmw/Mf7E+2EmEvHeTiwKgme0xObm27uMU2bYKd3LiXwnEBSCFpcrKeZkymDbFPHiBtve09RLLOrip3bK2lqpfBWvRsg2Mx6N/oUX4fEpXBxduOoCTaawk6vs0BuTt/LKWFCts7ClxjFL1JavXnAWCwmaonIkW/kqSDJiuAWCKlqMfCSEjM1KTsMJa7lVuiDqKwvh0K6IuhjjTllthdVpx7AfYIL9+4b+zUw39OhdyPeCVk/ihfsEj2ZJgpz6ln9avNpnCt9f03sWCoraN4rVTR4apeOAAmgF5No9LiNWcGAy1y+KvlVcIKpQN9eVesoW6RNCsZ6zSDhvaWWQGXwNUOvvREKZLurr+HuZQ0mLj49HFCmsstN+4buhBu8Fsm5j20R7Xf+hAcMH40qk1kOyyMMKGskjKvyZklPKXtHDP0tQC+/GxitG251s5eOWslO1Mhr2aIe8+2Xs6VeQ8hAhcmFidi46u9E50rjLeWzm9/WzZuMsALAuvvvk9twL/WZ6VeEvElq4hPkDmHlFzYAoKcL71CyQ4QTlFOwusr6LnZyR763Qc8WKYnTYOJLuZtJLLtjsPYO3JuzRkeHswPrFlyjjASu+MIoI9EK+k+g/k8n3Qc/Fwy+T+UTeC7qPyf+koE+OFC0cu0TeJNb3erbnHXuBaa8hQI3JnBbo6RgmQwbDykRJmdwl8qsga5+cnslbODxIbH7LF5jefYa9fYgFGYu29ptmKGvy+R3yZ88Zt/5dOfh+Jd0qhLp41qeZF6iUBMUkahBlpEBOYEWYjrRqk0agnYigrcaqqNM3dOfk8zuUq8fhc+H6vK9Ui0Ddas8W/D/E8U0wyQy36ttPnPR1wbjUE6JfGknkvg/fj9kok9ebmX8ev6+Ja1JN6bBAivOwKUXOgCUYjfFyYrPNjNk33rF94fDmSFaQ7+qRB8CZh2WKCEWtOQwtSatb5nv3ElmrDjpcEc2dmJCZgdHFI8fruixRZk/osm8/rtuMa1vRxRfNgVjvoTqXK6XUonGY9ykYfd40SyW+kyLu29BQBlpptSgVnjzm3ZVs/C4qcbgC9rQxU1/Ts8M/EL22u27JZqoV1VSqRtr0mssUz78TpG1eTweps7ahCjGffJc893fphxfYl38aeeeLcPh5RHcQ4KTOG/8dc5UBgNgBq47HvEQqf18dCcxzcnkybo7V9facC31p3k2LbMe24GvmiHj8tWAzOpTI2rMcI9iBnSLpDlNa0d0ReNWFtKpgVwJDR3qQ4D7osEKuXkUOK4wV02j0BVZ3zjkei3ujToT+pTXdC4KcxBy/UrQIeQMoTDvzmOqDIjtBDivq4BQxdjYhm4nVC2tsSuhOA40px52xudeTpoIOGhl/6vuEaiK/DHIOpc+UDlQmhu86YfNrP8f+L/60Wxf4YknRlSIdxobuxRMs7jufBLJ/H6ZHSnee6NYWSpOWbCQJiDB9wpkmBt1IRO8ECD4QZaLnpMQA41hOpPNTyvuJxmtKvbk65lUwVwde1SYwT/B4ey2Mroby5hvnWmKq5gUAZpQ6Vwy19jMpkI7mm4xXnit2aXO0qAE+aDy5mpGyi5+qfIa90a+E9Z01h8sCJcEeyruF3GUyvgGKZI9UcRo6eU4XNfvU3Lo0Ii0/+qyWJ1mu95uPXi2Vmn1bj7UbgsH4lObKtXWRhRVJTBAV930s6KNK0Uh9X4g6RuJRNCUsxchi1WIRgQat5lLjvQXJ2cFDfYQwLupErX3SFBs1SbF6eBf9U305wdm38ZLrM8TB/qKiazJYi5fE3uBbVlY+zAQphk1GGQ7o+48oX/1Z7L2fJe+/jtgTHOHHM7Uxq8K9fjYLcavj1wZoRvdV6Uq1XK4N/0e4u2vtuRb6khL0HTqNsdZnp4dPOqG582ISmHl2LZYRYuNu7YENdD3c2ZJf7Uivw+quYNuMZg+JTArlANPDntQ9IJ2tSV2ipI7jFOUVXujgJNHdFfKJuKP+EvRoqI2kux35NDHtwZ6qb5oRZW8lZTRVhIaHNl4ljpeQtwZRg8eZGGGSwvY8sxsnbGexVZwwDUbZQf95YfUASg9jzhSFza94EfnRFfbmFTU90LcUdBJU1ifk11YczyHdddSiTw3bAweYHhllK8jaaSZbgZwYshFiewEsef6BCDMHGw4rEfcdLA1QjMgcVd87QDS401liSYVtFeG3QG2Yg/MX6Cb+k1RN2rqbWf22fm7XfxN/Xmc2/A+xGUFJUcqzCdsfQ2aYk7SWMVFnOwza1pBxuaJBBOTcEO3+StlsE5InbJhAemTq0Efm8QVX+OYvHa5tEGwtpNO0qGdTn22pSYPKCVivlWaw+n20onPUT6222brErnXNx7XqHFyGirtAivtb0HxNoEfiWB0QF+Yu8JMJJUout817VOZieO1m6/j4Wx3dYZ5WaREmWoWjopLn6C0RBwDzQ1CzWlNKSO5QPANbajJe7MtQ+XvEx0d6oDePTDsV9Bz3f9XpWDxizfaGPH4E734Ve+tLyOVbyPEDRK8wfI9qu+aUvQFKxLzGTuMObw5MKDBxBqMmYy3dON9wMHnOhT4iSJ9Rda61ITM8k26uGz5rz7nei2CpkMgtzI9VQs46yqYBCNcF9wTtjOEZ6M485Gq1Jt3vPWNyMIq55Oof9OQHHlc/7IxyAew0HH9G33vGrT2dYA+pdL6ZBaCNG7bKMrhJusdr9pjXk5EkaEqMqnQZNqcr9ldHd6ZK9kQPK4xJkdTT3QPdOBUwvd4jr22wNx8FBeCLw8NXJ9IdkLuCnUI+D5r2GdR9SYmdozTjHPPGsDGRs5eMkB6vKhjBMaY2W52Km8oVqNVIkR5Yu+9FW1LJjYnfdue64bK6RjdUYW/XvwsJboGEq6+nHbJI5oGIwAgT20sP18VX0XRy1DaMcLiKBDiY92CIUE0SKUpGGNqyrw3IvUedlcnQEcZsrE/WHILSsHGCS+9u9jkEC/NmLwPYPWAU0giaLEoVR0hs+JabNqiva87bsAaokz36sCHNa9zBYlEsurvlPrThpVUyDflU96plcn67AYFA+JVqqtUxmy+mroeGEEJzyg3lDi2Spu5LnKIMSZOfcY6Ukie7XctEm5tEXo/k3H6oFv5CgUqFkqMUSCfYicBGSGdCugN25mOVw4QWNZIaZXdAv/Jl7J0fI+/eI+kzjKML/BZyWUPPr6PxVu7qE5sBBYt1Up+77hAon/bTG+05F/r4xiVTzVSbJ7eEeWq16IVC24GGFFl7U+zvfIWkC1IaPYGiCNMlnmlpQrcytDf0MHkWqgrWZ+zEtxhUm5C1kl5KdC94cuq4V8qVwKV5wswEdIYclWl3RJ8ekNKT8tpDMXH0WHeFcqo64sjNFpUEcX+meDG3w4eF0y5zcrJitx98YYwZDgkeCmMXyuQFsK1QHgD3BdLgURLmoYVGQunJL6+xyB1IdwTb1WgWj1jGArUP7pBiMkwn2HbkM3OfRY57twhblYid7mKJVYu6vgRYC5QjZXxGi5hp49zEib9vk98Wcn0pjHQ+rs4DDLES5Q4ia3PBQztwc9HVaIkljKz7CksIJ8O3jZwOPn55RQuFLK64NS4vXaJuU5kkxY5t0EWlVDVlHEHWme5kxXQ1hbZNsPdoHIlwWe1zOAhxqizKPIvGuMwBHT5vai0fFo+zBEAFp5RqbPkS7S903dy3C2UcppNW6yK5P6sKmVSIaqI68/ehdKQ6mxfyd7lpyuxzkJj/AdQq+o8xlhDI9QGr0tGaJRyFD6XufXENGFRV5RNgDj4TRCuFGLX5E+43SAlSImePppo24mslQJKdiSvnDjqDVAzbKdMHj9Avfxl754uwfwPTS4yB2QycwzGv18mo3y/nYv1bgBIKT+djF6FXFbAsiZ9v1J57oW9Jwdw0ktijUMCjGxB8Y/SKvqo2reBuamvLuEDLBXK8Q5pWlHCOkrOHVa53yO6SbIm0WiPbnlKMQobTjnwP8n1ga4z7A8MHFzBu6PstVgql+E5NulemqyewnxBbw0rdS2cSGaAhiGxGylYUJkOSWyWIO5k8ksPY5YnTz2VOXlyxO6pn+iZ/dt2DXgxwnmDdwzRgV5egFa7XVpA+sXllxeEO6AlMWyIfoMyUQeOOfZ7pAJgyPZ3o7nczOKwOxVpdMKz0oH+by8UKnkmZIV0NTJcX0CIq6mi5P0bqhh0WQnyBOq+FXi4m/UwDhfMUQ1QdyVmORK6aa7qIg5YatmhomUh59DnWIFQV+nv3KyTfh7cm/lixOSw8EKKVggr0XcdU1OP0+8Q0+Sb2w3FivemxVUeZzP1VCbesjgUbE+lM2sbd6QDp6GNl0ASoXROaXFvps6yrFmW67vg1o9UlXnLLH2nLL4S6P6uluX9aiYdRZrRfYhVqZGsXnQX/ZDP6r/doTgnVyCIp6glOtcqkLxKagFcFjZ3sov6ShPIwK05lRfym1WdeWJY+vWO+hbCvlJB0XQh+wVaCnXnodX4B8imwFqat0z1SDHkG9nDAvvoe5Us/gb3zM8j+IWYu8K9HGWobtKUta0uh3yida1qYWdDXTteFWojzSZ2IC+vnE9rzLfRR0B2UAza508L3qhVEunhYc7SVE0lrLH8sbJMI4Suo7bHjFWVXyFEx2VLyjUuu9vDB+9ib71IujaJnJDsn57ukkzM46+HMkHzALi8pDx+Tnu5Yr9ZszlYMeY9sV6itGXbA/pKkhU4THE4Y5Q7mGTfUHZ1qNqXWtE/D6QPNLmR6gOK0pK64uiyc3u9Yn7sfgS3YmcId812VVpn+MNH99HtMX/8QphJBJjksZsPkiuPuEbp+FU7FK24qcBc4xrUHR4OGoimROlcmUn3QCwRvxZgGWpaiLNBj5aId8ipJJuTJY7jY+aKsjnn8GK+xM6NzMeWa0bqkJFo5hZgj85t6MueZq5BqHr+6afy8GJ2HGjGbIhFmzj0wU5j2/rtuTXNqlOKvMTKE47bQgl4d0dMTuq5jGopXM+07tEygDg7600Q50pgMM/P6RoMgV+KWnkLagewNO5e2k5avf7sGYq/J5wYIF0j+mhJg/m278ThJKC8fgMg/SULK4uGLVeCLC2pViz0DLLZrBCsRXaM2h4dGNcpWy7+Wfqh5DYRQrNF2i+gVT5Woyqp4oUJ10LdMt2gJdFathACDadFPbv7gZa6T06Qp+kmS54dkSJ1QtsA59A/AHriw970uzOXHB0eGrz+ifPlr8LWvwMVXkfF9tzabEI7OWtIvVrvY5ueucqyNo34M1RNK6yN4vlq9MifUfYP2XAt9k4IdPoBRSaWHmh6dOiT7Dk+OCpOH2xk44lN3KIGjPesw7ZxH3V9RdEN3R5g2iZx28OR97N33SO9eope+YXfRPWWdkPsTuV+Tdgfs6inl6WPKwws4DAwCgxTKYQdFyJstud+yShOpGxj3e6bDipN7v4R09iIjviOX5Fo3qCZbC16CQFA9klOi68CywqZjWiuDGLvHifziGnkhIy8Cdwp2XsgnQtYJ+dG3Ofzf/yb21r451jy3RmJBXTJ+9Wv0n93SvXKPqcedUp9JpHsZ2Rl6OWFHN7clJ9j09Bt3LE6decGvG8L/ms9N3eRv2YkpqIvjDn3zbTgMsTjn3/hUnQLjeMSVg/YFEm0JK4FQl+yMT5a2eC1Qj4f5zgvQyujoS+tNO21oGO6kdX5CUcRyPOgEeoWUE+h6zDpXjkWwcfKCaF1GUk9JwDBSZGR13qFd8gpBWUg5o6MylQlWvWfkKnP2tSWsJKanoXHGhG2EfCnI/ZBNM1hsVMm1JKsFWLQq+Bf+I9ozAa1fmhSaP4+S3iTzfaA7Q/oUez1YG+eWeDXiyWS1bv8kTaeiKUo7eyauhEVgkwTQ8RngYZKlKSIL6tOu3WdFuTFmgfAlxtv9VvFKNS6zWpVGdUSZie9P0HVeL99oFFbKoGuQO27ZpzPBehf26WiMD/eUrz9ifPMNeOPL8PhNGJ4hdvA8D7wond+ShwR79JoF4FjG4QdAXZSxuBaRBot7j2deVNq82a452j/y7dyea6EvAjYcI7zLUb7ReQaueb0dz56LaVAFgomnhFsH0xmSzrC0RtaFdHpB6u7SrXtIE7Z/gj76EHt8STqATCtMV0hek/oetSN6+Qx2l9jhMeXpBewKhHkvBkk9acR2I6PuGPSIcMTsCJOxu3jI6t4d8oMzZLPCsqBSsEmdmzQBQjFZYVLhOHqssiVB+jWcZeTOGRzuksoJm/Mtlg0dRtKHV5QvP2L/V34e+7lL0r7zfII6YdTrgGAKT55SfuLnOX3x+1idn3HcwtEEVp5J3D1YOdtjtLyeyfBNLjQEVFHaRuUsrFIFGcyLZ00uPGRlnEihvPMh4zvvwzi5oGsgf8HDEug6+Nnr9EODpo3OizeLz+Jt297JnPJpi2p0LrcWEpJIrDF3MtMS/5xea1Cy7KA8Q7oTjHUTpPXrRBgTfUdJGSvG4WqgOw2fkBq5F3LqGYeRaRzJ2xV9B9MVfr6UXYEe1evzTCAjrI6gB9/nRtt6D2HeFG4VjDNvTaWBdRHKfK2/bn4UHyQcAWean4be5lh28zlQY+4bgp8qxWON5nFDKkIZR2AUr10VmbjNGqm5N5VTjEzo9iyyuLfYvrR9N4dgLR6mohL30ZAWoZwBgiScwkgN2U1Y5wLeti700znYylxpHYzxzQ8Zf+qnyD//JnJ4iO0/jAH0Imqt9DGVY7dFlFq9Owsr1l8SCqEh+XZoTSKcP6zdMDP4N8Z08dcvWqGf6Cnjqe9ConjCBWN4kBRLPbUoFRDxtBG6ZwmzNf16TX8G6e4l1j1kPL7D9Ejpzz+HbA7o1SN4+iFyuYfjCakkSD1p3SOrQpE96XiBjc8olxewHz0kUZ3OiCtTBaCllVsXU0+ZeigjNijH3Qfw4bu+204N86i13aVvn4mlyDZNYXlamG0FzT263tCdb9mdd3BSsGmkPN3B4wJ7kLGLEL8QumlFSl4RVJJgokxvf8jTv3TJKb+c9X/6JXQjjBZzr8LIyJBs5XutDQq1FruHyroJLZMrBh1wqgJgnej6Ad57n+MXfxIurkiB8udSCdEWi7LWcnFhXfu3onubf2CL97aY7sJMNUX4bkV9NaPbGi8Qfo8Q+s1p2K6rUK6wIZO6u0g6naNPFs7gBpazF1XX3Z7hYmL90j1KTpRjoVsL3UlPUUO62CN5H0IcCStIPCykGHpl6ONMumfI2q2WJVNBLRlh0qJZIyl90a03BUS0Gx+ncGRSa8plfHe1LgRtql0k2GStaBpDcuRehf1gbZOW6sP0ImQpaCBpcftLK7EGaYhIVK5dmDAhuJ2xqah3IeiV68jXgMjQ9xp7izkjeC5FxN6b+bklJ1+Oa0gnIFtxJu9o6H5A3n6I/czPwBs/R7p6h2R7VA9Yjb2nUstKaqbvxyNyIwCZXI84q7kQNSHR2j3fEPDfiLT/Bu25FvqWtrD9z0CZoirvBHYgyRFhICVDsmL5CLmgqM/eLpNywhix1fuoCNNwRA9XlEtBdyuG4zndZxKqTygXj+Bq8rLAdu58eTdR8gS2x8YrOFwi4+C0hxICIm600TQR550SZBe2UiLrV0avOTMOeGnnmJSSQA4+0IL/Puq+yxIlBOyWJOjjHmTlKDZlpxusi2vH4gm+MnWV7jBI6iB4Unhv5Pjv/hx3X7xL+cyKdMe7t0z4wj0ECq41VWCOyBBc9xKx6uARFRMeySFG2hh5dSB/+A77H/0J7P2HeMRLtT4CgX9k0BeTuj3/0uStCwSovK0fHDzwUpUUkmav9R5mtVks0vY7jaSrKSie2CUMQeggrTx6abjC+gtSd0bRjJRE0jWoUIqRxTNCS+pd6Y0CgzC8f8XmtXPyiTAMR1K/pj9NPsfWePG6dfTtPp6pePVJSmGgsN5m8gYPFewIaytMsYhxb90UrEYLdKtBUVr7i3lOVWFSyyNniyJvvrczUezNjNiq0SkaO5hHHR1DiNe6OqN6UbhRIjkr+ThXK6Du06tCTdJqlFWMawtEqjSHVHjuCVRagVYyUsoesojXTJqZD0cw1ihfB1p1ytRInblblJQNXSlsM+msI62gqFGejchbj9GvfIn8tZ+C47uoXlJ9QdTKtljQO7OjpSH16OuEXJ/fZg5ewxKtdX9iJschs/UwL4KlZZMW6yMspWvff7Q930J/27P9bb8WnhT0COU4IheKXU3YYY/u9th0hOkyQqQuQfdYHoLLLZRxh44TdjFhWpDjGjkOlIdX5PNESldw+Qx2BR07xI6k1eSWgg4gR2S6QIenUQUwyvqqxoTDyynXMCEyRkIjHV9yJlkCW3u9nLLHygH0gEeejAEISjgdA6U2vg/8n1xZaixnhFNIK4+KqTQFgmhC8pq2YXT4QWYa0JyvLkJ59xFXP/Jl0ur7SC91rFbAiTCOHWxwZy3hXy0gg3j5WGpJAC8rnUroY1PoIK+VVb6kvPM1Dl/8CrzziGZK1JK3lcIhnq/N02bDcm2y18UulROty2qGtY3qX9AVHl5Yr1OdZgug2/5p3luWi0tS7x9Nl+jxIak/R9KaOakIr4CZoKtIVQRWa1fMohyvJtanHZvzDcfBMxVyL15Q7Y6QVoLsogTzMRZwUCT64Uh5cw0vJOyUcCbivqEm4OKWUxWQRNgqtFCq+l0zp6A5a8Uc3UcoovSukKz3z6UINgVFMlaET1A57n9o1E517Aav745cCYFPE/htPjbWro6zD2Qdy2ttEbKdYnOSshSRtThepQabNViFZ8yJJVbwBefAYCXIqZDvQrc1pj2Uhwf4uZ+Ht78Eh/excoVH5njpjjpXJAJIZDl/EvP3bVKrO6vNAuiF5dnu5+Oib24g/Y/8fyPc+dMD/p9zoQ8cTjvSpvP9KG3t/JpGlGFFlvtCujhSHl8yPnmIDe9Q7AJhB+rQSKzDyhYtp9CtSN0lWo500550HNGxQBkgTSQrju6mEbELZHziSTojjsKuxQ4vQFSt4ieJJD2eqp+pTqnECnJCJ/HEn0i1tJp4FpmfVsmPQBFUKqTW+TAFOdBqwueoSgkYORxoPpkNPE67xVcLLs0TMgqHL36JzXnP6vs/x1UHrIW86jw/VgXNMAU7kkaQnTEdHe3VSCSdBJMJ2Qys8kS/u2D4mZ9j+OmvwcOjI8JrBb5icbYWCqv+WdOAFuinmr9LkVyhnSze1yUmoSjmRAFZLPzZqeYTTRa8qlS9sNQgoAMMj2E4J61OMds6X61x5ybu6nDYh5A9xyR7SO7+wz3dNrM5WzNMRHSR0J0kdAucQneyxp7C8Ehd+BeBA5T3lPwowT3otkLJnhdRz+HPYLT9ZSUt5SM1qakpgXi2WlfMeXJ8W8SF8K/6tAnnGiEzMdNKKn7dyvFX5F+khZa7lb5QApFfcE2/VoqrZtM2a2++3zo+NZHJQulJvEzVK7M25T1PL1nWyInrmdTnTXCSkDuJ/j6kM7AB9NEO3nwXef8rsH8rEP40C9WYJ5XWqWsQZqDRhL0vRAd3TNzcD3fxkIv3daAWyrrNyXps3SyoXP/Zp7TnWuhTDLtU3wuh1g6JJojLgtiyL93pya+dsR1eZnr2ecrjJ+ijL8P+bV/gpWDTBlndYXWvg/M3GA5XMF1hx9HRZ9RIFS0wZSQpSXbo4Qo7HrzEsfpqSIvOd47OhYriE0zSBJIxVjFDU1A5GXIPqaOWfqWGK16HPgi5+SQXLlOv9ItvXi7W++cpIgVqyBgGyRGMiCujuui1oiUS6dGR4w//R6wu9tz9ZZ/nshNGEqOugbSIggpwW7ezmwp0hbRyGjvZFXJ4iDz+gP3PfY3ytYdwgQuHVve9TvDFBF0IrVjS5FYj0SWT1eStBs+5/jdcRzeN4gmTP347V+asiHBRkyVpO6fhER3NWa2K2QRlj+4fk1cPyOsHFEKhx2M0NaahqCoqVyNPStoL43Sk9EaX1kgH2os75Ddgp0J6ycgPBX1XsSeRdHgF8s4EL2ev+VJ59xQ3LzYjj7q5enuu+ZA5KW3+fZ2S1OS66ryVOiclBL1dczi2LSmjXEEYrS7cS2obiTiYiVfbxjKQd3XUN9+IeO4CgufmxMRbCv6asQxRy2dhodWU5YU/oEXrtnxib8XimU8ScpKwu0J3D/qzsNzevoKvvgNf+xK6ewP0GTCRaoSRWRv7irSlxuSHgpISa1scZNQNd6xuj1enq9TzcO1zCcrQYk5WFidF6YglgPEKHFP77NPa8y30gfYAImGiVq1tbYGC09pTxOuzPiW/cMr68IDp/TeY3v5J7PIDpIPt2Ug6eZf94QIb1GvdjFHbxxyVlYg7zl1ByoFpOMI4Rs68tnrvTZgQ2LIKyLp7lhkiKYpwxeBVElw8Ukci9EOa1IiJUsHBwgx1lF+jcjyev/qAsEUcTM0FMMWzKAnBEOgmzqclSgdc7Xn2Iz9J9+YHnH7/97J96QWO2RgHRcfYsNpCkCGkZNAP9Jsjedqh7z9mevMNpnffhcfP4GqEMXuYbU1xv+loW75pssQdzVqXey3uo2lGgLI8yYyArgdxhIBaIqIm7JeKp/7tMfqpVm4lcjzIaOo8skQBG2G4ouwek05fJcWuVteGCRc+Pg5ezCvLSC5XTPuRMhY43WL9PaZuRToxUs1yXhl6At19gVcz00PDnhh6LBzHCS470t2150xkC4dKfcYqRBeoMM231NZQbSH03S1kznEHpz/DaBZRQjGnOhwZTyFNa8nl5cYgMZYCc3KW3XgpNMdl67e4fzNaNvWyfET4wOr6bwpcWUSrxRmjzLaftgpfaeeTLpFPe7gnyCnIuZA2ho7G+N5Tys9+FXvr6/D0HbfyyMHZUxdc3Lj73ubp3ZADdVvGRT1r5sxaX9H+JPn62CyaEZaYVR3rcqcWj25JX1GORm7Mxo9rz7fQT+KhihbiJvqw7cVZEZ1JSxwRA1VjGo1ptSKffIHt/XsMX/lx9OlXOE7PsIcHdJygCJP4Rhup1QMumApJMn0uTOMeOw5OI1nyWGK18P7HtmY3FauJwycDSwXoXLtHzFuShHU9Ns4Uj4grhIp3MY9emjd9mFG+BG3kMDuKRTVO4vqEbKhENNCBn98t6FBMkyFXI9NX3uXZu49Zv/YSq+/5DKd3zyl9YsyKltGvbwblgOyeoj//kMNbj/j/U/dnsbZkaX4f9vvWiog9nOmOeW9OlVnz1G12dTdbpAmT1EDYkmXzRZYEG4YkC+CLLQgwDEvykx9sQH6yCRiQQVgwJMMAZetFEmAZAi20bVoiTTZ7YHdVV9eYc+bNO5xx7x0Ra63PD99aK2LvczOLZItAMqpunnP2EMMavvH//T99coNejRbfTUBsqO0tpSjqKnkolApSTdLJAK3vyxxJk5+wEFGVxV8tRN3fNBVbqNmKmlmoe+NDHWvSSAp9xvGXqufSJKCZWaUDDKaIjG5BqiFZlH9p10lKaIyoXjFsP8gMpKfQnCC9Jzwf4cbhloJbWtFR8Fic/6HiX22QsSFuANcSF2bMesG6aeW+ytU6KL8XNItiIab5UNWogGZ0V95nUpRI/l7pqxtnv6szRM8q0xaUXvdB7aa82OfcwT2oTbDELKDz3xR5WNZqhVzrdJ9iQq8YWOrIiflyXjVOqpjMQ08xN/yZczxpfkYHrkF9ixw5/B2DKcfWPpNeDIQnT0k//RE8fRe2zyD2oFPrzamYTGuR1V7BVF2r+eEyNLhMzFQ8mpjb95MBUgxHmyzT4XbhYuhOCKYyCBFjLCjm0ucfX3ChD24lEyY+V/1JqUgETEhortIzWes6QVa5leFWGN0d3Ld/hfTTgfjkBzDsjPYgCgZTKILV0Bskh28dfjkwbPss8GVmhcQsN9xskvPyyvBRc4V9LQaKyTSWKDjvcM7nlp55wQFVndtjVYyvYqEhwedQd65RcDlWT459S7EwYL4Oy3UrBFKEQmehOaykKeE0whAYr7YM732ALBxy2uHWS0RGUhxJY0/qt3C1Q6/CZNGXMA5txsJPtRNGWlgs7lncXa2qenpOW/Q2BEUJ54dIcbJq6/QL4jzzxh+Vh79UWtaBkGnzVa9l2iLKDuKWJm2s0E+w+g9vCB6TjjaXXpZ43xEKjDBTbChkHpqYBQwwjqTrF+jNBvGntPdfZXQdKTgYFL2JRFGSA3/c4O443B3DiKdjYG1FQm3namczc/KEwU1DknLitz5bzg/RmhB2mR21KoAKvRKSm5LjKEa8F8goofxPzBDao9j2edYysocxGeSYvE9KWCfz7VR6+3kiNwvurMkp9AvVq8sKTbyfKS2ZwqEx5QrpBGmwXFxWHKaQs3AWj3oHvkXWLc1Zg64gZFpnXtwg775Hev8nyM0nEM8hbSGzY5ZK32JN2zKbamFsqe3nEjQL5PqgewZ4WcRlHRYrXSnd4IohU1p6qgZEXFE5+TSWJyCv2VuXecnxxRb6Ctqrdd+Jau3igtSOTlkXzizcGWzZG+ysaxy67AjuLotv/AbRRcZ3v48rcTWdI34tIaNJkE6I7dYsXLVwjk20uVMmqNKeN810G5SJ1GKhlu8lZsiag4fdP0H1DlSNFMqLZiFnFmgxAoqhR/lZhdp0PlsmswRpxj1ItazsIYwzR5HtiG4C8fzKchRxIBX3VjskLpCYa9PJccrcR5bMkeRSA2lJcq1hrxUMi7iZLBapLF3sVyPOn+FwfGdjNGuKXkvZ97TegYlbeYrn418sr4CmEcWK4oIo4lvELbKVZYrHeY93zhQRfpaKUUskpmQKOffclVHR6Fmf3WNxesTlNpJGRUOsOFkVJVw5+NSTFg5dOlg63ImDowCLgBCQtcBRh7/f0B17khd0iYVmBiZkTHn+FMEb5YDmmL01h9KsP9VCgIna31WrMFWLz2eDRyY5ZN3UOtBoYU0dwSDEOZQZZ8M8j73l352rstnComX6hWrMmALP0ObZjFkVdc45pFzSHKNVXOdeB0VjqILLsSz1DrfyNKcNsrbpSWNCNi9I776DfvxT/O6JCfu0Q3WsAl8JTGidorHyns7rqtpTe+vqcJ0Vw64kG+bu11yQfNZR5ErM3kTRzCVncShXbh9fbKEfQc6ZIF9xxkapOZSQN3sqmG91FpUVJXpnRTAN4FrG1T3ar3+PcP0h+umnGXlRIQyYc27whbRMJL1Ag8E3hVK5l8MPZV1BFbTCtDiLe2eKIjNMZcGfNEEKljzUAGpRur3pKm52hm9aAjYvGtdaklahQBgtf1D21Gzh3FpDxaLTyZIoi1i8WW2iFPZBC6UFUhggDNRFKh1WvmgXFV2CHqHNMSyPkHaBOg90OGmrENQwIv0W7S9J8QLRc1Q2VTVN9yiTVSfzgS5zVp5z7iJTN+Ce4Ncyb3WyZu/lL2bLcb+LoDN4pmup7QBFERlxaYdPkNLCvIE8ZbUFpCYqTYJbgduyubxg4xbI6WkufAvQ92ap1oI9Jd2IjZeD1CTQa/r+HIatnbddIV+6R/ONu+jXV8YCuXAkpzUG73JIz2ST3YdLWeg3gjb7CB+NWJ3LOFs4VWbldVKI0ij501yclzH9BF/1DKHkkmCChpLXVkILHUKdapsLQxcXCo3ZZ5yr4RRLhkYbv2A/JYy2p4o3VyDB4owlddHh1is4aUlHgk/AZot78Qx9//tw/gGuv8DpBiWYx5C9BpGc5ykGHAWuPSmB+TarTm3Jc0zv2L88EZrXtpb9WC1ZxVytybMthokWL6rwC1F4eiaP4RcdX3ihr1e2kDUkCjufYZMt9lqaFmv1BjMcLCtTbfNC78A1DSwe0L3+mP7Fp7gRatk3HpEVygl0C2S5RXcbS/IiNb6r5I1cE1aUm7JrZwscyn1qzjdME2IuqFW0qPR5nbq9hWNHttqKuzcTRsU0Ms9Ppk3DtFbqWebhj/miyLFT0cnqE5XpUzkvYeX8DRp7CmRN3AroSNqAu48c3aV5fBcendHcWyPiGbIBUuF5WEtiNybY9MSra8KnT61p9PAxlchlTruc7/oz8ly3P1cNsdl4V+9H6rBOm3Gy3FQjkonXbEg8zi+IfgElPCQBpEd0i4uZjqM9mnkpcbYprdekNEvULyzWnEY7VVQYMpW35DVri8POEwKiCecS6eYSbi5zfFnNck9KvN7BubD49oL0UEiNEDGDpPbqURPOlozPS8qJJXAbUyxaKnDJAIlZ3nFSiBnVUpK6JWQTMRy/s3NoizHLBrXQUmmsXsdPICVSxevLzPOd8lvll8KUKTXEibVQTQVWHZA4IMEsXhWdaiUAnOCWHc16hTvtSCd2j3K1I338DvG9P0Su3sHFa0RHUg3x5joMQAo0KTcnTnNhXwVyVY0UaGbdkDOPM1f25Dy1m5RTpmWwQs+5QXK48KsQYJ4Tk6wAqkP1Obvkiy30s5tpbdVSDrlnt678RMztkpwBL0gyxBahYlA0MUs5dC3tnWNrEEL5voJ6RFeIO4Jli3PnyNgjcbQ4pcyskGw1ai7n1xKvR3KiRvJOYjIs60SmLFgCKQ2WeEpKbV9XCKZqWx6xvACe2iC6bI6SEC2bw/7ISWnr32nDOC0BqRb04X1NAtH0pS3GqpDEk4oS0CWke6i8SffoLstvPCK9uiasHOMAw06REpYriIxoMdlRsfFcrvBHK5avPkAv32T42TuE5+9A+ohcmsq0dNNsUcwd/fL37KfAxKRZF9LsMzI9697bJsA1ggsR6aLBYV0HzRG4BaQduC0xXTIO54w7b+PSrY3qWlOuSh0t/lHzCg7owAVwjXHua7ZSk+KdZJCSxceLl+hQZNyiw5bSM0LUwhSSPOlakJ/CcJGQNxztXUVec8QVxMbZmsiCVfMw6pgoNMuaWmuMU6INjX2uVCRTeJByBbCQ4/chkydlaKbRmztz/hTzzFtgKZY3mBGzVQWQ6sDn5VyEWRFg9r6UXhTZwIkpmdcZdzCGLB+s8NJJzLq3oF0c0nrc0ZL2rIO1eTP67Jrxg58QP/4+3HyMD0aFrCWBUWCgdZnkeH69v3zveVDnhlSN/8+g1/MNVxTa1FBG99dqtU304AXd+0gZOLn12i8+/thCX6yt0N8GPlDVf1ZEvgz8VeA+8FvA/1BVBxFZAP8+8GvAM+BfUNWff+7JndCsPJKUFDyxT2Ygx8wXEDTHu9XcRpf5yb0YFW2BoHUyIWPaS9JiB01Cfaw83i4tEL0LqxWy3OD0Ch16NI05nzigrsmTlUzLijUQqRC9IuMAC3jaySVrcbPDIk4Hs5rTyCywaeNZQxPZg8FlpA7GLEoCF7Oxmqe6Wollw2RloJLj/+ZG1oIlhSnuPxOArkDPiuJoIa0gtSQag+p5gW6NnNxl/Uuv0n51zc2xMEbQrWYrUC3UOJBx2zLR6GSPSEVIThi90CyOab/xbdond9i+C+w+ASlln+bG3vKSKUGAWdw/j4nMCq/01sabOiahnWVGdQEswR2hLCw6mvMc4huc74jOYY0DelL8FB1OIB4j/RmyjqjPQpaQ0xxpSmKW2ozo8NLQOKHfbqHfYCElV5WxZP5/EDRFUt9bkWAOIahrcN0SxKPRI9uW9L7ChwNxmfCvOfw3G+Q1j64atLEakiqjMAudnXX1ckGQ0lq4JNwbrJuUOBPYDjN0S9jYOZtXJa/xLAZz83JbyoJrpQr8tCMne2Om6sAMm1KlPVuGWrwmxeCKYgrIvIrB8iCjFU8SLawjOZ+iBULqvbFoLjrkeGFUyZrgk0+IP/990sV7SP8xEjek3K9Ds7Au1bXVoCyh2lu0yfOq3LLO4sHfcutvEZ9hnjp7byrossiNTl+vtCOz02RFMQ8slQ5vv+j4r8LS/9eBHwCn+e//DfC/VdW/KiL/B+BfBf6d/POFqn5NRP7F/Ll/4fNOLALNihz/hNh6xp1VidqzRmQAGoOSqReahcctHLSCawE3UX5Iqzh/Qbw5zxvdo9pC6kjpHnRHyHFAlk8I48foMOS4Hmgy5SJT4NxodUtYhBxjr/SRMcftbYKl9hAMqA6k1FsTlz0XzZ5JSdmKb0GiLRBRlAapreDKF0oM2Qas2kp148yEuyYTcqmxCmXx0+su5MQxII6UVgin6PIe8uA+7aMz2tcWuFNrOhOXjnAi9J2hp1qBtBbkzCPXkC6VeKFWYLSVWd1MtmxcQShkveAdq0evse4825//Nrr5CONxDrf30MyRJhPU2Qt7Wnc2pvZbUQOiDapHkB4g3SlueYJ0a8QJ0QuqDRKV5A26iV9ZXD+fVscL4u5TfAOSrtF0D6WdKe98H6U7k/NGyzCOuEVHDD1sL2EccggjN3oRjGzNdYg05jmEEZKtAUvAeqRtLNSSMEE3Zq/3OhDOe3ivxz3qaN9a0by5gjPHuLCGa6p+UkYhc+IPUpGpzpchFpujRnL6LOeMRCrE04AAja3B0vSnyUWIHouEjVjXtIWa8O/FhP+uhLGyEiqY9pmQNOSX3ZBGq6mpye8QLcdU+G+0eO45DCSN5ZXWK7TzhDCin35MfO/78OyHuHAJusFyagqEHMYpsfpsQFXI0eSJTEekAiQqGGKy3M3z39vcVEWR90FSrYnqydOxNVwZOg9PUXe9GXPz/TAP5X7W8ccS+iLyBvDfBv7XwP9U7Ir/BPDfzx/594D/JSb0/2L+HeA/BP73IiKqt0ayHqow9DmUMRqW3rcOmg4Wnibc4IZrIBFwpJjw7RFNu0Z9C+oII4xDQI6Fxdkl8eYdho+ew+BROUbcHdQfQ7OEoxFZf4KTK9LVM9JmY+GXbGnW+gAmgVpQPAhWDp6tHK3CO6FupAZANdpCTfZ7tShq+0dbZBZfj3kcpsk3nVNCGW4aqD0Hz3IP9n/Nim2JplMId4FTtFnnNWMxMNUbCNbgRGng5IT266/Qffcu8XHHsLDQTC1kVSwnErOt0Zpc1LWgZyCvQrsV4nMhfaTwHMOpR4FoncRIKce0BY2OXh3Lu4859n+C6x9eo8MlEwykCPaDR51vCrX/KNTwwRS1Usxa6NB0B9e9RXP3FZrjJeojQxpJBYnCSNRg4yAOaY+huQ/Dtd1PjIzXT2iPGlK/hvjIxjhXflsJudVEiBilcnDRJKp31n9hGMxStdiFzaETrPG30nSemJw1+8aEs1NwvqXxC2vJjMX2NRl6hXGA6y08e0b6yTn9byeGV0/p3rpH96V7tK+fEM4aUiOE3AycbEMoGAa+KXIkw4uR+jdeKQXgiOXN1GXoc7K+wlYzY5+pXH1ODeK5wBTAzudegymTs8lUzTujWzbvxyziVBrXpOzlp2zlE8j+MDErW1UH3uOXS7TrkBSIF5+S3vl99MVPkPEZqj0QES3d0lJOP2RI5lzSTlYVpv5m8EpmFfAKh31Pzfaa5agUCgWIZjCFllqd/QuWD8+Wfn495/AEbkUqDzbHS48/rqX/vwP+58BJ/vs+cK5asH28D7yef38deA9AVYOIXOTPP52fUET+EvCXAFh/ibgZ4GaAneL8Ane8NJxwG0jhkrB5gm4Ga8oQhZ0/hu4M2jvIeg3HglsL3b0LmvAHDD//Q/jk2vDlTmhXHdJ6or9E2wHRHVxt0a3x6xvODWqyIFvRc8a/yQg1K8GwwTZhLsePQsqCPlkHJYk65QIyNA1ANJGyoFOXcxWofVdGs9TcCqSrxkflFalWcPEeBKWD+BB4FX/8Bs2DO3BngR5bjkAyd0oKCR0jcdjBmdJ9b03zemuh2AyMYMQKcgoZ2JQ9t2T5ElgrcmSQ17QEOYHmvqDvJ8JHAa4FN7b53o2oruRpYp/YJOHo6DHLx99k+/7HuEAddz2Ibdo2CFnhkg2y/JmyGaTs2Zzg0we4o29x/PgVgk8Mw4Y4DDk0k5WRBItdF6z0+hQJ30DHFra/A/EGJBL0U5rmBAmXEIUxRFuHyaCLRu0ghh5xS3zncAq663MYLN+XA5HRcgoa0TTiWg9NQ2pbGIzvKdHRdcckmspBVZpypzAgcYfGGxiuke1T9PkT+DAwfH9JuP8K/o3XcF+9j//yI+TBGjnyVl5BnsOk6Fhi14acqYixkpsRU07ipUTeLH0VJRdnsR+aKNFKr9Dm8E8HLBpYmZdBn2CXfx/EcgiYpWsKLWVoa4Iw4OJgZIgpoBpJRLtPASET5DUe6RY4gXj+gvTRH8GLH+NCtj4yI6aoIf+K4M4mGPOwSQ2l5Opazda8zKtsK3pwZneXoMDBUVSC1Fh+OvjEPpLvMEBk6t5COVLZ4wo8/Pb1Do9/YKEvIv8s8ERVf0tE/vw/6HkOD1X9K8BfAZCHv660jbmjPaRoHer9WlAf4GYk9SNc536w0gIK/QhtQJtAt050d5/gLr/P5kd/SPzwEvrGKvMkoFyAewE6kDYB4ojGYPTDqWSCs3Cr1aWY1TOvrhOyYMmxOR1tYakzqyRZxyhJMTdlLtOYl0hOFMkMgjmfeSlWjIDKaO4rs0KY8qPqD3M3JT1AVt9k+e23aN88MvrzwYwljVmZpIj4CPda2tdPaV6BsTU0YYmwMKiF2EuDlCjT2OQkJCPIINArcoTxkjeC3gU6R7NqCD8LpOfJ2EAduNbyDmmMECwmuxFh/egruGe/jV6e43Kv20mCp/nAZPjchDyy0ANlZ0G2zSQd4xZvc/TGl+jZ0PdXVl2rmZq6Zuubeh4Vgdbjz+7jvad//1Pof2QKmGsLQz1V4uUaWT9G/AOzSmfutyHJPE3bMg4bKqfNtOrNw0pbdNghzYrgFb+4Y0pfHajDdWukWTKGmMNjKTcmH5E4ztbZFtVrCC8g9sgOuPiY8LM/Qv/2MbxyH/fGI5qvvE73xkPklRPSScOYc7bFizWZNhf6UCidVf0EFskACiCvXTJhm81XbQmpAo3lxGUlxmUVIO68UTVvQXcJtuTq7rw+Q7byQ0RiRDVDKjWjoargJTex9/hugWuEtH1B+OgH8OxHEJ5D2iCzDvPVSq8Y7IN5KesopfodVz9fZBYH3ymqI8uMl0nw+b4ur9dzzT0H9g/JZ56tn/1T/sO19P8M8N8VkX8GI+I9Bf4ycEdEmmztvwF8kD//AfAm8L6INFhn1mefdwEh0Z1FQrcgXgrsBLdW/MmAjpek4RKG0TZEas3FzoVBitIsN3TtewwffJ/0o5+hT2+QUDSkCeYYrq2wg0Atdsix2NJ8HYpLlrPyChZHtLusk6xgMWhDNNjCbHJSL3BI/VqLDmfwQZ0rhFx4NBXFlO+bhVJi/bV4ZuaKiioa78DqK5z+xldIbyzZbmC8Ae2V2qjEKcgI68j6W0v0PvRBSFuFDbmnKbn9oloTmCaPS7mdSPkP2nsYHLqxHLAcKS57W+51R7pxpJuEbp2lEgSLJauYAEuJNDjGdcfi7AH9+Y+zBVMazmR6h7ntUyoWBUR9/d2mxWKopoqPWNx7zCCRvt8Znt0v8W6FtdwsxFWO0savJJ4TQnN0Svf4TzB88ATCM4gjYfMMds+gEeT+t/CrMws2KJkcTIrsJ6VESpGcDcUC39l6jAPa30AMeGlJ2xs0LXDNmigdOMV3S0LK1B+N5YpSHCEOSApICib0Y29WcIqo9lghk1g2NVzD9gnxg58T/+4x3H8D9+ZXcW8/wr92j+5+Q1gr44QknARXRc3l8c80FHUqFFAzRSDLpQJiK2i2stQ78wwlWt5OV2JCf+tIraI3WNw/JQuDhXzdlPddqZmhrD3IaAfccok/WiMykp7+FHn6B2j/FEmbbMXkEE0Os0zJ2LnQn0nbMhBSBL/Ocgg627f5ActerWuIzz4OBfvLcgflz3m9ShH+t45Db/j28Q8s9FX13wL+LbsX+fPA/0xV/wci8n8D/jkMwfMvAf9R/sp/nP/+L/P7//nnxfMB9GbD+P3v07z+mMWb96BpIO6Q8ILh6afE55cmmGI7WWs01r2qhW71EcMHv8X4sw/wz3ok5nCMWBzO+WZyqQvCRkv9ua8b394z3LRtJLPM0GSfaTyCxwpJYobKeciKRCqPvJVKJ7VYv0Oma1Sq4SxFVbOVZ823RacGJLW0QKhID3PHy4KMGFHL6yy+/mXCoyWbF0q6Nmu8GqGtR5agdyPH310jd4TNDtJWka3gBiOgSmB4584QGW7G0KhZWMfB5RZ6Yh7BFtiB3kDcKHIGfg3ytqe/DujHAYbG+sBn5WedlRIEYeyFozuPGX4W0NSbZpAOaHII3JAywpityQw/AaxrWvbKCm11EmSxpj1asYnbrFBbXNvinCPESQgba+FoCd/itUcYRTh+8Jhw+Trp/IXFlOOIc8k8n/OPkPghsnyESkYRiI2dYnBDw2gbYVZyAr5DwkDajFaM6L2FhwZrAtSsWnR5hMqC2LbmRWQSPy1Ffpqt/Djg0haNW3TcmALIRobxtWTcZMDGdLiBK4c+O0PfWTI8EJqHaxaPlrj7QrrroINxVagxtGx+UHDRVxlVctgaZVIWCSp1yeyQ0ocALLyYQ0Sm2wSiEEtF8BhzmEwxgsHGBLZ3IB2SWjRdYYNn8Fq/PMI1iXT5KenFB+hwAfEadEuO/FNoQhxZsRQmV+Yh2xK/yiiEUphFGYuY91uq36C+x2xP75/VHClFPktA73kHrn4/BxP2rjKpgXlI6GXKYDr+YeD0/w3gr4rI/wr4beDfza//u8D/WUR+DDwH/sVfeKaopHdfMDy5JDw6wt9bgdsRn1+Rnkdk4/CpBVqUJbBEZQXLJe29EZfeY3z/I+R8MJy4sTWZMKVDtUXF5zJwsYnXgMgGEas+VUbUskzZSiuaONbFT7S4oMNDirgU0Ey7axu/7ILs+hZ8P1BDJJQfxaogLzaDtVkOuVQ7NZACEzxzSi3ZKRW0QboHLB+ccH2jpKsIG/MKZOHwCwcLSEvo3lwQ7wn9BuJVQnbOOiFlpla3EPwCaK2Uv6D1hAw2SYJbuQrMYYB0A+ka6yfcQ9gqeuZZHAurtzybTQ8XNhcKuEYQb03tCQltBPEm4FO15MpGLcq1dF+3saqFcbnQzQzPLPy1weVm2Sna3InLYNqctG2aDrwSgnl1mqulRRyu6Uhhx6AJv1iQUkZegSn5IOjmGuRjXHOMLu7VCu4yv7FwvQNOBNTh3YpmdcrQ9+juAmUk0qJ463+jHr9YEmNvVn3CFLBgTdaD1XxIHM3az4oohT7ngWYGot0s4JHYoO4Y8fdw7TGEDr10jNuB8eNgCNazhub+kvZVT7oDuhZ8pp2QQZExkfoR3UUSzpa5bw0fr0LN7Ck1uQuaK9JBQsb5x0x9EgUthG2dpxRHsWhtJ/nWvNsxkDaD9aTYjLBV0AHaFX59QrtoiZfPGJ58H736McRnmBUSqghNe4K1JB5KiIeZ3Kxm9uzFmYVflGp9Z+aB7h23M1LT8ZJ35LPel3oHew5CnuT5HX7W8V+J0FfV3wR+M//+U+A3XvKZHfDf+/s5r6yWcPcMvbgmvXuNfnhtCSEVXFwg0fhdkqxRd4zKElktWL6xpV3/hP6jn8L5DvqGFJeIHiHpGHSNcoy6I7Q7gmYBkuEnEtB0DekpEq9APwV9gXCdM/7Z4sfZBiq845kSuBJXFaucauzlSunZ+zpZFwdPXr+fW1TlcxWunz671vm+xfDq1dUGYIk/uscojngV8sYQXOvx3j4XR+AU2jtibABXwI2zGHBS1IFfCixBfHaCKwxZye1uLVDhxTouZbfdr8AvlHDuLE57AzEmevUs7zvary8ZfxhhpzmZXAycPBYpovSkws2jeWwlInicJlJGSBWrS2uz9ll18ywJLC4i2lPCAUpOFKKGYhIxuCE5xJet6jqbqqQwGhXyrMTelHeCdEPancOwwS3vkUSqotFi8eYQBbqj6xqadcQ3Du8fsrtak6Lx/uAU10REIs4rMY0ZouiRJteARDNSJjTLDg1bSMHCZVVAzAWGA1mAPILFK7j1V9DuAcmvpkYnY0JuhHQeGT7p4QOPOxPkGGhHvO5IVxvC5ZZ0cw2X15kEUZDlCbJc49ojou/Q4xVytEIXAqtcwOXzXUW1aMugMBoO3xqkO/MouxY9bSt6tCJzhw65bAnbHXK0gJ1HxmhEhgvHuHtKePYTuPo5hKdM0MxUx2Eu03VWycp8++5ty0mYy/zvveKq+Wu3hXON14utnzkqb4J7zm+izF6uC8r2fqFvoNQo/X0eX+iKXFm0rH7l2+x+9gHx/adm1IXMx0GDpCUa19ZLd72guwfdvWui+yM2H/2I+MElcr2G4X6G1T1Cu1eQOyv8Kwvc4w6529Ace7N6G8H7RAoJt4lwkwjPb4hPnhA//QCuPobwCeg5IhuqjK3IhtLlfu4S5sVWg99QuUP2JmyyJGQKzmMCbzSnsuQY4gDO6FRxHUI7UTWIg+RQWvzJmnHEoJKjIJ1ZzmHINrOL+Ncc2nj0WuFKcddmoUkDrssLd4Q4WrVqbeVbIlzZiouNyRJWGPVFp8gpeCeE52LojF6JV4ld51i8KugGws8S2vvMG5XHCaH1A/HmCUkHjBtdqoKpYawaQyhuuFIgm3Vktc2enaBpY+6HNnk+cuBaFfU+J+YLZlFNmJaCvzoXyZR/7e+bqNXgyeY8xREZe7N6DwpwAAsJxaeIewKxQ5sjFutj/LJhSAuCetARzzUaR8Y+kWLmYlHJhT0Z8pvGHMPv0XhDCtc4jTi3QkOD0ud7zOErt4b2MXRfQ9aP0OV9tMksouqyQ5rzJurMO9yMpA8DpJ7IJTK8QC+ewO7Kwi+J3GO3heYauhPi4i6cHMOpovcc3PHQNmhbEtPgVdFdQG4CbrDFpAih69DWqoV9a/MqfYDdwDiOJMlFkkeebu2JvcDNFjf2xMtPSOcfwM3P0N3HOXEb6jqZwiMHVnsOt2jNSB9szbzPJf/ch20yMz6K4ZexObciLToZi9XbOPQOisEo1btXWsQacuIyelCdz7mEGQ3538PxhRb6CsSTFe0338KfHBHefYreKASrotTGw2nL4mFDd3pB8h+yu3qX9PFT9FmDXL8Gu9dJvAZnd/Fvr1l8Y0XzZUHuQ1gq0QujGg7agArerKnQ4iJoXOPDQ5qrb5A+vEB/+gHjT38C1++BPsNaMg5UIqRbT2Ax5cnAL5ZBKdW2nrrT4tgXZCV4MyeYE0BTrAVYFuvLRTE5QaiM1jS+JGGz9ZtGtbJ1ErhAs15b05gr4CqRtpOl7BzEq4mEzGLBJlglY8rJ6Qvp1ApWFcNjt/mRFiDHuYdwsNBNvI6MTcP6tYarDwd0K8SQrMpSAad0vqe/emIXlVTMQyqxHGm20SYPp1rUdTxzKIeRNFwwjOeIv2+bJE1hI1LI2Pw8F7kKFC0NrVPOyVwR+g+xqqP9amBrEHwK2qBDMpRKpn5uvJBSJEZDdY27Lbz4OUgPTYu0a6TtoDlBWaAbo1tg4UkxKyFpEL/AOUdMxggqVeAXK98mwTULQlwC2bMRB+4h0r6BX76NHD0mre+Q2sVEB54t0NyENz+Tq1XVjAnCAu2PEe2QLqJdB6sl0mbFt7C/3aqDuw1y7HDHLZIJ4cZdRHcDXO/gyQa5vIbtJaqDWfS+oTm+C93SjJHGoTEQrzakmw1st/a5pqHpWrRdGtP57pqxv0Cvn1hF9/AM4k2tdZlCONM+mwdHkWmPTp/6bEGqSWsK6eCdfMZi45dY++R3FQae29fQg1/zOWT65tQKrKz5edjp7+34wgv9UdR65L71Cs3ZCePPnsGF4jtHe9zjzp6Cf8L26hPCsxfo8xF/+QoMXyF1j3Bv3Wf5nTP4ZU96E8KRMrTmQhuFLLlgKIcYItZ7VyA6E2ihVVh65P59um/fp33xdfz336X/wQ9Jz9+B8QmiW2yD5QrCMjnFJRUmDLnOnlBzxS3ZiqvK4NC/LPmELMCFjNow/L71ye0wjL5DuSANz/DyilXSCxayCSOScqjIWSx9vIZ0keBakDHfc4DU68wCl/o80rkSVZqM5XEmJ5KNoTbgvOBPQBcgvSf2im4j0SucCf6+WhVpybkA4iKEc8YXH9i5Ci9R2VA1DOTqmCpSETuV+wyZYJwkNJ4zXv+A5d1fYcvSwkEuwzOz6+ydJXMjCiFXeuZqUe8daXhK2lyYYZDjdpo60CNYvo0sX0X9ETQN2nik9fjsOaRobpK4I3S8D7vXEX2Cug3IDcntwEea5g4prOiO7xDVGvCoJnDgXJNh4SMaezTsIGytsC5uIPWQNjk81JJiC9Ih/iGyeAu/fhNZ3oflKdKu0Uy6ZolRUMnwYzEEk0B2UJcYbcUK4R7OCW7REjtFVh5xluT3S2chvgZSB1ESaQykyx692cBmC+eXcP6U+OIpsrswSJmzIj1L2GbOI98RCkNnTBib5oCLNh7BgdZCRAXtkXgDcYum3BCnNgSYrZ/6+/yvklgt+3L+1/Q9yQAOkQNvXadzli9W4rRyzLdzYc+V2TnmAnzq85jXpqdQrBcfw9qvlpU+Cyn9AqP/Cy300WInY0iHO0vabz6Cpx/jhveQ8VOGJx+TLrdw5dGbJbL9Gkm+hXv1Eavvren+pKd/Dca1En2GSZauVmZo27jnf5Kh9RaZkVxEZRatCvRe4NU1i1e+xfpX3mL8gx8z/t3fRz95HwnPLAGsY6ZNMCevdPqZL6s9CankmF25qVmMsAiyAhUFSoWf5O8boghwIyJWMik8J9z8lJV+HfHOWvuFAZIRyKkmxGf0xZWSrhJszXovucekoEEprKLiBV2KYa07AZ9BSjLbQIWTPQpxkQ3MFuPaiYpugA2kmBjWDn/PEX7U5/Z7DiSxWPSMz/4Qts9rFfS+QX9AN1FHIwuuPG4lAlqGEt0Rr94jdkesj77KbjwlFiiSCikkgoTslQjEhDQKRMQ5vHMMV1uzBsRnhdCAPID2TdzR2+jyxKiPlyvUW6LYUDbZM/ENzekKvz4mPL9DePozGN9H5BnWFzaBX9EePUTaFSmMOWENZPbIGCMadxCLwL+pQl/iNRovCWIcQCItyGP84m1k9Qjt7pC6JantoPVGm+AlF1yBE288Vd5QWjWWLqDOob7BC1ZotQQWFgGznFYixcESyTcD6fmAbreE6xs4v4DNDWyvYXOBG27Q4dxCbprbdkruzVDCcbi9JjlSKtqT5VzSXrNKRWrj8SLsC9/UYeQ71TUk9e+ywAQkewElZzOn+She+JxFU0s4Zn/bfr4B/pKwH/O1XFZuaY3oqTUbRbiLZFSWKZDCQyUyqbmXHV9soT+fMHHgPHHtae+dMLz7HH3/JzQvgP4hDI/AfQ336mssfq2j+Z4nviHcnEBqABHcXHtni7B6UNmjTVBzKtb3Iy84JlEswCDC8GBF+2d/meX3voz8zo/Z/q3fQ5+9i+jF9MFysXrkRZPjeYXOdp8JMz/73ndnkq++Pd2bqmGFDVoKyEC8/iPS+a/SHD029zXGHO0oEFFbHTqDWM7hoBaizrEdL9AobmGbXRZqCNkWmlZwoqQghFHRUrmbIKqSLD9urUa3CjfAqITjxKLz9KXxiihNE+h4xvXTn+NCa9ZNJq2bOKNnVlD1sWX2u976b92c447+xY/RZsfy5Ov04SGaTkCEmCxf5PwCjUJSE2SCVS6rqlVDuxW4geQ8yCv49a/S3v8SsljSazTredEizk1zW4jJFEIa0NbTPn4Vf3rK8PE90sUPQS/AnSLtA6L3DOMmx+4B582bUyWlLPDj1nD349aEfxxQNUSTph2ucXj/CNe8hXQPjQK6dIorLKA5PlzsDSNfk5oCwIH3ydp++kxdrFjidqvobiD2AzqOaL8l7G6QfoNuNmZxbzdWLLm7svtMo+UhNBeSqRVZJQQR83ILv5XgSBn9Zk6AKcX9gqrZRlOoHFf5hduJzikWX8VtZvCUGsPcD9FY689Mvra3F/e99nKtCYq5twJnR0HnlXsvxslkHO59UcC8+wJLLk+Q97AUJSEvu9it4wsu9HNipXR1EuP1SMs7tK9+l/Hd57iLM6L/Jrxxn8Wv3KX59Y7wJWVcCLFYooWjvJKhZfdtVrKvVuCI5gpKVxZBls8zOW0KIVu3o4fhwTGrf/xXOP72V+h/6/cZfu8P0ItPER2wnro5QZmM83uy2guArBxFqOf7qiRUk3VfrRHIAt7hpBSG2TltLSXoP2L88HdovvLnGdwSUobIlWvHOIWzcsWtZtSOoVK1Kh3xhtNnDRwLcaGmTBtQp7ROTNjnfcOMbog2e+83oDcCVwJNsvDOmUBndRXejawWl+w++AN0u0XcCVR++wob2nN661+l0g2YciLFJS/7q7Gb668YPv4J4foZ3b03aNZfJjb3CHJiEF6naGNcN6o7NLQYOZ9H0h1UHto8yCndvV9j/ca32KVEH0eSOKRpzCvKpGQ2ZXmBJUXjQBAhtS3N8RGrr32L4cMT4s1zmuUKdUJMW6Z6kDIhanUqaTCBGjYQdhiF5QC6s/BOHBEWqN5B2rehu09sOstZWKNem/smz22aBJaOar0rSsxu7OnHawjnyHhOClskZKoR16OpR0er6kZ3ECIp3iAxQDSKCLRY5SnvhSKYY52rYpHPt0HFvpVku4xZJsyTqPMgTMry1LyzeZze1kt+LjmwzPcq5Ms9lPyYfX4SypaElZK4z0ldRWubi7kiqL/VxD/UhLAUBVHuDyqvVn5l7tHWXED9sp8/BVWZ/ILjCy70oRIv1f9C9J7m9DWaN/4M43Ol/bU3aP/xNenLyvYooIWLvlT9SFYYuShkrkFFpPaFVmVie00JHZ1xwhfagVI+L4bzFbEQB1HZOhhfOaX7C3+a1Te/Sv///S3ST/6QlLbArIKvVLIcqOTJ2dSDiWRaJPYH84UuuQF0tUvE1bCGpivGT/8O/t5rcP87hq4QDIrozDOIQW1cQoCQi5pKSKXIWZdfz+X2Woi3sqWvznJ8xkiZvYJA5mEHN5gSZQNpo4bkaZIVxolYUc7RwFquGT/+PuPT93OtTL5IobXN1Lf7BSrzsTwwcxT7fJnsYqlpgnEgnX/KbvOC5vR92juv0979Cn79FlEaUn9JuPyIcH6OyNvI6p6FSnQBzmpC3NlbrL/6DUZ19Nsedck4cyQzf2ahI4iFjGK2zHJBUoqRIQiyWLJ47U36yxNivyUN1xSkjvUdFsQ1uehuh4SdhXfSzpA7JexRUDruPtK+SrN8iHRHBO8N8qlqlr4ALlvMOtlCLimkEY2DEcLtrg2Cun2BhA0aNrVDleoW3BVOBmrNiWQq7BTMXnFtXssFlWWGlKQcxmK+F3S/nqBO4GxulZz/0tkuyMrqECUlB+fJ1prk/bS/bmZCf88rL1XEOgmIufU3h2vK4c5k/7cCLniJJb4v9t3+PwFDhxVU2eE351cUDkXHy44vvNCXHGMuz5Iwa3xwC7qvfZnFVyLLX1sQHlrCNRXr1Fnr72pLCzl5a1Nf6mZKMwPIuJdOSUvQ3hGdWpXoVicEA/NlqKZYvF0vtEIQoXnrEeuHf4H4+6+z+Rt/Czn/AHTI+qdYLwfok+riHRxFaNyyCcpvkzUzI43A3GSQ8RnDe3+Lxcld5ORNhqYhjQ7vhdCMxJ3d+3zdMzNKgEzpIOaoBKUyIRbIt6cWclk4NTMvZsEvCoyQLhWuo3kVPsenAbfuOdILhg9+xO6DHyHjSOmGZo9jrpjQUHIgdRPP4qy1wUwN/0wWfx3MvWR6gr4nfPox4dkzODqnfRSRxYpx+xR98RGMAV00Bszp7lrDKNdCd5/ll77B4Fr6rVV6is+wR7CcjpJDboZK0abJ8WGpKBuAcRyJ6tB2kbmZWgvTJIuxGKe/R9NIGreG2NEc4ilWMpp5Z+7i/Rs0y7uoOPMrC4W3N9bQMhySBVfp4axpsKYtYw+7G9hd4eMlziVkcQyLE0gtykDob0jDMxLPMOjXCAzGjVPI6jRObnIpZNRJUSu5UrgKw5es/zpz+zHzcpbpmBZwNa7mn8iCerr21PxE64LXHErMX6lCdtoYSjLkDgfnP5Dt9Y+ZUth7Rs0v1tyfCXm7ZmYYoOTXPE4apvKuefjnQMF99hDW4wsv9LUUMOX4upZRFcdw7GgfOMYz6F0ihBwCaTHenOJBKpXyZp4sT3YBq9qU7Mw5kIXQLLBmF6OgmzQVEBUvtUxaCUc7Ma/AK6GF69ax+N4vcXLvPjd/7T+DT36Cc8EmLpWYeqkmLYvPnmuaxf3S6rI4JE+bJYtzZ6ED4abqsnGyQy9+zPCjM9bfOkXbVeaRU7OkL6G544iay/8zs6S12yuVw1LlZyl7SjE/ugMaMSRFMrSOeGr1vZgsIG4TcqXILl+79VaAMwaW7lM27/wO4d0PcINVTap4asLa+ZkBVpScTYIkzeNYrJ4WSss7oOQKpnzAzHyY95VMApue8PQct+yx5tgR0hX076O9kZ01TSSqo737HeT+I7bXvXHSi3XE0uyVqToTfhG7vmTkjfNEVxquqFXmoqQ0Gp9O7JBxibqdTUXjrVUnav2aY0RTtBoCJQsHh8gdmu4x0qxR6YhOiLm5j9Z+CszClYbxFk3G2RN7NGzQ8QaGDYzXZpFLIEpEpbdzeEPqSNMi7SukjTNCNLnI15hCEehQNkoV2abIJ1DCnkJ+icWxb7i+xDKvAj4dfFdufTtPzP5nSw0NE6mykdkdXG8vt1YMjDy3t+50rhAKP5Dmv4SJ8sEZgswYHJn6dTc5HIiVvDMV2lWFTQ7p7oWwpN7T58n+L7bQL0ZCYTvcc2HssUIQuIEgKVvdDhfFirh6RXcpY9Nnm7xQApeLZArcmBNINIIuPMtW8CPEQYxmOYcrTPjl7wrGKe7ANQ5ts4XnhB1KePUR6z/757j5zzdG/lQskEP2vb2k1MGCVSjIFuvI9RqkO4gckQqzqIwoW0SvQLag0SBrKuh4l/hkyaZ9RvfLbxJaE+ixHwiXwvLOCum8FXFlK94QZdndLH0EguKS4AWGrAB1NCFeDZe8Z6KChoj2Ygm/m2S3FRK0Dlk1tAJ8/BHb3/nrpPc+MrgokIpVKFTfpQIosnUkSbLnlue1lqHbBkIy4R1F+5STlHWUww3SZEHUgjZoioZA0TELrQHiNXHzKbo4RpwplOX9h2yHkRSsaEoKBDgzdaraT1yczaVmq9+D9zXBm0LmD0It+VsgM40prJjSxDRZQpQpb13XIH6Jb49w/oigkRQtrl9pICrC43BvGfKLsLF/4waJOxhv0HSToaJhJksTuJC3UYtvl7RHDwhXaqEfsU5g1ZGaGSJzH7Qu7xryZP7uJLtu3fBLjmIA3Hr/wBKfna14AlqFuQlhgSrwSw2MCew57HN+yvn5Z/deXVS59V8QnFoyXfM/IVeC5zqbklecTmVreLpckSH7iP89pNrnHF9soQ91AKd1mzVbUZgbYXyOTdbSKgp1BEYlbRJyo2aBl5yRYF90WP/MzqhYVS2fIzF/xMMwKvEyoucJHTyiUkN7biaXtUDbGkijs4JPb6RQ6j3Doy+x/N6fYveb7yB9bm69tygPF0+9UYqS07RC0kPgG6Sjb9Pce0T7cAXHkLyzmPduh17eEK8uiTfXhL4376Q95uj+I5pX1lxfvINbjyyPFoTuiH5YM/YdfiGEnOesctJRBb4hXxLhxsNa0CaRRIgRY95sHc6VBHgW7qMig5C2mOAf8sAtG5olNP0Nmz/4PdJ7nyBjnMlineY8X1qyB2QbYbaNxBRBrXWo74iFRMrDALbR1Cx4Kco/bzZdQnuM8615GJrZKktnpeEjxqsIegVpgTSONGYunEqaR7bc7Zx2CV+FW/EC7L7nYq4oCqubUOdsvTrrnmWMqLP4rl+boeIcvlvi/AJwhBiJuXVgqdPTYiRlZSROcN6RiNZcfBwM+TNm2GfISKASl8uhtbwIs3yN4EcSzpoWHT1gvHqOpvNaDGXhyOJW5zFhZmwf6KC9Y7bX9178TGF2YGUfnnsmC2tXBi2vzPeg1L/3K1w/68Kyf72s0aZZnozLOdDCxK7s/Q8pqZ5iwEzBJ9m7R/up9VxF2czX+ecN7j8KQp88fC9RYqJZwG+B3plnX5gOgpqXP8jUoCFhn2mcUeHmjeQyLl9GrM/rqGbk3US4jkiveUZm4ZbC350HOuXYvjoleSMPo3O4pSc1Dc3rb+AfPyL9/Me4lGbOxoGu1pKBF6QUW7EEvgGrP0P3jS+z+NqKdMcxiDJGw1N7DyInuPSQRtX6AexGwtWO8dkN4+WG7dNPcMstnH/CzdU1bv0Q/5W30Jsl3fox2h0RS/mtw4QE5BxctuBGRXdiCnbMnyvJbg8xitWoDWpt8XLNmoyGKjJmT8H5AfnkPeLPfoQMOwvVQE54zyF3Zo2pgcFtXHK8EwVXSHtmI2l6SqfNV3HeBr/D+SlMiEPwqFvTtKdI44jsSOkG42zJ+NOwJV08B/VI9wjVHo0mDN0sVFRER2m0Y4NWvIpiYWZLsphypQBJBHGOph8YdWFWvKghwCDHy5NxzLQO35hAjrEnhiFb5TF7W9aRec/ydApOrYm7BFLYZdriGwvnhGvjlZJcxSwOcV1mkZXcrjBkDyigMRJkpFueEHcPSLv3gWiFS8xkEJMo3F/v82MusD5f4M4/IXkOb9OaHH59Eo6iblpnktBM2Q2Yd1jDgfOLziV7UWLZONu7rKuFmXutC6uXOSnAKgFm+qGwmVbcTlFO8/xAvWCc9GO+9i8S+PCPgtCvMEsoD7RHTaOY8CkIm2zAoc6iIcU6KsKhEasoXQq0uRB3q8guwY0iVw7ZCmmXYJuQMRnMkcGoB8pl3VRWbckwRX2OFeaaAm0dcd3hjxu0OaZ746tsPvw5DH22+nR6nrx4Kta2PmSLi2+hp7/Kya9+nfiVBb2HcReJfTI3o5EC8rBCLQfSOuR4gb+/pH3rDHl6hb4vxI83pPMexwjDe8Tf/UMgEt/4Eyxe/ZMMzRlhNAvCus5JDrF5UqtVPjUNRFeu69BglA8OjzOaFtgmdCvIqIj3uNbl1sSRpj9n84PfRa+uER1NIGNcIxWeWvDtGKtm2YxCk+G2QEp5s6RJGFTrO899KdGtJPuzvrrZ0nLO0zQOdSMxXMFwYYnSirGH2j5RR+txrEuIyTqo5Tm3nwoEY4wshTv1HrJCSrlpjmaOldxhDTE0j5yc4bLwUAzx4tC6LDQFxjhk6oURjblzubMcTCoboYS+St5IExoGlMGs+7G35xyvzNJ3rRkeLpP4lQF1xp2Da5DYWA4gjiRGaCLNYsGwI89Xodecx8ZdNXSmxiFl0X6WwD84Dgz6SYhmJVsxw5/1xf3rSA5dWs6kTE8RIPPPM7tPqd9+2TWkFDdUC35aZ0gR4jM5khWHiQDNjkOaXbmMyST0K5T38KnE8gK3723/+EdA6JeNLFWR7YXSqntlwmkexkwO6ATnrFRcnWb2PkqvlWxoCePOCk302iPXHrYJ+kBKAYnBht7NLFBXdnARCiHHR42PQHyLLFak3ZoUVqTjDv/gdVi16LjLX91foMXV0/mC0TW0X+H4u99A3liw6Yu1nd1+F0mdQCN746C7hG4jyTnGxtOdnnD03RPCgzts/rAlPfsR3HwC41Mk7Rguz+mGgfVbv06/uMcQGpREJFdsehvLLPcKrxt48AtB8ZY72UC6jFAqfIPFp9VLhnQOrN05+rPfI/z8xzDsMtqjjGyk8pBXPPfMFCre0Hz+6yIpG9Pn/SEUYjQpnb8pRTZFYBQkxw4kN9QZXpgATHESnHVnOTQqw/UlrI4otBigNQevYInamYwpaQq75XzPKe0339BELO0ym8bWRyokfrnnclJT7DHz6JcxUhOsKBb+mieutYSwFMaRmK7M3h6vK85fxgtEe6uNAFBrKmNj5/MoW1W2E49IS4gR4sgYtjgyXHOWTJWX/LYvSPfXv9ZdkIXbTNDNXGyqkNw7xOY9x/dF9z3ocoKKqZ+KNw5Sx0VRpfyXTNNfrfX838wHJTl0Nl1rYnkt4TXNckqZq8IizMsLmZenGIT1Ief7Y57EPjhKNf9t7Ove8cUX+lCtoz3Bz/RTxah83Z0Maujzd1os3uwwtr7GBiMBMeYilAQOR3PUkAZHvBryebPdmUY0DVkwzTaoZOY+zS3cYm5OnQxVkcTjdj0MCU0e9Q20LSw9ejWHn+nBJGWrsRCn6V30lbfhtROue8wD6dXCWI3gjhxuZVS06mYyCNDRkXYRvQkMN0poHcv7D7jzJ0/Y/EHD7icbo55NA8SB/of/L+LFT1i8/i2ae98l+DuMusigHlNCqo4wOvwgBh3OwlW84oKQNopeqrW/i5mHiAQScN2WZfOc9M7vsPvR37Wy/JQTnVKqV6ditrk9pGk+RvNGFqVCEyYLqzi9WdpmD2EKnblsFc1FQSKOycJSo3WeqlZZLYYTMoMcqY/QDIaAcmbFOjEGxNIgDdRihxUWiYUWrRCE+sHSxCMloxtWtfBJ7qdsFowhqex7+XVmAr/mKDKFQZUJfmbojpC2tu6JECykQ9oi4RLnIlYXsajjqOLQHGa0GH1AiYjLCogAXINcI5LqODnKup68nZcfOpPJk1U74e5L+K4IXDf7fV8cVhSMGiVDSXNO60Nnr2iVHfX7Wu7czC4HVMptxJRvbdQzUz3F0jx4SinTkv8wZcMsnwCQqvdWxypNIctb+rLStMyBH+XtQwX58uOLL/TLfM8OYZKTJdSVWrUG3ALhRtGrEfq8AcRBq7kJt1LqVAiYNa9mBfojRzr2aB8hGNDNKQbJK8UvmhEUBRaopZWbNa8gZX5zPOp6dAh2ncUp7qRBunZ/TuTlDykIlhG+R3f3VQZ1hJ3mGHmCRvCtNyu7zVZ3MXaavOnF4dWs0HAzkvrIZqvEZcv6u7/O6vQ+57/9n6I3f4Rojxt2pPd+xubJJzSPf8jytS/Tnb1J9CtUFiRdoqkhbYS09ehijRwv0LXV/PiQ0G0g9FbYZn0GIs4PNN0Vbf9zhp/8IeG9d5DdLgs1zXOULRiNyJ67f+Bq1xBNfk2y4NHZojgQDNPwRkqSVSs3Sxb5IRNoiUNKEVV11ctJHMgav7xj4aVxlzGrmX5ZDq9H1mcZG5/DgLax88LNcE7RXDxYIIQp2pqaN+6Zc+jXnq3zZOlsDRVBWdaXRkMAJWt8LCmg6QINV8bXE66scU1zjHcLCrLElEYuDCpoHg15feX7IpLijoKWkDwv2e2Y3VtRsbNxOjikWvczRVEVQImjz0IYpWtVVQzztZMF+V7OZ1ojJSRYlVO2JAW1+U1SQQMVRZPv0D7u6qVeKmdv7e002SClFep+2MKeuuDKi2IpmqLUBxRI5h4CsKzkX3x88YV+MXrnsf09+SiTK7QA1wnNMehZS3wOXEfrh5GsnZ8h8RRK06XkzBpzkFpg3cDNALtIHAYk5Y5EuS+t5raHSTPCI41oGCaBn8mgzLgcYBwhKHHlcMfHuEVHrAUpul8AUiGl5EUcEacsFg0bxfIWowlK13Q4LxiHWhYezkEruDZPfZYfzgnet8Qxwpjoh0BoGo4ff4Xjf+y/yfXfiejFz5DcbEJ2gfjehusPP0RWx/j1EW6xIvku4++VxD24/w3ca19G7x4RQ0+6+JB295R10yI+U+PGAd09I773DpuP30GvLpBgLSd1ZgFWSgxKGdqBnVZDOmXjax2rYmPprMPWno7I1nrBNivOWmoi03l1EvqqkqtJMa9LPdAizQl+9RrSnZpxHgLihgxvXYAmkgZS6R1bEsgZNUNKxNIruRx7+O+ZcJ893zyvYPOa/xbNAjmPW2EpBUrdhqaM60dN4McNki4gXkEycrbCSpnw+HSEcx3RnaHqwXW4boETJY5DrhMYibh67xq3pPACGKmhsyp7i2Aqc/kZRYh1DPLCrX/HA4U+P3IoZ88z0Gn7MOXN9g0tsRyFZg9tT1G46TOl2ctMeFdeAMGQWS97Fp2eoao5TZRCyil8OUN1CQfFYEyfqRj/uKfWymer6bLXiOWzjy+80Bd/2226/SGQlGNzmSFQvIWghyBwMxLHxnjlR8mdevJANg2uzJ2ALAQWDXhjN9TQw7BFc1wfNT6RxmGbPAbDRKfRQjwp5S5CFtIg2kZJzzzy4Axpj0zAUAR+Fm6zRWtPbFacMiJiistiVyn3dRUzBLc5risCjYfWkZqMSsrkWGW5Nr4xhsagxJi4VGH96Ksc/8Y/zfX/7z9BL36CpJ5EbruXFVq6uSBJSQ5qbpjxOn53B5fuI7sFKkr84FP6n/8mg25zH0XDvTNsccOQLeiYwUGTq82tGfaTe3srPFCs2/xeFTD70LYa5KkW6YEVmLx5gDo7bxW4DlGfFVwLcoTr7tOu7qLNkbUn0AFJCYkDsEKcw9EwhgFxDd63ZvNKFkPFuksHK1k10zPMxyHNLOWZNVfrF8qYmDKbLNRcwZm5/xPmFbhMcKbxEsYXSHqKxms07cxw0cwHFQV2HyArxTdLUswIora1NRYcFkN0OVmeEHrc+JQ0nlO84dL/1XILjlq9qvuyewZgrWvffiuCfPrkBHG5Fe84+Fcu9fJ0piV8wRL8k8Ew+8RBREX3XtdCzQDMY/fV+rgVfil7O07GCSXMuP/M+TL7850te3tvdp97lMp5zXyOOp0fX3yhj81znO2JlGqIeUrYqHnDlsuxKU+t0t7zRFHSi4SkxqapavGMr1cxLzrkhemMLMvCDz3GcZLj+ikXy5DLK7IGT6rG15MMxSKUzRohXqMXws37gdX6IVeNIn0pTDmw9Mgkc1qebQdpwKkSkxXvOJ/rEYYSSlLw3so8VMyjKZa/qIWnUkYIN54Y870G2G6Vo1fe5vhX/wmu/8YVuvnQBAQFZx3QmC2R4jokD7ohbS7R83N8c4JrvYV0gpKGDRarzJZnjFOYom7G2UZVIId3ioKyF91LtH0JveTVcfh+3fc6kydi35vJT+dG0FLaLrPz5rvTaAlMOcK3D3L7w46QRlSifT/uSMGh/hWaxQkiOySO6ODR1RGuXVBgmCkpWmhcs+AuxoEmY690MqUwp7DF7Lmydwhiseb5+1jMP5EgjMgYUR0RCZBuQC+R8Awdz0m6gXSTY985J5LLqOO4IfKEpjml604IjRB1hHEwg0Yy26MbQDaIPkeHT5B4jWjcE4JWbXqQdN83uV8yeUoJg+wp6b3v3LZ3916TA4VS9pjMPcO9O52d5dA3cEWngmbg6SyMOBkuWmktCv1EPY/kea7XTXtXsO9OXEj13gQ7l066ff4d+2/2IMjr62Wa7uD4wgt9jVqf1sq7qWilJFoJv1yD5ZNGLIErWAy/gebMkBDjk4QGh89FVimJhXkSSIn17xSGXHqrIYdtkhWyFNe8bFaSNXmOGbmTwzrFUjRcf4+xFSbieYR7I97NQVmfIbWwWLXIx4SL91m88ohRPLQGk9QQ0CHm5LZRM4gY9YS6HC9sLLRjIJCUFWeu9sxkdGmn7Gg5evht1t95zs3f/WswPs2LVymtGgvdbTE0kRsknMPmCjY7dLUCWZGaO9C/oPLHZ6VYnniqIdS6WM2Yt9irbbrJq5oX9cyVhh6M1e0xnG2gIixnNRB2WcG6jJXvTArAXlvRdI/wi2MiEdUbnIsIIylckMYXEE9heZ9GB8aLd2nbhHZ3jOBsvAPNAvVqCKvkzAOKFpt3YOMkpaVmXtwxTo/kxf4mAwck4dKIqGF6Ct+FpJQrkC1ur2lrwj5dQXqOhitINwZKIJkyyKNpY52w5uYJwpawfcqiPWLRBpL3JBeQJreBDFs0XJLiBbF/AePUoWqiPt6fDamIoimJam8WAaf7X6jCdEqklnwMyIR8k/1Efq3nKYI/K7bJ2JiYKycxOlMAM3nL3ufLUppXwc6rdLNBVHlfDsageqtz7yaxR8XyEjO9XEuU2pfDzjC3BkoXsKlq9yX1w/X4Ygt9pXaxOgQCKHmCoiVdZAC5EAMeLLCuh86UAkCzFvxKiOcjaddamCeogQPIa25UdBdwm4BsRnQMaAw4zW55IltnmfExoyhStCpIuykr9oGOxjckCcSMXXbuBf3z95AhF9vMBVJ+pT54/lPYsDt/l5P+l/FdZ4qsIDlmcEbTPYqraMWEJqvuNB6iLLQ1N3WfKdBxk9ikjtWb36E9f5/xZ38D0lBjjyIR67s7CX/SFh1foP0FsrmkaRq8XxMXd9BNgxHMKbkHFZN1ozDbNlK4Q/YsFHtt4g49dLrLdi1nKUngIr5t4xVBUT7npJxP8tCVHe5n5ys3k2gXK/xSCHpuHPZk6uI0kMZLGFew/g6LozdpwjN2T36LyA53+gr+6DvIckFSK3Bq1h46B8Gj24G0GaDfobqzauqY+5zm0IwNVxYiaTR2Sy1hGiWpmEItylhHJO1QBiTeIOkKjVeQrtC0MQx7zRXkOLHMZW2uahYjBtBxZLh+BsMzlBur6xBLBqdxi45Ts3GpNMSHAn+2Pg8QPEWuv8ww1Zq3ycpiT/D7W8bDnETu1iET0uuQtGD/Z/l1Wp97xVVQhU+NLtyiYShl//b3FLuff/bA89m7o88yYsjx+sN7sfOV9e5Kh7nDzx4cX2yhD8yKHetRBl1cHqYAXIAOihrrLa6zKESmVCGJ4I8csXXwTJGNUPolV3qSAPQJ3fTG5z4EJFkMX2tFnHkAEi1pW4jTzIi05FBS63nanEEKl+j2ypB74zXh4mMkK6o5lKwiVvYWmpUKh+uPiZfPaR+9yijkMFNggopJVQDW9s4EYEoWpy3U0SmmKtOm+K8tzkEFtzrm6O1f4vz934M4TDaRTtaEfSmaKxm2uHRN6i9I4cjO2Z1Zo3q21N4Be5ttH262b7GUn/NtPSWqynf2N0VGVNU4OJNlUM+RRbrqbPOYkjbvwhRhRWNgFmtMHxH7F1VgmjdXIKUN+Id0J9/EL0/or3/fukJFT9oKabVB7l7g7jb4kJDRmqqkEIibG9LNFsbeajaidY6iggViXnc9SbdoGCxprLtcMZuqEHVYQ3fVHZquEO0hXpPCta3VDLGchF5Zx7ZGJnCirTehRWjt7XEDcYfGi4zOKTBWBckoK82tOz9L6tbPFytUZkiY2ff2vm7KulTb2oK13tXFeq8NRGaVsfPTWjTG7q8geyaMe/lMsSJnS2ImMF9GxVC4s/ZstTymSpohz8oJ9wW/vT1PVHPw+2Twvey9YtFP70yKRl963tvHF1voZ+UpTkEkTyJk1FZdT9pD+ITK784S/BJkDXIk1t5zYRWksvDoJsKFxb9djnSQsF6eux2y26K7HgmDbbKSoMI6U1n3n4SU5ijFbVXMxZAlbuVI3Y8Zrn6EbgPOeXOx+4HqkosJ68nCTNND1Y4MAYk/pf/0HfyDx0ibb1YTqLMlr8nK67vWnl+1GlmaC34Y7V+Bcoo360xTpDTq6Nslq7uv4++8QnxygUQxd39WAq2ZjkIEI7Ebt8h4hQ5bUqtoc4J0j42eVy/ZhxSWjVoWpasbp0LNKQqmhAMAPNaQ5GVHiX1PzIdTckupFXhMQ2snSpa3QXNowmcPzdecbxpuQLZVmRg7pZjAlzWuexPXnbHbKeniEa77pwwEsD5Du9aS2zfXxJ3DbTy+awlDj/a9FfGNOdGfjELBJxOySQckZotdd2i0Hriig21yKQoqEqtVlNkyVTFrZtwba0WzXZCoCryMX010e0QXqFtmL2BXOfSlkI7NE8xz9s4yidV7pb5fk8t7R51wJuE93e1cydd+03VmS4BDJ0WfwzlzUrLp6WdhnD2boRgjqZ5j7/60eORFqDP/8oGAry9O18re1C2Bnq9p2bty1hli66VHUc9zxVWq0IufOlMwn3N84YW+Bs2cIdTMe4paW7ppwrhdevuKCNBgLfoWICdWtKUn9rp4K9LRPubN6zMEOaJDxIVoCdIhoCFk2lmz7gr6QtQSuKjOKi8daAt6gqzXLO++YOzfRTeXyNbcW6c7s5CrpWUPOQkpMHcjU+naE4EODC8+ZrHtYbE0ZeGbmrQlJWgyF4vL91L4UjJHisYBxmh9AQpZj3NTgjUl1Hf0R2vc6Zr4JCeIZLax6l2W2KlDUiSNN2j/AtwJGgVp78HiBt3tkFuVmvMVaVj5ae+UHVni/wcW/i13+yULhmlM9wXIy76viOb8ASEvmCxOinFRnl8xbyDTTzu9Q9O+RnKCO+loX/suqCP1W8bdpiY+CRGRFhnVqBJiRIKaAjYssQn9dEMKn0C8NCs9XGfiM0s6qUZjHz0IUtRx1cliryRrdf3Mx3Y6JlvbBLDloayruRmmo+UHGJFMMasH3y0jXAvZPktm5fdKnYI1XZ8LuUk87wn8vTPMhefcWihry80MlKIMZtZ2QWjVs0g1vKbLSv3sfmVwzg3scfIcGjH2fHvJ3b3PftbIaP2fy37ndErJIIqyIKcQ3fQUE2T1MJ/ysuOLLfQBkkzeeq10lqkOZpY7gbyoxBSCeGCjpA24u1i4RSG1Qu6GUXHnOiYrsoopV9daEjeNPS5lmuJSeKUzra8g2mBVi6fI6g6rh8+J+vsMn35ohVTJM1EKqIVnZjG+/UhjsaRK0lGBEe2fINfP6O6+RpCcuRaI3gR+9JE4GqtmiskacLctLppCi+MIwwjRMOhO1bhiyGELceBG4q63oqPs2Uw+c/GbzStQdYhvcZJI43N0s6Dp1kRCJgU7Rv2ZWbL0VBpbObSQJlz+HLZa3psOn6XLy6TK7LVb1tdtwTL/3H56LydUyYZAva/Z+hIH6Q66+C7N47eR14+gE4aUGK6tT22F0GZvisJqqfm6RWmjVpQWLmD8hDR+ZL+n3lBAGme3fvu5bHnMBR4UCvL63zmdeFayRVBVQ1SEUotQEqVCQFMPOiA6UlA+NbxTbNQ9mefYD+ftz3Md5zm1xv7dMlneSuUNYgaQqEbBTAgW+V69kLmCmHHfzwVFvl8tXvfsbqZ/M0NljoHPY6B7MMx9dVWGxhTc7J0ZDxL1u5MwL3DV6V2fl0xen3uKqKSVNW+f/fDVZx3/CAj92aOVuubc27lMMBkOZ8wIOnmdpW1fb1W6zSA0K0iNkFyCwaoggwYLVSQ1bGiEnBmFMJJ0tC6AKZJ0RNM0ySaMliB3cUcnLB49I8S/w/DRT5GrhPGe56VcjC5XYn9lqVlitjAzTpOeF6n0wPvI1Y9Ybo652CgaPSqN9Q9oHb7xxM0N7EbrkNTZvYlGGCPSj+iwg6BIswIkc5Fl1Id6pI0swkfcXH0IOpgAUJcFfX5WUoaXdbjmyOYjbki7C2S4h2cg6gaL7z8g9QOanjFZpHOLpyiCMg55U9e9pZDL6S3pXdz8PPdz5VBRGuX9Q+VwqGhKXNysQ+MwHyhx7eleElq2iTrgHrL6JY6+8R3k1ZbgAwQh3PRws7U2gyELrEyBoDHnfUpc2znEtdCtcT4Sn/4A4vtmVKiN734IpoxGXjNZ2laOpuz4Kw5Vn+epRXUFuqLik9mA3gA96ox0z5qoNEa0ViC2OqC6w1hGB1xuFi5zA6UUGJZVXIsn9w2a8lrhAyqOU4mN1z4Zew8bKdkGyXMk1QYuSuMwJKN53MoYFdRXiXmbcK1J/bzvigAvx4Srs2sUVWWPIVjorHynrKHZQMzUR+2doWRCvUlQl3MkJk9f8nqfjhIVwNBtxFkB1txoyXc5g8d+nuj/Ywl9EbkD/B+BX8rX+R8BPwT+A+Bt4OfAP6+qL8RS4X8Z+GeADfAvq+rf+YUX0bLXpSIO7GWpriJRbf6CWfBWGGLaUZ0Y1e9WCElZPBS8+Ax/yvHqlC2DGavhHpFVxIjXCn1rIbkxRjdw93HrY5aPLhnj32T88GfI+YDEFoPHQUmu7rtnB9taJ6Klua63h3vB9uPfBXeK+kek5THuuMEtPNJhyT7FsOHeEceRJCZAUt+jQ+57mjQri8LJknIRhNJIZLh5l7S5NCoYyXDLPZPOXFznF4hvSCkLiHAN/RbRLZIubMO6DteeEYZLVAeKcJ7W6cySLgs2W3TzcbJ9meP1e0N2KMjLazPPBA6H+WBHmGW//3fIyk6yPMqcNOkubvVNjt54m9G9YPvO+7j2DH/nIWk3ZJqDInBkRs1QmhQYd0upCsZ3LE/vs3XJFHIVQEWwzm6rJgGzJVsx2S3QoXqEygnqHkBzF9fexXcPUb+qhoTEQBqvSbtPIf0Y0kcol4hEBG+ucckJyA7VLUa5kGbAg31LWepesRveawA+s8IRasVwDSfVeZuK5CQ/6+QNFuWXKKBQbt2HvZ6qkimx7+Ld5FDsnsBsbBnOwj8lxFIF8yEKRoCZNT0HYlRBX86vdkdVwNf1Xk6VppdhSqvsPeP+81WFsCc6dO/HrbX+kuOPa+n/ZeD/oar/nIh0wBr4XwD/T1X9t0Xk3wT+TeDfAP5p4Ov53z8G/Dv55+cfkm0aVatKLZtpLjuDIFEyiGMK/VQSJNEaxqERXCiCRtFcSSnizOJ1VlCiNZRjiU5L6JaF6VBtMPKtM/zJKe0rHzP2/yXjBz9ErsBFzxQeKTrdFthUbT2fKTf7vSy7Irw8pBW6cWw+vEIevYE/6WhWLSwhkUjjiHdK6kc0YK37+oBqRMNojc8TGJZVcDmJWsJj4iIr9y6bj34XeuupWjaekhUo2HPrEb45sy2SBkr1cRp3+BbC8JSI0rgTg4vWRiJkGNx8QRclW680GUzlJQ6TVPOVrXXHVKtHZwDPw8tVRaIHr+VTSd6sOk73JIpyh+bou6zuP6IfPqD/eAMskDsrdC7wncc5Z3w7M6WVUgnv5XWZs8XiHL5bE7bztTA3buZDlZ9NWkQXJD0C9yq0r+KWX8KfPMat7yKLBbQN4hxRUhWGHo+Piu5G4vUvk168g25+iOh7CDczZI51DRO1SvMajNH5/WTJU/pKwFxq5WOmAFSyEKQqeK3r/gBVPrfY8yfLSNY8zxyQv//l/ImCsCmG1u2lMHktUEOLc9oITfVck0qavAORNKF9VCZv5yXe6HSXc4Fe8gYlTHUYfuIWN49tlbx+5FAv/UOO6YvIGfBngX8ZQM2UG0TkLwJ/Pn/s3wN+ExP6fxH499Vm4W+IyB0ReVVVP/rsq1iiTVNEdwFNRljGylUmU41SwSxkgEFF9oido8K7xLo4WaW9M855b1aTjs5QkJFcnl8uQBVY5C5Cog2kI9Sf4I7usnj1E0L4fzO+/1PcZUDUigPs8lNYo4jzaaEmKrmQZMst02QKDaoLlDXoXeB18G/jl4/pjtc0d1aEBfQpggv4hRKvd2iyeLtKMnoRjSbwFXBLUOOd0aYlqYWVXDdyvPyQ8cl/Snj/x0jah0kmsPCZOkSOabv74NeEOM7IoXaksKFbnNAL6PCM6Hc07QqRMAn8PJ77W3AeGpjmbXKE8+quVmSxzPMir+dz0/fq2i87I3tRyqRkpKoYirCwC8ZpvqUFvUdz/E1W987Y9B8Tx01eH4Ml/ktoEKwNorhs0U+UBM753EvXmDhtWZhyEb/AqZvQaXsKr9xnOdYoj6B9G3/8VbpXvoY/vsvYdUSXGHK9iPVBCRV5Zk812ro4anDHD2kfPkCffYnxk99Gwx8AVzSigFWhayqx/CrVZzcTZ+Oex35PW88fAPaJ6+avlzmVl7y2vz7KlV6qsPc+Vd6ZBD7MBWQW3sVGyAK+8hlB3q9z5VR+mxkNs88LxStk5o7O9/n8KEqoCCy7zym0dFhaNRvjeicTfHHaJZNs+TzR/8ex9L8MfAr8n0TkTwC/BfzrwKOZIP8YeJR/fx14b/b99/Nre0JfRP4S8JcAWL6BXp0bymFUnFuaJe86pFNSDvnscTqhpCjUZNGMV6cRqX1aPeC84FsbrOBAfWdJzX5tuwYH7IAtmkIuzPIkXYE/oTk9o3tly8hvMb7/Y+Qy4GNr9wVZiBWLL1sf1S13qC5mC9WezUicFijHqLwK/gHN8hXa0xXdg4Q7+4h+2LG9/Apx1eHuBJZnSv/Jc9LNiG/O7PqSSHlsxLfZQPEgLW61hlZg3NCstnRHP6R/9jfp3/sR7EqxDdRqWBHQDscR0j5GujPrgVuofS1bTBrPEY4Rt0I1WNWqbixWXRfufPHOLbA5F8rs/aooimCZCweZlPMcSVFw2UXz7+mYkh+YzlE2bFlCc651Tfdxy6+wvveAze4Zsb/JuscSmTruDLo7BxPU+3OzWoiMLBCIWTA7Fet6Nd5UW7Ye+VeXwyqiC1QfQPdNFne/R3P/S6STE6I3Jnsj08uc4knsekW5KVhuwoRJkkhyivOO9pXHLNo/Tf9xA7u/i/IUZce8Icm+GNn3SCZnVV/ixVHn4rMLjw4NgJcdM6G2N8hzS3361d7JAn8PYmp+ZSow5CIgax1Kge+WM8yvu2+97+U3Dh5r/x7KsS/4qydShfYcmSPTiWonqHK4vfMIZFSjMiW6/+EJ/Qb4VeBfU9W/KSJ/GQvl1ENVVW75J59/qOpfAf4KgBx9R92zT1HXITRIN218cS3itawpYzH0ZkmZEZI3co6xire3x/Mdadsj6kne45oW1zZmbzuseGu5huiABfge+i3E3jDquoLujPZuw/KVjxjGv8H47u8iL0Z8bLIGFhP2c+OmWJXqyOXCEF5H3ZfA3UOaY6SLyGKwzl4tNK3DNT24nyLxku3zc8YPd+j4dbovHbN+vMStnsALYfdxi+gRyIjzmitd1a7jFmjbgLTIoqNZDnh5gus/RHbfZ/uTPyR9+gK2miGJYBQS2QtJlqiW7g7aLRkkwzBztyfR3oqDRk8c79J19+m3HyDsSKGfJtdWKJObdmBl14/NS+WLEHeTJT6zpMSVMZU85w3Kkho20B7oMzTTCpuQmhI9sP4ma1+1RTmlWX6Z1d2HbHfnhN3GKsCrlEnEmxe0Rw8R7cwbQsAZ9W+h5UXJicxc3KUJxCPOw3BN6p8yxbUnIWgJTwe6JPkv4e99j/bV7yFn99glJUVFx4w4qoV3gjiPa3KIyYnVn4yD1WpErfee3MjQDCzO1qzcr7F9/xodPsUMnVgFU92bcijIykhMDJKyB5ucH4fWbpnMuWszn4vya6Iq5pnCKd9KewI9z2DVRMXLL4pisqgnQ6KYIiWin4W+TLLldghpuscK46y3V+705d5IGfvp3spnLRlflWMZa3X737VQxC2vZv/4fJH7xxH67wPvq+rfzH//h5jQ/6SEbUTkVeBJfv8D4M3Z99/Ir332ESPcXOKaFUhLigmJyWJpfg3LtiZ5RUAbyRETzQ3sFYtfC66BGBPxpoddZsRUiK7Btx2ua/GtGrbaN7A8QvzKcOi7kXi9hUGQxZrlA0dz/FPGm/+C4b3fgxc3yOjMES6wxFwtqwcLR0UovQ1VTvF3fpX2zW/SPA7E8e+QPv0paXdFGnb0N70xeIYBHRISFVKLyM9ZjQ3h/cjVp5fo9ddo736b5o5D3QWJAY0hb8IF6o5wqyPkeMQtfo5e/YDw5I+In3xIunmB2you+L2FajmLFjjCNQ/Bnxq5ovbAAGoqQdJASheQBgurDde0zRm9rCDlDmHz+GsWhGbAzxf0TOiWzwK3LST7j+SyfC1QLY4R9wri7uCaM5zvUB2Jw1PS8AR4jsqIljJsos1FJnqTXFlthwOWSPMllqf36MMV47jLlB2uXlMBhgvi5glu/YiYnFnZTgwOKz4Xs2HwzdLTMmUP0DX0L15AFBSP5HuqyXP1JL0D3bdYvPWnWLzxNTa0hBCtuCuvb6sQVnAO17Y0XWP9mrMx67sWHxxhM6K70fIPWcloHOjHgeVqyeKVX6L/4CdI/IgCY5ymZy5094XYBMPEwn2VwMZxSJ+xf3yWcJpb1Tm8VAW/HNxbNgp0bjWz//2KGHv596S+nvmMqnWRRfgslDCtt/yZudEw6fiXPOc0dgVRpDp/bboisyfeH6nJW9kX+J83xrePf2Chr6ofi8h7IvJNVf0h8E8C38///iXg384//6P8lf8Y+J+IyF/FErgXnx/PBzSRtlc4P+Lazqzt2JPiNlP/niCrBdKY9RXLfLhcuJUZesUr2gCNo1udwE4JVyPppoeQiLEnDRFp7ZoFbhclgWtxZ0e4eycIkW5xSSM/ZDj/LYb3fog+v0biFB6YJn6+IIomr+/Ya/4Z/vin+NfXyMOR8affJ37w+0g/s0SSYenrAlBFuODqpz8luddw/lc4evxl2geRbXqXcfMJqb8B1CxJ1yFNw6JtkP6G7Qc/IH70Plxe40eH08YQPQeoIjPKz/DNA7RZWeUnPU4z/4wmXG70obqx7+s1cbjArx8h3SnsLrhl4WWlqLOkl/2WwxGzDVeTYzlcZgp0ppggW/lrpPkqfvk1WByTMr22QyC9Drse3VxDphhGdqDXwGioIh1QNggvEHZ2ZveAdvU6gwaG/iYn6XKP3HKvgGogbp/RrY9Rf5Sjss7olZvO7LncbNt65hbhIKh0sHwV2q8g4w9BLplcfIdyH9a/ztE3/+vw6BE3QYh9qD0VcI6mtfqFGI0V1HlPyAJF1Zg77VYTrssFebnBehpHGEc09uxQVmcP8NffJT5/D+FTihjNd5tHfR6C2PMD7NW5VVzCKDK3fee0D3sLY/b7LFRXK8LLVfOmnqN96v1NFr3WeHtZz3OFNRfC070fCmebg4wEpFT7uuwpFlx4Z/+krIeCwIsIN5lM7/C8+Z6rUyKze709Gi8/XuYd/eJvwR8fvfOvAf+XjNz5KfCvYLv3/yoi/yrwDvDP58/+3zG45o8xyOa/8gvPrgrjDRq2pNAi3cq4QMbWyvzHgIR7yFEHjVqnN1cJJMElXDPi1BKJzgGMqF/h0oLGNYybTU4SRwxVKOBzgrdtYOmQtSBdBH2X8fKv03/wR6RPnyOXPS5my21eEScxW4Qw4YlLjL3w0YDjE8Inf41x+1/QrIS02cDOQTgz3DhbYMjeg0PTEvQVs2jbRyzvPGB57wSW77G9fo/+4gm6ucKNO9CASkAlogQ2DKA9DD0ucwrVJGzVJ1a8Yxurg8Uxzi9Bcpu9tCGlDZp6jKW0xD2NcE5lRxxfEOJ9muVjwvAESdd27uyMT2s1h7hsoqjhJJ0sISDXLuRtO7kB+YcHVrjmq8jxV0mrM1LbWsVxSZwq+JMlzeoOTdORcsVkCAEJ0cIewwb6DfH6fdL2XdBzfPeQbtWxGS8pBVt1Y0q2KQtfw7AhXH1Ec/yI1NwjumRV5K2izhu0N1vi1rIQxDWItOjpl2j9P0V4/wS238fppyAJ1fvI8a9y8if+LOOdB2x3mllVAd8ijeC8o4CEbCZTjgY4JBltSSraMiSMGllwTRa82SigD2hIjK3QPvwG8eJvo+lZXaf7wnDqQ7vX1yArlwlHP58nmIfktBKDzbiXaq1GEV4vF5Ra4K9SzzZ7b1IGFEh2XjtTKmie5J9AmvU5MkjAyhBMSasU5deY58wxIg/BneD8Q5Cjei1VQ/2pjmh6gupT4FNELxGGvHYmUIdMMST+3ix2rWNdC5Lq926jf152/LGEvqr+DvDrL3nrn3zJZxX4H/99XgGXoXOaO1LhR6TpcqdCTxxa0nAGdxu0VVwTERnxfkvrn8PmXeLVNWk8RnXBcPkcH9+iO/0a7ngF3YJxYyEjnOCd0C4VbUek2xDlOXG4wt0skN05/fs/hCfvwtYhwVlYuy42zUo7/11jujrT5Pn3QseQtujFhvHKQgeSznDyCs1izahPicMzUIfGY8S/Snf2Jv54Destyk+4ubwhPLlG+2tkHPGxR5IV1cQ0IORq4uICZ/I4Va0LEIyDqHQpUhTnAt73JJ6j8YoUN0bLqzG7pR60ycjD4olEI+cK1/j2lOjP0FS49feCR+zHKufw1LnLtL+Ab7Ee4sDdRZZvIMv7xM5QSTSeVCp4UZLzRDfSO82FUQ1psapWqUv36cSzGL/OeP6M/uk74HYM8SJb6ZJx6nPBJJN1ESPp+gVjDDSngaY9JfljaJa0SxMiaYTQi1GFo7i2xfvWek2dvk77+p9hfN/B9ncRRnT1DY7/a3+G+OABuxtF+zxP3lssP8vWqOT5JKPWbNxSVAxOKUhM6DhaTwg1AIR4h4jiGkFTRxoD46i4xRnS3ENHg9kWCOtkMZe54cA6zSHWWS2NjX4R/JMHU89TUHGimECdhU3mHt+t4yUCsjgGM0VxGBy5/QXKl2YvTY1R6rOqQ/QY/EPEvUG7fgvX3TcDQ1oQzX3n87mSGBPuuCENN2j/DO1/TtJ3EHmKEGY+1MED3Lq/2585BCL8/Vj58IWvyDVNWzan5mpY4yPvjN9kd4Mmhz9d4QTjmAmXjBfvMp7/EH3xHnrTI7pmsTzC7VaE6yXhTsfxt+6wOrnBp0uISoyKGwKp34C7Jl5/SLz+iHjVw/hNlnfewG864i4hAUt6zuJyecYxIZYFa15Ue4u8fsK+55NavFcAjdAEmsUREIlB0XiE849Z37tHc7plM37EcH4Jw874dGLEpYQQEN1aUU3qmRfOmME3WT/Tpsqu996aUTTtYHhCUoem3oR9vWehIFHqqXIISuM1OlyiboFrz4jjM5AcMqmfnr4o1U0+WOQVejYfsWldiFoltPo7sHiIdmdI10DjjH5a6pbNayflUJSDpDSNoI0phiSwSwFtwD16THvvPun5xwwvfgy6MSGMxQtFGvOCspKrN5UU3W0Z00ewO0dOHuFYEllaIRxCu2xIrSfsAlFcjhY1xG3Enb5C+/qfZni3Abnk5Jf/G8hrj9lcqTVhRyZWWQFSIqUMGigC2eUeDonMwZ9MEYRgayXuQI10T73DO4cTh2s8o7aWGhCPtA26LUGRfWGyv0zyapgJ6H2WATf7xhyG+DKY5lyU3xZg+4yXL//MtP8O389J5rnRsBcemuPwZQrRaEHTneHW36E7/Q7J3yfSMmpAXS5MzLmcvSXuBNctcYuO5ugO6eYh4eYNNP0A+CPQLdajd6oFuCXoD3SAKcXPC439vXgK/wgIfcOq5y2varTEUdDYoE2LHDua02s6+Qi9jITekcaIPI+kixa9dsi4g/iMwXvgWzjW+PWKOLzH7ue/Q3h6CbsO8ccmmHUHaUPTX8PwHAkJlQ24QNMdk7Qx6zkzZE6cF5nfnNY2Y2UA1PxnLvfXEicscFPJk6oY5cILhnGF+gX413DtHdanS9Q/5eriE+K4g6SV6VM0AFZBqWxzGb1VUlZaatWp0EPnI7wvhIsQUR0YhzF73VPyyv7rp4R1sW7y76oDabzA+VOcv0N0d9H4KUicbTopM1p/n84/K7IC9gXE7HPaoOlVWH6bePQAt1ohrbckqmAWrpRqT2bIk+xpLTzNskXE5b44aoXdTojB0R69CUtP/DjiwgtQiNIi7QrfHIGsCDtTrioJUoOFmxpghTqH6pY4RmS5wi1adCHQCXLcor0SQ4bHJiEMjsW9x7T9t5HlSPPVL3O5gdSHzJdU5ihZY5VCFJbXmTQO5y10oTEX+qRooccQIQz2LzNxOpeVRNNCs0L8AlIwnqm6LifkyyHmfTJyQCu9cr7FOn06M0LnYYgJsGjhOwUN01rTeYX0zD+sSqZ40Id49sP72/NDJsVRbmvSoDMjqOQTHCpLtHmLxZ0/jTv6EkE8Y8zMqArWvKOxUB1ugqxmzyulkZQGkiT8+i6NXxE3K+g70B+BnE/X36s4ncP+8v3vdcWaeSm3lN8vtvq/2EJfHcoaswQ1w968KQJ/Ascdy9evaI5+zO7JzwifCvSntItHeP+I4N8mtJLBGltr4+f+iNPXjlk+esqLiw/RD57itgnVNdIucOKMzVAVDQ0udkjcEeSaNHqa1X1rTJKLXpxObULmWNspw66z8u/Smm5mDs2sJFuDI0kvSKFD00OcP2NxMjLIJ4zXz2EMOAXRhNOY8dQ9SXckekgRyXTJU1Ui+dr5cntIjBkaoa6VaVGl/F1xGYlx8BmZPYPFKkc0PUfDKa47w7cnhPTCrj+ztnR2ybqWi6c9f+HWmsDgkel13PGfZPHqt9k1gjpFOp/nL+UKbJCKIBHLWeRxD/1AiCGzjeYTtw5ZtfjOkQaPX7+ONgPxvZ/gUqRZLcC3BBp8dwffvUK4vgYV/NEJ3ckxu22PhgGSxzXLCs5TFHXG/dQuIeyEeA1pl+c+wRCF5u23OXrdc5MccRthBJfcjGosC7ZUvEgTNhUJm7IXGVOuj0hIDLnrmwksUTXr1BlzZ3Rd7ujVImkA3VC6C+0p4Jes2Xwz+4l5mQuoMrGH++HQap19pibrX265TjHx20VP093OeXMmj2W+tG5h2uePyhJZfJflwz9H7F5lp4NFEXDgOlyzwDeL7MyoFS46N51EIcVIiIEUAikONF2Ll8bQtUOE9EPEXc/uv3hGMvt5cM/zLTi7YamJ5JcO2d7xxRb6rkUXb1BgOAoGhesa2rMef/99VH7AzXu/Dx9c4XdrRE/R5jly1ONWr9EcfRVtj4gbD9t3ID7j+uP/jM2zFWm8A3qaJy0g9LYj84SJKuI68AGXerTf0bj7Rlgmw+SSzUbaiNOK8C9afBL6+7Myt6LsXEZ9sCONN0hzQnfsSXrFsH0G44CLglOyULeiKNUeLQx8qlm4lcTS4bXsv7VBdHl1kt71mP7S+Rrcu/uyLKcIZcSlazQ8Bd/imiNkXBhj4xxfDxxGNSddM7MKyyaUjJ7QBuUR/uRPcfL1Xycedehug6rStG2WGbHGV7Vu+lKENbNeoylH1ygiIUNiO3yzoFm2cOQQ9yr9zQ16eY34liAJFY92nqM7DxnHR/TbAXe8RO4sWDZKHHpiGlncPUJ6ZbyJpBCQ0SPJunTRCLLK9t0ooEIadvjXOoYjz/BRhG3Kz5C7naXMAFu5bqZGIxoTKXcAk0K8lgaL46cs8HMTGM0ssZqcaYqkFmrqPBJ6NF7P5nTuFs7mS9l/r/z+EhbU4snWZVbj/geCuKypecV2VQC696F9IX74GWWiUCjacP++92Wjzn44kCPc8qusHv8FQvMmQ9jk7dzhGo9vLIwWNdOWl+/lfIA4sQS7g6ZribEjDQtCv8U5oVk/JugFOj4xBSs62w9z693GYa4C6zt7D/CSMfqc44st9JsW/+ojCx/7CN0N0m0R/wzPDwnPf8T45B14fo3biCUa5QYNFxAvIV3hTr6CnLyBb1cMyaGbnyDbC2QzWjl8WywONb5zt0BchgGBldO7JaSe2F9CuI9fnhE2l7iy+Pb4OoJt0BoSKayURgh1GzoGUwm4WAl/Lt1v/QDpBePVp7gwWakJQ9+kkp/VccKta2Sikj20hCYxrQcLazKxXyLZ1ZvQdeV9P3vbMQHiEpILojQ8I7kO397D+RVRL/PJKq42n+dwUds1REBKpyRSfhSBdB939Busv/brbE6WjGmssfngm+xEZeEeTVlYbUSi5A+0kOdpsvnaXKDDud1S25C6JaFbIuszmu6U9pXXGHcfkVym/2gUZct2eMLi+IzThyeMMbAZLnEnHatvLxmXS6P0/gSrch4jbAIDDW7XgDeLWJ0Y8mwp+KOO7sizuQaGVGlFzDEza5HaZN4qfFUUomDtLJ0hcxzQSP5+tvhTgpj7Q2i0hL53VBZYEcRFUnxCSlfIHHgATFZonqtKVHZolR9Y7/VweZml2Vqbv5/X1h765uAce55GeWmeoyrG1v5ZTYcUeuaZATa7T0vUO4Nor77O6vX/DuPiLUIYzQhplzjX4FCSBmIYmbrXmZVvyfER5wbQHchI4xs6WREWK0LTEW8ikTV++RZhfAb6DJXt3i5Is05nt+ocqsIsr8/nwNdzfN7xhRb6rh1YPvgxyBbRCzR9SLx5Rrh6znjxKXp+g/QRN4IVEwXQgLBF4w0pXBHDJe2dN5F2zdGDX2f77C7x+gdovMBpxCVBXZNdzgFNA+KWSNNZLUDMCUsfSemcsHtIt3yD0Hycu0PNFuJksDOJ1ZRFXOH1VqbiFfbWvi1QxeHwDTj/gnH3PJf6lzCFNdJOdT/m11QObuJQ67/kNZGs3MpGdbf24rwAalqCB8phL97osrXWk+Ilzp1gy2yOlWb/+3XQ8j0KaGlYLvufV/eA9evfIZytGCRYLLtZZFSS3YpzpixUipKxnzWxLi43xAGviXRzjV4/R3yDazoSO5JfIGuFewuWp3cJd0ZSv0PcAGow4nBziaRnxH7NOHorGLx7l9hYmVfcJituVUHHRBx2sPXoqkOWDbJq8/ALtEpz4o2Z+TrCqJYczNOU0oCGXbbWs/Xqytj7LHhMMZuHypTfUKVUAltC2xSH5AZCKYclGj8Sb36CG+chB3nJ7/rSd/dfnSuI/L4evPAyIwMoVbjzs07hnMOgzNxK11vrxapXp89W+oQ9fvxiaLTQvcnq9f8W8fjrDOMARGhanDdSxhh6IzAk2HZxxqvknQMNhM0VYXiBxktgIPqEbx3N+g7L9QmhWTNeOTTeBXkE6RTRwZQS+wDSw8E9VK8vG+vJoPrs4wst9HU4p//xf0AatzBsSWPuSDSSE7oe0Y5bIZMUUW6QIaHnHWlcEJeO0ByzfvBd0snbbJ//EWH7HKe5EbSoJeQYEO1w0lHimkhE3A7Rc8btDcfHX2bb/tDuZT5NgllvUpamWRR7YZKswQ3nPfMQyoSrxzlwbkccN2i4yQZMdsmr6WIKYqZjqNWlzDfYrVEFSqGJWVb7fWOlPAglJFJK6/eFtn1+4kPXvbWnRCReI+45TncvKcI/VELKlN4r957HSwXUI3qCHH8b9+AhO5+FQevxko3ZkGaQQbEKVZeFvcuWaSrInhw6SQ5CB6HDehy3gLcG5gJxo4TO4+7cQW9eIP0Nuru2eVGD+FvzkSM4bmlih16B7yD1ziCaUWGI1lBnNMtck6BtY0CgvEc1we4moRuFwSZRsIfTaA3ZbdgKpbHLLM7lWbODqWKd5RoHyRsXlcUdwFuxn/PJBJV3xKaFzuPjE/pnP0B0ZN5sXPeQN9Q1Vmbxpcvsc49p3m+HKaTmfmQvgK15fc+TnMWIymuh0E/L/GyHx6GQLK8K6td0r/4puPNL9KOF/hCPbxucCCmOZrg5cDQ4te5njoGUkoXYhgS9wOhAE4kNSXrGq2e4ozXd8es0yxPCuIDmPvSnKC/2jMeC0tmLCux5N+UZ8hjVBXR7h77s+GIL/ZAIHz2D8QqnAYdNqlNDSggNSFNdO7PkpqYJwhbiM3R3H+ePCMMTrjfvsjj5Gve+8ufYXj9j8+n3CWGL+ACoJUbTBuc6lMxEWV2oG8btp8TxaxaX270wy6lOWCkysgWq2bLYc1trgomZpT4XgBFlJIZzItajV9TVe9B5vFtK+Cifo+LxS/rw9mEKoljA5SZyDKHej8/Sw6SIq1zu5fNTabxZ5XMLnWxdJUO2xBco42wH5kKnPY8kh2MAi29OsLui1kwgv0bz6ncY1x2R0UIknppMy5CJaToKbNPNxkwVRtDUIi6gwWHUFieAKQRHQ5QWaCE6YgC38BAC4/U5DDcWNsFouVU61K1ouzPStiF+DG5hnHZ4Ycysm6jAkEghcxetPM2itSgTMN6QBb7a+S3GRQy7TLsQbGzFFL4TLBTppDJciCu5LzHrUYyFFWd5HJ/nXceB0A+k1CHLxMIF5PwddPvEzlMtRq2MoLciDQde6p60Lev6pdrgAJFVDZ/pZas9EETmjKrl1/ken+XM5h6nZKU4s/yLsVV5mYr3KAI0uNOv0j38VXpVNPSGkGs7nIeUAimOSI7hC8lyQmkghB7VhGuP8O2SqCNogKFHks2haiDdXDCmQLt+Hbe6h3ZH6PAK6AfkDlD5TufEafPwTRmn4gnN/83n4fOPL7TQRzyuOUKHHSmOWTBY7FKkmDU+b/I8GEp+vaBXrtHhE6T9Ks1iSQgfsnv6lLB9ytHjX+Zk8T12Lz5i3H6CxhvQkZQCjhbcEkkNSsiY2huIn7C9/BKLu99kvHkf+nOIWfBmojXJwr/g8uccG1p2eJ2sPfM4/7CWg6Vwan8ii5AUZoxQs9lOUCptX+o+FyFqwvcQHyz1M8qkaA4n5mXqZP+1hICMaLrKHDfzZy6/6+3v1kK2cpbyvB7tHuHO7jCWyqTGlIe1+bW+xTHFvD5yQEBm5y2KxdkYKcmSmHKEtEtoleQC0IBvoVnipEWT0siOcXsO2x2MgtDirGwbkTWxO0a7FWlUZICwTYgTmoXA0sEgEBoT3M7RdJ6mNW9itHy8eQSl57GV7VoSdixQy7x2cpc1Eoj2OU+ZzKoPZgmmsYftJcRrvE94EcJuSxh7O98QTDP5NYpDwwXh8qegW1u32XBIe3H7InDcZOvXXgafcWTTexLZpWscs3ku66FcZb5fZmul0C/IPiWxCXyoFb5V+Md87WZvlUkxbKrGErQ9YfH6n2JsHzJsBtBgRIyNQzUSQ4AQcDFO46NW9KZDj7iGZuEJaUCaZMaoLtF+hExRzRhJekWUT/BNR+o6opwhNBO2Lns5Exlbvt9qlM0NxKIYD/2uzz++2EIfMe531+b5y5pf22wBuPypgmQpUlPrGCkD6DMYHuO6Y5wsUH1KPP8dLvvndHe/S3vyKm5xwrj5lLh7jsaBoOBZWbGP7hB6NA5o+oRx+xOWd77H6u5vsH3y1yE9R2nMGsXuseDyp4kyIa5VQCsTW549Rb55jBSsLORi7U5LtvqwewVMZXMWtr45amg6bG+UjToX+EUgZ6V1oAzmc1IVkRZLZArelGSZYALXaCAwPHqxsoq8eAmu2k6q07hlb0YlIkd3Yb0wHqBijSbNj563SQ4LVFx2VbL5vhpwjScNDqcdslgS/Gg9kgGrYjXr2TUdtA4dR4abC9KLHoZjkAX4BUm8XaP1LO7eo72/JK4cQ1BkGPFtizpBVsJqvYLdkuE6EbcDadwxXt4g6ci49ItMtz7oBjXVSIqZ6yj3Zs6ln3kZJHQXIPSoczB4Q0y1K1xSUuphPCfFjYWUhmiJ29SBP0YWx7j1MeIH9OaHhPM/zDeg2WCZC+cJjjytM617roQIJ892LohmRolOa3JGwpCFnk5fKecrL8nsuxqnRLPOz7+/NstKfFlYEiysKaiFck/ewp99m90gEEcLlzUNaCIOPTL0aBytBFFB1aEhQvC4Zk27XJB0S+qfgw40zQJdLM0hHJxVpmsP0hOHa8Rd47oHJHeMxhXIlgJFrf0/UEzBToRw0zEPdc299PnPlx9faKEvNLhmRXJNrowTkA6ZU+cSUQ0YZHGyJop1rRkCSTyHeIpvjgnuKcIVaftjBt0SVl/DL16hPXpE050yXD9DU0/UFmmP8zXPSUOPhEs0/oztxVucvvZrDNsPiBdW0atSWiNOtyLZqlYpCJ18i7OFvT9h5QXlNu3AoSVePj25tZUUirwBZ7HCacnkTaKzYvCZAioK8/ZCm+5gpqK4hYSo1MUyi7HOF3L5dzvSL1o6PdmilhLOkIRfHRsqJQ0W2smKE00WU00Fspqfay54nKPpWtoTZ3zyNyOxB5/pELTPjV5oqPDOQlMxKmnroX2EX6/xqyOkbXHekVIipEDwkHojBnQK7bKDVhnGDU3XMlxf2fWaU7rVkv7qBi63OOeRZoEmn6vN46QXU0JStB4P5V/ZB1khqmChnxTAO/xqbXydsYdxC9cX6HiBSovjCHVraI9J7QK3XNE1Izp8wPDJ37RCRB3zjM8NieJ5zOYrC1uBWQFgnv/ZGpyv0zoXdXXNf85XcymkmjwLme+Xct1blu/83SwU62eYsOzzvSOC+o7Vg++S5EGmqwi4tjXTKUaraE5FvjjUNThtkcZ6FKQ00G+3kK4hboGRpAFZLGi6NXHTodsO0gaCJ/U9yW/wzQDNCo1HqF4BgRqe3fOMc43LZ1ryZR//vQR3vuBCX/GIP0OaczRssIfqzNJSQAdUB5TRsOkws0rIgkzMeomXpNDTdEsj48Jwy7p710JH4zV0D2jaU5anjxn6a+LQIs0xrsMonccR2CHylLD7MZvLh6we/mmu+yew/YRaEWQ3MnuOwwd7uSCdL2D77zwUdPiN29cpC7zaUbWysQh/zcCJCWJ5O9Nf6CNkb5PZUaoG8wKrl94X5nrgvrs0WWKavYiJ7rYcxl6p1ZLNbjQJTQ4Rb3OXoYfFAlKyYo9ZqaZ8f2L5HteYBC2KJG0DYfuC+OIK3IqwOCWp9Qz23lodJsXI5BJoSDAMSHeCO1tbC8JKh5AhtjSIqLVEvBxwztA2KfY0S0+6uiA8ewq6ghMjDhSHJXnDSApKbUye4/jsDb2awI/R3nMZUaZTXNuJoXOkH4njhhjVSNZ6NXpuPNp10B0h3RHSrWjaCOMHDM9+i3T1cyZ3w/bQPCQzraGZRXN7Yef/Tuuhyq69Byr/HPv0CreF2pQXgwmu+JItVO9zfpS4fUGfzfbNfO029+lOv85mwHoVxwhNM7uOWO4EC7M450FWRsmRFJd64uY5cXsFyUOKpOyyNQulPV2ibUPYLNBhAeGcNOxwiw3aLKA/QfRT9sNX8/398qKt22P2WUph//hCC31EwJ/immOQDZoUocuCowfdkrQ09LCvzEMWIplel0TiGsZLVI+Nw0SCibsUSf3HxBjQdAHxNWjv0rYPcH6NrBt8d05/uUFjjyC4NJKGd+hfvEJz8st0r/w6w0f/H2ToQY1F0OzQKbY+5XvnC7P8PoNN1g2iHC7a/bGhhlLsh0y/I/OtydzqklKtCkxFK3Oru6S7HLU5+K37FZCYXXJPQSpprQKedua0/e0ZJGVBVT0PmbwM8Xh/hmNNiIaHBrOAlLsI3qyumOGHsQ4YpDH/S3Y+30G7YrnscC1sNgM6bpCbc/TFe3B5hXT3WD9e0KfIOHikWyAOus4ZvD0m465vGvx6SRIhVqUCmYrRPAKHCQEa3A0tRwAAhBdJREFUUorodgvjgKSG8fICrgfAwzoiraFmGMEn/f9T96exlmVZfh/2W3ufc+69b4opMyLHqqyxx+qu7hbHlghZtGRaMkDAsCXZgEELMvjFhgF/sgwYoGELBg0YMAwIkEFAhEl/EE0LgkSBkmWKVJMgTbLJbpJdLHbXXJVjZIxvusM5Z++9/GHtfYb7bkRmd9tA+GS+ePfdM+1xzeu/CHEH7KgXJwTnRouUMtFYJDM1M2WKt4RFR0CSwSNrv7Ucj+YMqVYWflqforFH3QLqE2S5QpZLnAfCFd3Fd0kXP8CFazTFnGleioxPCHf2T43hlLYujemWNZRt0YNpxo/rQEpwgTIVNEZWUPxgZYUlxqCMsgYnqJ6zo2ifOlwziE4yGb/JT4leU1niz76GNm8Trvts2hG8CBoDKfV2S1XjXIW4GnyDUpl8EQJeKhZHx+zSEdoFCA5VizIMscetlHq1om5OiZsjUntEiltSjPhFQ7+7i6QPJv0tPcj78IXHVHuejuj/H5t3wCH+Hqm6Qqst9DnBQi1W2gj+1Gk5ShAUDPayQdMGwsdodxfv0wgrrBXCBsIjtF0T0w5N74J7B20qU9OrvJizdJqkR9IzUvtdtk/f5PjNXyFtnxOe/TYSerNfy3TwZSaZ7JtNpjb7YbpmuOTlzES6vsHU5+rdaPIZb7Aksazy3ihoNsp1kiVsmcLdFmaUNYbRyZwo0RRzKN55ytZ4RIrZZxaujaMUMfELR+Vuk3RFCK+hISHuLuCIXYtBOVvUlqKmescthLXhJKkgiyMSQug8XmoIHXH9lPT0ffT6EdK3sN3Q1Ql/+gBxtw2eJoC0ku25iqs8VBVR9zOYZeTHlRjo6LD/PI4T0lUi7iK0HroKKssDUHIUlnqTxrstmrZQOVx1Mha3QhDJpk0Ri8iJuUiJJghbSFtiXxieRfeoWDSWNEtY3gYqs1Evj/HLBhogXlvC2fUTJESrCZGle9GCilrW5LiWp9njOs10nQoOE0f8QHeHqR4Fstkh8986uXb85tDnmW3pwJEmC82CPwaCj0C1YvHaN+nCMdpvAMVXtbGP0FsinxO8r6Fq0GqJSo0ipgXGQNtF2HaZ3yxwlcOLJ8ZofHoXaMMa3xzhj5e4ekHfLokxUFUVzr9OSsc4yXUpZlK+Tkb+UF/TgZ6/XOJ/tYm+CnAbV70GzTUpPUNDi+g1SUuF8yk1lflvYCw23aH6kLh9Tt14XAncoKiyPS6uTaKJFTQPkKMOpcMlwXC0GyA7uqTFpY/Qi39Me/xHOH7jj3HZX6Hn72cJJ46hbzd00bKJ9he1DOqkHdNNlSXlYf/NlNXJM/dDvOYhbyPD2d8485aMW05vXlPi51GTuA84+eyOqSZTGMaEeOp4veQQ1xA7wu4aqZ4i1TF+cUq1OALOCekpGh4AgmtqHI4Qc2Hyfgfrc8uqFo+kiEPoY09fLxACVUyEtoO+x4UAek3/+GN007K4K6xO7tPj6ftoFdY04RYrfCUDXj2o0Y7aqrFRftwgiNtQLCucP4NtjwRBU4MsFyQnhJCLoODRPqLdFsKWWF3iTxdEqcZ0CefB1RZ2OUT1YP1st2jcYfg7DeIW5mCUBlyOyT86Q73gSfiVw1UbYtgSthfo9TPoPY4VImtUd3l+y9oskTFlX+W5zeGQFjJdKLpimm1gugYHJaDg8E+I+s21NxXe9mTWaULjweNQ/upUCJlqy2VwK6qzr1Od/gzXO4UULefNQYgWQQcg3pBHaWpiLkGJc0gUxDWW49NvEV2AGOCjI1DViYQjqUeDEGNP8hVVvcTJCWm3M5JdHSPhBOFTVPq9cdkPdhjHexTExvMvJ/d2vNpEH1AxiF7iMdI9BXaI9nlplIksCzSTqmnCAuUShaRo2NGnfI2zsC0LIcu4/dHK0LllxC96Urxmt3mGtorjGDKCpY30Bvqf0H66RJo/xvGDP8b1+r9AwxohTtZ+wkkJfyvRDaVhhfAVVW26OIsdMV9bImB8NvvM4FzHzNP5QhgGEqgYo4emKkO+eMjOtY2dAFPNZaIYTLQXyA7qHP6mJRwvX+wsNt34blG7s4RbiEfpe8qsRtSgnEOLygUqjiBijkhXs0hfptcFIh7nKnxQUkqkbgftziR+53KdWCH2OyQcmWQZBNeckDaXRM2+hl5h19JfPYeqpjm5g/MVrSY02ngMOoyzpCffCNLYcOXAITTXzi05TSmBaypcVeFXC8LpEU53eL+mrhyc1LTXjtCuM+xxj242aHWNVEeIX6C+huRsvrOWKU7Q1JuGQG2JQlJZdq1zphX4muQqSsGUFBNOr3D9JXHzhNhdIWGB78/A3UNdZ2UwNeT5K8S5rKn8M5jr8jpRKwlpZq6y5opWrOOyw7RHmfhhhrU0QGCXd1CiQCdrteyNffTNqfAkszOzvTB9n06i05a3Wb7xR+k5I4UNpIhrKgsEyHQAZ/G04oC6wlU1vqmpmwoipLYi1UqUJVUIxPaKeK2EdkOl1wbh7Y9I1QlRKzQpfYpIXQMLC531DSJHHD5GoW0u0M0FrPk1Lz9ebaKvCUkN1PeguUCrR0h/jpGOnGRSVEjv926W+cdBiNhfLFAAj0QDSAsSqKTDx2u6cEXchTyWDieVhSGq4dcrT6BV2od3qd/5KssHP8vu0T+C0N+Qn2VoTDmKY3Q6kfP2T0mzDHtk1GgEGTdWzo5NBZQHGLI6BxjGEgM8l+fN3uInz55qGXuax7ApYSyGYuNZEoeADCc0xhFrLkOJnubre2MA0qNcAylHgFfm6M2SrYrinEL7IRKeIP4Nkiou98clIOWkJw2AJ/YdPvbQb8xO7RekANXiDmHZkeJF9hk0ONcgsSWtP6BLH+BP3qQ5fp2+syTAlB2I0gjV0ghvn9SsWi7DFCtWuKQw9DTOrGscrloSn14Rnn2Ecx31yT2a5X12m4TEiIsG88BuZ0OyykS89kBj74kJ+mQmB+8Rt0SpURyKt3HOabkqEDXhvUPYkHY/IG5+QNo+QVRw/i5SvYfUR0ReJ7Vmz5eJtD6YFXLk2ahXljrBOkD+Wm6cCS1SnNF5rYxLdiJ5D/a9vM7VVuYotBak2pIVP1l/N4jdeNyUdGXvs7UxuYr63jdxt36W7S4Y7HQW4mPoIBh8ORpx4ojra0gr3O3XiUGAJaKJ2F1DfwHpGV37CJ/Eoq1CIPVXqO+hukIW1/jmlORukbJ5SOratFTvSFTZZNm/sP1zHWjS2QE19/PI+a860U8t7M6p6tfQxVuk1ado9xQJBlAUS0cFhkzF2QMygRtMjTIRSsqicqPgjeYU9AtIT0mbZyg7Gjm1KlD+HI0m2QzVsWhBH6HX/4jto8jpW+/Sb35IvFxDLJALN4n5/O9DKu7UgSWTjcMoPg3f5dYPal9Ry4GMpmn3T3TrSRbxwBOnmas32lXGc3pu+lMQHm1ODAfHtAtYoHoCctcyX+v7VnTeeVQ9mjZo/BDChsQ1wiU4S5QzCdEIUGofES7/CfVrt+niCckl1AnOVyYVO4bkJg3BkmG61oDpFg5oiLpEFvcsUSpEqsrjalAuSNcfE59+ilveZfH2r+KrL5LSiiQKlcMvACeEqCVPkMoLvjLmFrN5JxZFMFcpi8nhvKM6u0varIlXn9JuHrN4/Ra+aUg7y7jW0OFigNgazPeigkpI4tBOrLat9pb47Yp25ceZ0rwr4i5rHQ1eGnR3Tjj/HuzeR0KLSEWqdsaQq3eQ+gTRd9A2YolEGwTD3R9gLSbrrKwLy0dM+XNheFkiGISWuZBjORQexKM6YlCYB6hDaVE6SvLgEDVUMsTzAh4ZxAuIXXGw7G+Vcm11zOLsa3S9J3ZbI+6VI2kk9btM9IMJGxHi7hL6Jc3pkiDQtRn8bnOJbJ+im0+hf0jd3MHRWHy+Qkm0JFoZRbe0cF6VxqJAXTSwNvHobNyK5jTRtGQgZJM+f35iX45Xm+hrS7z6LpX3uNNT3NG7pPYT6Dc4bUk6CW3SSUyuK2aSkjk3SigCBl4mjuRkIKC2nPK1+pTQ/ZDGV6T2GpV7rE7fI3HJLl5YhITm4tMk4876IeEKtk/f4vi45urcbMJmxi4rYOocK4S9TNpUign58wQ1z/mROBexv0hCk/BHLf0YFvuEqWmJBtpbJFkLmD12fsHk6YpKSUSbq/8jZohHJRcT0fvg3sGv3qQ6u4s/XeCWRsxACBGIDsI3ITq07+jXH5M2H8Lu+wgfg3S5YS3d09/g+OQeevQHCNGKvgcaiCfgV9D3WcgMuGhFZrSPiFfUW3ilW97DycownVwH7iHavk/cfIJsn6NXD+l6aB7U9KsvQe1wC5AKUlADV4ShPm0I2VIo4CqTctVB6pOZYaKSkkeqmsXbXyI+v0v7+H3C9Ybm6Iyuqkkxa6wpIM4joUP1KdVyR90c03dWo9ji6GOelQKHUQQQwceIpvOcQXpEqm6hqYPuGgk7UMtroe9IRNAev/wZ4A5JA6ntEP0UKxBvDuGRvOgYL59Do4ekqoEfKKNQ4ihIqmiNuiXKLeA+Ur2JNA9QWaAxEOM1dB+Dvg88Ab0C2WaCn8m7lPq1iSEybiCMe8t0iIibAnhbgRgVwR/fxS1eo9/lQvO5JkEKnZnb0g4h4fCk0Jvm3idkc07dCCl4C7ndXqPX57B5htNLvFvg6prWL9BQmBZICCA7lLWZrH1Ao7cKdXGNsEEnpi4pUVADpEoJ6Sp7OzPFYo4bO/4iJWg4XnGin9DwI3ZXW7z/OZZnb7I9eZO+u8BtW0Y7PpQOC/PU8SESZZJ8pBnfRdQScWYgIihoS+ofsouKpojqjpYVqyNHVdX0QSa3ZClEdhA+Yff4Kb3fmcQ0VAqZxK6XYyI5zSQQJkI4Ojk36Y8aTLBpNhM/wSGCPpMI5vb+YW1IkdAHtnJgMubnhk8y4amQiXMucrL4GotbX8SfnqDLll7X7LpHpMucdqoCrsb5bKNfniK3TqjvfZnUfgU9/ynCs99E2u8AFxieyTN2n/waiy82qPsG4u+TqiOTxuu70IrlbCgmOYnPUrFVtZJ6afbUpkE6QbsLQvsxKUNqSOyRJMQn3yXKA9y7byLumKrOqMat+R/Ee4gQokmT0YN4yTxWcF4xmAtBg0BQogg776jv3qZ2Qr/eEDTi6orYCSTDWXJSm7ay+T7tw29xfO8BvovE3TYnYkVKYppIDTQkKlQ9EgOxfUpKLa5+HV29h6chas0Y+CCWCNbvSDxEqlN881VEHiDqSa1H9REia9NoC/igKlZz2fZUmkn/4/os68VRkzgCvY36t/FH7+BX76LLd3CrY6Jv0Mrl5LMWLi/Qi4fo9ido/12EHwBrhC5vtUmm+cAM5gLJfK2O+2jKHEQjrq7ptSZ2FuYrlTcBMZhETurxXpCkEDrzA3TK9tFjquOdBRdER0prYr9G+y1JA91uzaJeUlVCF7NPy+XkqgycF7sN6qKFdocN9A9J8RmImbIseqoItFOwu0nfHUyzm0dt4MDW3TtebaJPRPQJ2p0Tnuyo0zc5Ovlp1kcXpP4aCSEvQJBpDG+RrjUTToVp5qghXGbJBc0E1DHGtySIm4lP5JLYfp9OlkjJui3PGwUR0A5NPTEY3v04ITlxRnVIV9eSOLanf87CAgdJjhw/PfZDC9GUqbYwedZBjU8PnMywzBPkPvt/SuRLmwu3yIXQhzj+IomZCQV5HX/ydZo7b6DNFbv0CfFim7MddfCPCBlWw3mSYOa05gipT6ia2yxef5Pq1r9M+/A+evXrwCOEHXH9EdsP/nPqN57hm19Gmy8QTk6Q6guEJ8foZgNBSbJAfW+x1XKUQxgrqDxeBWFH2l4QN9cGlxm6gag4vSZsPqaO13h/YmabbYQQzSyFmq3fwwxOI9mGTDmkU7xpoCV3MEWlc0Jz9xbVckm4vjBfUpkXEcTXiG7Q9fvos+9w/ew72EMtQ1fKvImAO8L5O6icZMIfIZxbiLI6onuNurmNyOkI1zRMaw5s2P6Epl5Qr36KIF8gaYX2FegjYGs+BDHNojhBDVAvh99ORAbzZB+T5IzkHiDL9/An7+FufwG3OiIIBFHEOVyt+DoXHUrgT+8g927D5j7h+QP68zto922QJ8bwB1AynSzjsiYnHdtjRqN2PVn1qcvO2gTeEq409WP2bYp47yxsM3YMZtC2I8QLs9PjqEJEYmcapTpC6FA2SPaxmBXYstRNQA+kbk2UzirfhXO0/yHCU5QWpwVloJi1RkY9SPV57m7u5+l3Lz5ebaKv0eATksNppHviWblfYXX759n0z9Hrh1YYAjVJz27iEPGbStOaVTwo9WVNDdWyWLQg8hWjS4fGZ3RbM5VIxiYnb0Bz6Lm86It87kDMOZaGaJ9CIO2zUE3aNG2w5lamoQWqJZuWgcukidQ+P4pKvT8AZVOU59sJSXvMR6FgtM8Zio7rcBpnnUV+TSuQB7jlF1mcHdPFTwmX1zZHgz+lpOlP2lUyUaNH+w58S1rs6FY9/vg+zXu/Sv/xKenZr0H8AFyPXj+h//FfJz77bRZf+GXquz9NPHqdxa07aPsauhXCem0BRFQk76lWgqtaUlyj23Ncd470HaIrVI9AW1TMBCICqX+KpktwbxB3QAs4C1M086sYfn0ZtlmEoM5iBqS2QJCUsAgOB9Xpgth60tXO6q5iyV8JwXWPiVcfGDMSHWha8XEoGaZDekvgdIrIsY1qipC2EJ6h6Ry4i9Svod0KA1TLLN0JsIDY0K1b0kmE1QOQW7A+Qdv30fQMq+7UIbIjShjaY2G2uUqXenBLknsLad6jOnmP+s67uLN7pMqzi12unpaoGqhcIPZrwrolhR0iieWyoTlROvecFK9p3Ju0T59AvMxsZcocx30iw7/TY4/o5603RHWnDj8kdhoZlKhWTzipGVbDjtStcVIBjZEGBEJEY2+wDkkhZZObK/lBvZmebZCRAbwu5C4ERBIunUP/CaqPUNmMWsygvWPEv4z30K/R1zIP2tZBAH0Z6X+1iT5QIk28XJHC99g8PeHojZ9mdeun2baXkK4GaX9GnCgTPAUHy4eMT2dQoZShIHNZGDnCwGhUhlIdkpGmZDJTQi1RQIxcOZXiCEWzKCap8t6R4N4wAc3eooUfMePsh/PRJ/eV/hdmVFbPvilo/hzVbEKYIfiNbLC8YrgrHSPuZ6hPv4gsoesuCN3VMFYq2RyVqzYNrcsRJ1beL0ESNCpRU0FWwp28QfPGNwiuITz6r0F/bNJYu0Uf/4Ttxae4u/+Qxf23qW+/TXV0D3/8OpeLJce3XmO92ZDqK6qwpbt4SHj2BNoO7XskBLx4kj8xyU8TSmtOyriB/gINCR0w6Q1+2aq5gbccrqGojdWflWFqZNy/oziiRpeDh/rshO55xvAXSwpT35F2P4HdYyyMsqwpi/bS8lB1WKW2DSILHEsSFcjSJMxwCfEZmt7GN/dI27vAOaQKUYfqA6i+hKzewZ08gJPXSPUR2m2RoxMafgraHaFNpN01MV4A5vQsTA+tEH+E1Me4kztUd+/jbt9FqoYUhC4GYmrNYektADaFNW27RndXEFucS1R1ILTX7NZP0W5ttUv8HarqASF8gEjHENZ5c7UeWPc3ryqnFCH1V/j0FOE1FM+Qe5mFEEHpdk8R6aG6bf6EAhmuiiOhcWPjnCyLF7FCK0bke1S3ZrYimiVBI05aRDo0XhJ3nyLxCmQ0VY9Evwh9c4IvGT34hlCncwbwsuMVJ/o2AKoQiQg92v4Wu6cNp69/hXDrKf3575A6c/iMwSmThVGsPZm47g/LoPzlJCMzujjGkMWyEpSC7TJE/kxjkTNxR3SCsFniTjLZlxzLXRo2Casc1dLpMRLYgcsrDF58Hc+Msk5hJtOjMJZRA5glRM6iAcpHl30fU2aUqY/k88WZFG/h/Hs0d76KLlu67jnar80pmd+vRDNpTZzONrIu24EjiiDJMpqV1mYnRlISOH7A4o2fxdUV3ad/DfoPgR2JgHTXpEfXbJ/9hK2vwS+R5g7+1i+wvXyHEM5J7UP6bYtuI5Lhh62+cA9UOL9E/euk3qE8zW2/JF1+iLv3DaI0UFl1qpLOYBGuYw81S4KqybSnGNCQ5zZ7eiX/q+ZDhXqBv3WfuNmC87iqxumH7K6+YxnGeWObEJMyM5msAzHfFGmLc8cGTkgNWkFY4+I5GtdUzV1C9TPQXaLuNXS5pLr781SvfRE9OSY1YqG+UWEDWidiXdOsTqj9ihiTQY6XqDXB5jIngbnakypPqIQuJlKfOygR5xXnooXFttek7SX0ayRsqVzChQ3h4hGxy6BjSYGa1PS4poGuQYnDKh7BPcpivSntl50+T0nMCVwKqbum779DtXiHPi5BXSb62ewaOrRfQyM45ywJK6lBXWtAU0fq1/iqwXln9Rk02fjQommHpGuEDb44kLWFeE1KV6R4Dam11mXpQCetBB3mexQLx1DsIUqu7O+cJ3GDhBw4XnGiD6OaY+YYx3PC+rtcV7eo736JvnuIxg4pNWT3er2XCjL7t9j1p1LvIfSaIqkPiUeD3p4GKRomklx5TpGuhy/HxWf36TCJ0/MTMXiQDOfPnVxTlrtOL0xj6yePH2BvZ0lt+XFDO0p7x/EY3gngip8hYb6KCnFvUN/+ErLoaduHaL+FlGuLlvcMPgwmGsJEB1LTIgwtNXtNtYUYScnTqyedPKC+/zMkUcInfw0JP0Klz64NseIjJJBIWkdc+yHpWiB+RNp8iKQKz7FlrIoHbVHdMAD7+RUSb1mWK5e4tCFdfZ8mXhDq+ybBDyq1MLhC8vgMooZikR19ssgQTVAZnIJIRQHm0wRRhOruPeLzS4g9SdbEi3+Kbj7I9l0dlsWwltNkHZBQ6SCtEVkhurTxkxWi10j3nLS4Jtav4U9/npA8/tbrNHdfQ26fEo8csQFtwFc5ke76mO5RJLSJ4DrcqrJ8AXHgZWR0KWPIaoY2l2hj5CxzwJWkvq5F2y1xd412GwhbJO1waU3cPqPfPTcfBEqBTFeUmDrq2iO+JkXLCVDZzzq9+XdZc2W9j8zAjX/3Hd3T77B858uonpHi0taEM8iKGLo8zjUqtc2bmJTtiFavOAVEKgPhG3wcAWghXuDSJc5tkdSaVpDWpLRFSFZ1awIwWITCIuQOlELGz/NIRCiO7EM+i5cdrzzRn3JqACQgPKZff5/67Os0x2/SbZ8joXvJQwrRlmGgytPH3xNjTXa8jASegdBPJ2f2CMZHFBx3kULe51HFMvk9paf7Bhc7PbKf/XNDAzLzkhLWlTHsbz50QvR1sgGECYEuCwmEOFlO+0uqUO4z6uOvwtKza5+g3QZRKzxu944FN0oRdWbPnOMSmXOYkbGmhIQNafuM5Dwcv8bi3k+hu2fEp89BnwzjZBs9+w5IaPcEXy3pu+c57ro2SAMRm1+1uHTVFsUkOlctQG5b7QRa0uYRsn6f5u5r9OrMeauabbOSE5cK4xzosDn2YoA+g8DFBOJJogbcJUbAYnC4hcffugv9BSl8i/D0t5Cwo5T/G6Mgy0AVpp7nPkVUWiP87gw4Ancb0pU5LNOVNepkiV/epr51j+qkJjTXRAFVlzFOK6Suqe41ILfoHlqFMI099UmNVtm4IFmrzi4n7wTEI96eo0FgE9GrlnS1I20uIWzRbotjg6Q12l8T23PoznN4pCXVSV6PSiCGDeKNCBMnzuIxvO3wUbZs8YdJyQUYtS2Skq6eEp7/Ost799j5rxLdAkTRrodYgT+1+gTVMVATc0a9VbMzRhdThyQPBIQW0RbRSzQ+Ar0gxY2Zf7RjnrFu0v34e7rL5UZnpn6JYbuU4jWHJLyXHL8voi8i/wvgf5Lf9i3g3wLeBP4ScA/4DeB/pKqdiCyAvwj8CvAU+DdU9cef4y3jLzUPueg1rvuA/vkZy3t3CM0C2hzTW+z7sv8MyYLaRAXMzyzHCEZmzjSbpEJKRul0ShinDqViFHTDw8nceeLsA8aCE25YwDenS6azy6BVzK41gID5E6bRPNMhnBLubA8e2lDGeE6QVee7ylAkM/aAeFRv4xdfx986pg3Pcj1ftcglLUVjhGKvtlb6MZR1IGTFXpJt25qzSguTjj10a6SqSc7TH92levBLpHSFPv/bSLrA8iVKljZYRs05sVug4QLSDrOStrl7aZy6tIMQUC9EOQO3QngNjdfQ7+g++DscH90nLt4hJW8EPAS0jURRS2oTjzpnELzJHH0D8mcfDCk6S4tUC5z3JAcalOQqFndWyNU/YfuDv4lsng55ICVrezb3Lq+bojmq9Vd1i0st4gX1x6S0RAGfjixBSBJ1FZF4yfrZ2gq0qJVSjFVNWp3gT2/D8giJC6hq6DurDBUafEYsLYCYglmtkppVSKMaOmrXw65Hr69gs0a6NS5tkbRB4zWpvUK7K4uQy/tjRvTKPKaYXdaRm8g6UwK5v3tkIPhzjbYIOlkz7BPdw+8RY8Q/+GVYfoPUvkHaRqjvInjUJZxvSCpWNAUlJQvpNByGKpsINwjnSLpE0xM0Fu2lZ3CwDtLd1JQz8ZENhGsSocSUPukkVFyGno4E///HRF9E3gb+58DPqupWRP4y8G8C/yrwf1LVvyQi/xfg3wb+/fz7uap+VUT+TeD/APwbL38JE/GpdCiikhB9Stz8iLi8R+XrbPF7AeDQZF3s89Hh9MBI8xWGIWDnB+46XWA2OfP3TRjA5O9Bop/S1KE9Mp3DyQXjM0ubZz3UsnwnUT177z/kGC5QDSWkdTYiWoimMEbuTBqsRtBVEqQG596iPnuX6IIVrdc+E6tpFALME8+mn6azUTB/ChMq8NRjWKj2O4JcW0z/6ozqtV+k376Prr+V+zQhApJQ7UjxiQkJGkkImusrW3aomVvMcri1fvsakRVUK2tWCMTnH7P75LfxX3ydwAo0msreb4CQtYMGdZUBZqWAhH6U9GNAk2BlGrPPRxoclZmvQ0LknO1HfxeuPsEVj2JemLPtPFsne/ObOtRd4tw9kFtouoWIUFd3aRU0mfSs2y1pc5WTkIKZbLwnNtfEi0uqs9uwumelIr2Z3LTvSTtv8+ELFhEQIPbJksvIU94m6HIxEgKiAe03pO4cuis07CDlyJnC9DVHv2H1ExDwrsFpR0ybHLVUdtNkM+NGiXk6RoNg4SY0JO+i/FkU6APh0XcgPKF+84Jq8S8QjlZErSB4C+xxDmJEtM1rvEVYg/QWBBA7XPwUDe/ThwvQLYYPViwDuRjiIMelPbpWEGknfRu03QPHBL5ipAOH1sfh4/dr3qmAlYj0wBHwCfAvAf/DfP4vAP8bjOj/yfwZ4D8C/j0RET0csnLzmEmdCrQQHtJdXOOrbkJEpgsiHxNJd9SSJxfolG8awQEGT/xhVnK42SWOfo4HfvjWdGiCFGZ2/uH7sRUDeuWNIiefccxMBIfuShNpqrRbZufLd+pvIUdfgdUJfftJjkWEojlN4nMmb7KxmQPl5R8pnlGzHUsBxCvSswgpqZUG7DYkv8Av7uHv/hJx+2NIV8yYSw5tTP0ag2IGkWCqNm2OtnCILHESUa7M0cY1UJGoEbcCp+Aaussti26Db2qQFs8FSa9IXUD7BVIdmzNYxIryhA6fYnZEp2EYxTmrhhUDJT9EYo/2T0nrZ9mOvz87N7XBUhJyNp8pImkN6Rpp7uLq+6DJyjpiJibtA7HXXGY2Oy+jguuNQXUtiuJlRWJl0q1G+qsNrouktbMSooKNjVYD714ta8Ml0oTg6UMidR3srqG9griGYMBus67tkQAzZ1nSXmrPs5aWJfUc9DBg/8AgrMw0VRlJ6eH9Mah5uKDE58/p47dYvHGPprpLqM9Juia5Y5BTUgpI2iBxg8TnpPAxThyOO6T2nBR/DPExkgyFdwCdmxTEGXawwCxAZCZcleYd2qdjj34/x++Z6KvqRyLyfwTeB7bA/wsz55yrDrP6IfB2/vw28EG+N4jIBWYCejJ9roj8aeBP21/L+UunVgEUlWtSvyVG+7sMysSAY39pxThgytSkU5xGdt7wy60wcUB1KFfMPGJmrkp5LRIpw6IsYGGyd+2+FD+VSsYksvkiKOkvc+YzN+OUMZksrRwimadYlDHOudj082ex3yWbcr6wlME2SgnVuwX11/GnXySwy+gODRBQiROGN44xhZmWgvZDYlcF1PZbakRqJJuDpBB/zQ6vJBB78990LUkW+Fs/h179hHT190G7ie5g42UJs94iK1JApUXJmD+uQnWJyAmW1m/49LgjhGNUznBNRb1qSAuPXH/M0dmG7eVD+sunOcRzgdR30SZC1Vv+R99mSdYIpkPAVaQoaMoJVAiizmI+QyDtHhvBVc8YljfXtKbrmpyZPZxTLCckbSE8Rep7uOYeCUdvhnfA6r36qqKqajPL9AqpR2JAQiSllrSB1fFdSEK33mFF6RfEtoVKkZMF1bIhRU/aqlV2F+jXEV850vUGFxNNvaRjbUl5OeFJciCuECx8VzXvwLK/CphHjccT4w5JCVE/EW7dZD+WcSpC3bhPilQ9zRIeGULJnVFUF0i4Ddd3aD9+BHwP4lNwDbJ6F6q70CnSrZH4lNQ9RNNDg85OFRoeQzo3jWao75FfVUyUs20/+WMGWzEN24QZAN2wrssgTK0MY/8/z/H7Me/cwaT3LwHnwP8D+BO/1+eVQ1X/HPDnAMTdmjK5/F6MbufFnjQYsNmgHrrBZmxWwLFgOS7lDZcm2tNECh0EBQvb1JnDSMbrpm0a2nJD7prcoXvP2OfwB0eCcZr3rz18n9w444ZchenzivlkfieoOPt2rgRNrhEsMuQN/PHXcasjc2T5I1ugxdScemaLcMpgyIk8GaPHiH02j9CQ9enBzDvyxDLYySJ7wo5UN4hb0dz9BXabH0D4mHFcp1LTtCMJU9G99cUJ6ApD9rzG4t5PkOoOzeoWrt4R03P6tZpdd/uQcPUY2h5HDV5BukErUIEUA3Q7i0/PxF98gzSC+sachM6bmSwmnDsnXHzXnM06sm6Vkn1Z/C+lH1NYj+HqPHc9mi6Q9Axfv4n4Fb1UuGqBqqGXptjjPFSV2ZRDEBO+VSH06PqKtHzC8uQ+wVmU0fL2EXHh6eKa+sEx1bJi97yDqxbzBgshJAIRiRUxBFzEkECzBuhylMoQcDBsOZtX61JFkgrvVqhEUrrAaYZl1jiR5rN9PkvNJTj68KRPV/H43RA75gS/uouvv0LfH5Gi2DpzilQBaa4McqE7x6dPIH6MaIdzp+bHiucIGVqELN3DDZ/YSNz3Qkxnlw1qwfz8IJCNV00FPftxLycp+fj9mHf+m8CPVPUxgIj8x8CvArdFpMrS/jvAR/n6j4B3gQ/FPIK3MIfui4/JvE3NtVNJdYAy0DG0TTLmiRGWxkK9ckhVeeDUG05eiuMgjk8e/WUmKc0ap3bdYGMbduUoaczjaZl2YjJBU+Yyfcb0ObMbXjhc46cDTGr6HrUe67Q6Vm5tMTeOgU5ljCuQE1z9RfzJXdS3SEr4eoXhG2GYLq4GDRZDnxPcZHDWFkJfYbVlPc4fgV+R3ALLjBY0S00ySb23iCpLnFGNaOyI0iCrt3EnXyGdP0NoJ/0pvRaQ2vqq3vIASqH6pKgsEHcH5AGu8iyOjpGqIaZr2vYx2iVcdY8mXtM+/q6FKqYlwhJNNTR97nsyiVrJ3s3MoHLGptNL6qMjoq+IUoE4qmqL2/0O3fn3B9PAjVDebCIYtkCJIJpKlAMxjSTdkMIzqJ/j6hXiGoQaEY9KACIxbEk589iLOXNTUtOmusj26UP8dktz9wvInTu4e8d0dUdzdpvqpDLtWhxOllTBGdMISuyyj7M2BuLSjlRrhh7tsdKX5lS2bNM9SVwqxC/w9ZLYPzIJukjleS2ORo7iB1Jjdlri2JXD5kmdkFuliIXioK4ii+MNC7ek65eEbkHMdY41nuN0icYLNH6Mxic4OcZR0acrlKshWm22hfPclcANbtSlkPn2nBH/A1L7DemecVxmAuzLj98P0X8f+MNi6P9b4I8D/xD4r4H/HhbB86eA/zRf/1fy3383n/8bn23PF0s8QQeiYgQ/A6Vh0pokkw7QY+AU3BIrg+jwWmc1eIPqFSIblIzgR4/heRjhNmU5TfbTVHYuhF3zOI+DriU6JUsdupexO+DXKwzVhmbH3jAM4u1I9LOt5ua1uY2jHCB5k0ydqJJfP5Xu8x1D90YMlcKsNLfDUDMdZm57Czn6Om4BMawhp5urc5ZZ6ypI2TSTSxoO0TmapXoakqus7mhVg1ui9THV6gwWK1SF1F4TtxcWQaM9Qhg0uJSSmVBchUpN75bUZ1+lu/wdc7hJJvSFCIgHOUHcPZQVqhlR1C0Mwrg+xtfHlgik13S7T4jbrY1qanByl9Wyod39DmnzGOEYV90FDyl6JPSGw66KppSJawOYBqrR0BBTm0hNwh0fk5zH+Wuq9APah38Lts+wWPcMDqhW1i+JDkwOMj9Ie8l3eQ4HY2Tq0fCMGD6GxV1UVibhO8mah8E3Eyx6xjuPG5jyLZI6tOsJ2pLkHHf7BHeyZPn6EjkyF0DoFL3jofGkHlwvxCu1bVUBMVHFHtntCLpDUkdJsEoKllimoDEzAQzXRzyuOcK5SN8/Bl0jrs9rN2tnLDAX4inOn6JyjYYPMYNDRA7ukbKnyqIvkg2QOrr2Qzq9wFUrYt/mpLpTqI9JXY3EUwgXaHgO2uPqRa5Vf46ypWTkD0ybfYFPhiYYX5owr1GFm7V3urPLFXPpfv+YvvfFx+/Hpv/3ReQ/An4TMxb/I8ws81eBvyQi/27+7j/It/wHwP9NRL4PPMMifT7zkFJlSSuECscR6ClJzoAz4DWSP4bqCJp7uNVtpE4WbuYatF6alNltcOHCJNDdp6TdR9D/EE2fILrGsRvVqXEmGCT4Q5EwHBp63Ttzc4IO8PDhmmIqmsV4KQzZeDN0wanZZpRudOzJjXaOaqVpQjeavb/UJtqVcAbV13CL26RwhYYNhiSplKgUyzwFqwRSGEtGuPQ1KkuolriqRiqPiCNKjSyX+LNjAonYB/xqCRKJ1xbfDMkYy+AfINuJewpcsixfQ7eXjPbuZNWxBKpaWZ7UUC3Msak+M4cdyo6YntHtHKlXSy5ThxGXE5rVGSH8iLD9FEKgYKngkmXoZgwX1R6S4J2zWqrkhB6Xw0mlJlSnLJYVi8U1rL9N9/HfQS8+Mq0gM9jiDzHtdG8uBgn18MbWQnTiFu0+JS3fxdX3TGhIatgymbFoEug7okvgarw7hdVriKwI3RrajSW0LWuT7mvot8HcVc5B4wxupoX0NBCvtxBrcB5fKS5s6NcfQ/sUtMWgCQrkyURbyfZ5Kx1Y46uavv0Y7T7M0WJN/jlD3B28P6OqzwwIT7d07TUxRAZtfFBTb47OfK1ja4WItmu02xDFmIt3pwiBqDtULhGtkNgbTr5bIu6EmNbAxShkSUEiHcSmWb7l2CIZvrAplVEbmGnonykT3/z8OYT931f0jqr+GeDP7H39Q+APHrh2B/z3f3dv8IjcAz1F5W3gHsndRxdv4I7uIs0RsljiTpbIqUOWHqlkqManUgZTkKg4fTevh4jrOuL1E8Kz7xHOf0ja/BDCh4huKQVStFhumMrcLyLzI2pmkcxLtvwMwXLynBc+c2Zz1wO/968vzyuc3o39Ltdkgj5/p47Sz9iRvSO3RRfg3qQ6+RJuASGco32HSEWSmNPT84aWrIUJoLUluEhjv+slVbMAByF1hD6g4qgWC1Qjod2gIaLiaFYNcEy87iw/IxfSsLKA5kBwGkB6kqzwx18ibD/EllrpXwJ6QveEq4vzrJEVLbFoTyWK5xaOU9NG3DHKCa5aItWG3dWH5kQGkGBMjwTNgkotgawQZfGLXO7QJP5KassqrRfoosLXj4nnv073k7+LXj9FYhwROQrJKAx+6twbpv1FBL/8VtOMwiXafYxb3kdkYTkG6k26lirX1N1C6EguIMsV1bLC1bdI3TFuFZGzBjmuiRW06xZd95A8/mSJyxX+YoS0CxaqKVjyUlzTPfsx6fx96C6x5KUxka30bTTtaGYWR4ZU2z6E1IIsSP4Y8XepmztU1QL1LUk/oQ1rUn9Jimugg5IMKfPRGJfyXGreHzmDLQfnahNUNCH0aNiCbLFsccG5I5AVUT8BLNdBJxrG8GaZvlIH7Xnux81RSJPovMIyjAaN8z4yDhnaW/4cZba9Fxw4XvGM3BWJfwVZfYnq9hu4s1OrJn9coytH8FACKmNWFRMGFayhmFRG7m72O5NOWNXI0Vv4+29R7f4Aev4J3aNvkZ7/FvQfQTAcEBlMMUWKLhJ3aaNY+FwuU0fSnEmZhgnbh1Cemnvm0MjlKje7/nC87rhE9iN7SpJZUQVH9jJKEwPsgsBQe3f23Mx0colDkdu4xdeoz+4R6mek67UVhnDOxiNpNr0bEVURzKySsXCqJa6pkRpiWhO7ltgnYIksjnH1gq7dWJFwNYYdk1ItauLWGQInmGSdTRGiYs5BTUSpcMfvwPMzM11YhhzqfB4LzTZzLOMaGDJAcSatScS5FnW3SLKAakG9WBD6HyJxyzR3gxSs0pUDDWv6bUCqxua9WqH1EXgP3pNchfOCeMXHlvT0fdoP/gGsn2SFLjshS+3m6RwP+RR5umYO3OHb4btR4AhI2qLdh9DfxflTKt8QUgUkvKst781VaK+obol6TV1vkBOPtg5/dkTzYIl+oaI/FbR1cOlg65CkuCTGU1uAGo5q6k5J15eEix/B5Y+R7hwzz2XgQS1BFDmzFUzjEIf423h/Suw+QsIVzq2IssTVD/D1KVHWhPYjUjyH1OFQSKbNFdysF7PDfWFprk1PzbUgJCIiVn7TaYXIzvazNHi5lbXMK4zZxJxbUZ5QiHL+ITvl95uEDO0uszi0QvNFYwLRpJXljsTMz5gJvt4wH8+PV5vo+zssv/4n8PeO0RMBn0iqBA1EVVJUEjmjL5FjxQuRz/bt4qjMSUMqGYZZACdEVyH1Mf7BV1m+/i6y/hW6h98mPPwWunsf4TnmgMqRMANa5QS/f5Aqy9/T34c2Z/lextMz9U4ZETjZYzLT4/ASH89auw6aocqiGvDw9xfKGEtv+CJ34Pht4hJCf23Y4zFkQlX8Bo4CU1uctZa0VJNcbVmb7Q4NGZogOZPu6hWqkEIcAE9xQowJ58XCGlMxeZTIqqxJFa1MBa1OobkN4dwSr8ihgJI3V9aIBtC3YVwtpV4NNB98R5IltRfQc2L7FENHC8OYQIXIEd4fE/tnVnx8cYZGT6o6s2G7iEpnWbKSE3ZCS3v5IbI7n+SAWObyWKeBA9LaRCsbtACYkqvhXP4eIhLOYfddqmaBrL6Kc7fpYxxCa32zIIa1mcO6a7qrj6jOzvC33qDbtsTzwKo7QaoG8OBa6BQNFaE3YpaSIJW3cpJdR1qv4fwc1hdI7AbBRlVzKLOR1aKTmNZ1jFvcJ9GT2k8RAurOEHcbX52Q0iWxfwjhEkm5hq9CEfukMMhxcd/8rOP4zIn8lHACQ9tC3h6lklYF7jZOTonxU9A1Y+W6fQScqRRugkqB0hgxsA608aaqzbg/p1nJxRowMgYtSIAHnzEerzTRd6sG/8WGIDtCDNArGvIAIqh3iK8yLnjJcrPfvqrwlQef0/mTGkpeljY0BTQEC/kUh/oKrRuq2++xuvMW+uY32X7yO4THv47sfgTpArNLuqx6l8zR7EzWjLMOFEKpqUxmmgCaFXpbJqbYIYvkUYjKVDKZbuRxwQ7yewGhGv6ZT/r87ukfhXiUd5Y+TcwfOJAV6t/Bn94hyhWpXefIlBxr7ybZtFhUigHIm+NW/AKVmqQuh/fl/It8nauWxJAy0zAHaCFsKWYJTkyjkGk+hEBSsaQjdcac6mOboxEn1/4GSgy1TuaiFLcwVNQeCzqLSHOMbxq69iNSf2VaghbibI5tV52ZjyA8yTy6huTQ0CL9Gk3XoFdouDLIiGSYRC7mUpqMtvm5BD9ZGxNwv4E5MI26YpQ3imkj2yWNn3XE9Se0/TXN3Y7lyR8hpVNCu0V1i8chTiEI9D3x6mPSk8jxV09wx3dpL9esf/tjnNynev2IdGtJ2uyIux62lrHqXWVLNwZCyL4xOYZ0B7TD4jxKH8Y9wQDes6JavIGrj+m237O4d2lw/j5VdYqmJ6TuIyReW7YzRX9N4zMFm7fZO6bjmd8/wJ5MEuYm18sQXmyCVxJF0xbxhmKKNiTtSekZVh97TEYs6LqC5JDaQxn7oLk045Rxj3t7aEgO4dexfzo5Pzx5SvhL7svLj1ea6Kv0bDaPSb0goTI7pG+QZY2rHVJVuNqZwJj7nbLq7nI0TYCcIl5+BFdXVLkSfVhvoQ9WdyImYvB0tcfdfovmzpssz7/C7oNfJzz6TbT7MaI7BslAiqLlsQiXySRqlkittFKmUTrcM18MU+59SEMoX0/VUftbZRKzPVvEY1BaOdzECTwyicmHkjQ1EEozWQlWTNwtHV13biXltMrSdI76GQLrayPczgi4VEvUL0BqhNqcseJwTgZpPVYrqLMDuI9Zqre45xTSKMFkTcKIyvgzBE1Iha9XxEG1mRBVmBTaGfs9TZrUQQKr8IuzXGz9yN6RcpZ1KZLjatzinjn+VCwsUitjNqm3KJlwjaQrJF2jepWTkdIAKTDfnlN9bCoQTCXRMnd+gNMYePagIZRku8IQFEJHjM/YPf9nVMdvsTj6BkmOSdc7QqyhJD6VOP2nn7Ct/wHHX/gKd955nSALNtsNmhr09YrQHBEfR2QHlTlnSJueuO6h3eJrRc7ukmJNWp8g8RHolfnLsKJHUSLkOsqyfAt3cp8YHqPtJ8AZrn7dwjbDp6T2EyRdw5BQtUf8JmGaJVvdrkrjtVpMQEx2R+7zNNJNHEKFqJLocqhRj8oKcbdIKaHxIXA9aoxZpxwT5HXevsnHkaXv6997mtxU4BsYxD5tmK4i2fv7xcerTfRjQi86SAvUO9zSQJ9oPHhBKjHQKjdRrnKQ+QwVQCHrWaCGCy5S4RqH9yu0DWggp8xH6BIxKMlXNGfvsPyZu4R7X6D9yd9AL7+PpEuQbrL89u1o+YyTPNEl2/Vw7PBer2ef9835c8cye9w/X6OTZTG5QckS7ewGHW4qQiI6mhrsd4VvThHpDBo3Ks4tzImbnyCSQza1QsTQLKt6hVQL1Fe4akmSFbFqkNoj3sISQ0wkp/hlha8q1PfQt2g0qSwlQHPSVunXEL5aNomAMwlcfJ37NfeVlLHQadirHth4gHMdTq7QVFN5ixpKZWABwzDwVIvTvNlXeC2aXUCkN8dcstJ7qjniJ8WctzB9ZzEXKtP26tC+cuSqLbP1IONQTDe/Fq1rj+BsnrD+9O9x9MUz6ls/T6gaYlTorNAHpWpY2xM//DGXjz/marHErU6RO2fw9AH1z36V5fEZydfEp0p8eI2sA2kTYNfj+g6JLeoD1e0j5OSLdFd30M0zNJwjXKH0IK0JB/XruJN3UOcIu49A71AdvY2vhH73A1L3CEkt5DKCzMZq0u3J+I29Lmalcj4NQ2r1FArxH807kgH/UsmmV8udEGfBBUog6bUFEMxmogzymEc7CGaT61yhQ8MmLT63Cf7OoI2UdTp901wwGAW+8jefebzSRJ8IdBWuaXDLBW7hoYpmKy1cTe26VLJoy6KPtlFNcFWQlLMnLdMuxkT0nmpVUS0aIy69olFJIZJCIPaBXQTfLGje+CYnt99i98Gv03/4t6D7wEwD6ijhiTpZPOPxMqI+1UDmhGBOsPYmenbl/iKbSwNTJGkzKCSKfjK129vluQbqLDEokeSE6viUmC6h25pEWy1QqmHRSXHcYr9d5ZBaEdei2hOSw5+esjxeELTPPc5FwHOznUaSD4ZFnwRJYuBbdYOrlwYh3FvlJnuNw3lL5rKatG4YIZcTWTRv9OJQs71m41uiNcqVVvsX0EvS9p+h/dKk9niVCUCO0YoOrRaItLkk4RMDoc7WA1WP5xSXLFlKtTd/AYoOBa+nBF0oUv1IAvJanUiTUwF+OHQ67zo8o8AZWBnPQhAC6epHrD/8Tzh+r2Vx9k3W6W2DDF6vID0BvUBozWS23cBui16v4dkj+OBDumcb3Jd/juRvkS5b9OFTmij4lAjbLanbWZZq2KDSsTw+4eT4mLi5R9jeot9cG5MRB6vbuNNbuKom7Z5T17epFxGNH9Guf0Tqn2VzzgReIY+fzvpse0imEAhFyBqE34kQMMTpl3UvjCHRRZBIw2yIZmYhCdUWg/uw580NMzrssfk05UhAjEiXfJkhjl/KlsvrcljFwlj7m7Fvw2c3UAlb+cUk+/LjlSb64hyL0xOoPFopkS3aBQhqmY89JkFpQvEkapKaROR9YxXup4PgMbND5RDvUK9EUdRZaKegiBdcVeNThUZFYyB0LRGoFw9YfPVfwq2Oab//n6H9p6AlUzSreEPjdT5HNzo3l+xefOxP9D6x0H3BcXJP3hRTtWD4fejdZQPlMLIBeK6hXi7owzmk1r53hVmYiSUVALCBwXSk2CF9JEUHS09TbemvPyV0AalOcf4E6hVaGTyAhgjRQMokg5VVdU21XOGWJyQc/WZN3G0tw9Mrqdgxhx+daMMTxjcQ/KlcPVGTijQokLSF/jEazKY+VaDLv05A4xPC9icQnoMm24IqwAlaHJ8oqmFM2CshHcOQTwlXac9omvnsLbw3tzLpr5Qw1/xoBylF9PJDtj/+q9z+csPpvW9wVb1HfHIM12aqsXjzESzQabKvtjvS9z7EVW/Tr2q46vCbQOyucCTYtRZ9FVuIW1K4YHP5Q5x3VMtbLE7foL71NiGeWnnFRlD/HBceIvyImD5kd/ljUnth+QRxBdSYD68DNkBXZi6PTUlELM7Ul+ypQektpFpH1TmfKX4CzYB9xmSqnBjYIdpCNlEdnoID3+9v2cLW95XuvZuk7N35Apy9SwY7fjYzzuDFDx+vPNH3TaTXLbEPxNgOHFxcJkgKriS1aINIA3UDTYUTb9E9LlngwdIPPgCimL0uZu6rqQiQlJH23uGqBlc7QtvS7TqC1Kze+CUcG7Y//Oto+2RSWLxANexL6FldGyJlfu/HrED6fLTYJ+Q3jUh77x6oY/kZCX4BYDO44YZUV8StJR8ZBEJEnEdclcMzyzq0GHFNvRHwoMCSql4S+2v65x9CrNBakFVjZehcKb1Ywk9TNo10RAIpJNIm4Ool9XIB4ojthqJZFcTJATa6/AyJMmRNbN7XmUkwM7CSaCbZnGCF3KdRESZtCpekXQ/9FZKKA7FoUdPojPw8AS1AasOYF+Y6zk0h2Ddmbqp8zSYxDU+QcRIo8YIjKNuEGYREPP+Qi+//FW5/PbG49UcJ9Qn98wV6viC1S+A5aHbAppLvktDrLfLskur4jLTpkTYS1tdo6nJEVoAYLC+mF1JvCVndtqdva/ztN6hPl9SNI/Q/oTv/h+j5d9H1UzPrpRp4HeEubnEP39wB9aSwIZZC73oJ6Rp4ihIGRj+OV2Ge+0ISwzyPAzrdM5KF/4hBPdueduLzHLSIWmbxuE/GgOh99K2XHwd35NjGA9cePDfknIDIWLDoZccrTfRVlDZcE/ttTv4p+jOUTa2qxOQhZUdqZSnlCQUXkEpwRx5/5KESQlJSH3ICnW1kVTVOXpz7uQhIlByDL5766BhSpN+s2bQVJw/+eZadY/f+/xPtLvI6m8bNWsjXRFnPR0nimoZ8yuS+zxyVG6rj/DczaW96FCFynkS2d5lGyzMAi3FHwC3oqUjSgNRoUMT3UC3wtWHCp8FBqaA9pF1GoRSkXrJYNWyvn0AbcTTmh0mKE8VJMhIs2dSSzP5NiiYl7xJIsrT3xuN8RaxqU/0FnDPnpWdLCOeZYOvsZ4z0mI+z2cSnc1HGQwaVu1RSGx31SojnhHiJRYwIlhG4QDnLOD5LkA1WYKMnaQHkmr5njC0XmawBzetDEqV28Jw4jZ/Hf4UR2G40+U37OzjbAUmJcPkTnv3OX2bxpaesbn8DX53R+vdIF0ewPYJ4AdoaVDQBybjw8XqN+C3aB1LokZig3THyToeKJ8oKqgcmjPs7uMV9tFqS4nP660/pnv594vN/ivQ7SCuQr1Kf/Cz17XehObZ5ix0at2i3o4qvG1MJPWn7nNh9D9L7oGtUcrnF2exO514m63wq5Izjp2W8ZHK9OlvbaYsFbMQMWSHMCb5FL88cujNfwfjuKTWwJWbv0oFx7B8jUzp0jOJFEdpefrzaRF8jqb22GriqloSRsp0zFdsloLXZfp3DuRofKkMHFKU+bahOnAG6BiX1fVYdR51Jk+Q0eDIvsQ+ikCgFEITKC6uzE/ptxfVux8nb3yRtP6B7+PesRu++bD1IXVP9bEJYBlVeJ+f2CPXgfCxPyCYdKe1Mk+dM3r8vEBwY3zGpq0iDo018lJbExjdWiD9B/Tn0PZoCLju7XDGthIikkKW+XEM0OYveFIHoQS2b0bnGcPKRgVlk/SJnUud6pQPiXYKYSDFS1ZVJNc5lATwjMLIm9RcIU8m7dH66caYSfnm+zE7fgIXai/yRDPNgGkTWNKWi8vdw1T2rmUoGGdMRNG44dC4KlE2PZFwgRkTYcfKm62A/csf6MI0MM2Y1ZWRzqVZiIl0+Yvvd/4z4zg9Y3vvnWNx/j93yAd35krS7QPsNGlpIG0QC+CWpU6Tt0C5l86qzWH0nOUzXgRxhdvYaf3ZKdXJGtRKSPiWtf0D75J+Q1u8jMaCc4Ra/wtHrfwh/do829bTtBcSM2ZNayyvwIFWNq1fUy7v43X26y3sQvgvyIQN0eDGZSZ63gxmqUwaxpyHOvjdHe0wB57rh/JBBfSMUe7xzeMq0PZN51MmV5Tlm8Z8z8BcR+1kz2XvFS45XmuhbfdQdkkJWs8nEOY0x8JqhlLUB1wC1ga9VSn27oT5y9ClX9wkKvWSWbCjeVnE+k5xUJKZRbSuMRVH6ZDkCy7MjUopsuiXH7/wB+ot/hl4/n8Rav+SY0viDJ5lccOB500tmBPuzXrp/lPErRU2y80lGtXWIJRcL92wWR7R+gXhjhCn2RvBchXf2DE3BHK5apCeHhkTfRpa33mCTFqTkcPUR+AYQUohG4DSXxfMVKWXTUilAkguqWG9SjozyiCs5CgnCOdpdIgTLgDwQKTNutexG071zenPsp+a0uWQ9RWbNQoMEYJudf1uQDqaah473a3n2TCsrtulD9+wRGG407MXz/KIlogq7S7of/0P6px+zeOObNKc/RbW4R9i9SdoFQhug3yLSo1WCxYkFPgio99A0oAvENyCNaV2+pqobXOXwvkf1J/RX79Nd/AjdfIp0z0F7lFP88Tc4fuePE6tTrrtzYncN/QZJ0WoSJ5/3KNkRaiZbd3JGVf0i4XIF3RblE4Z1nDuts7Gd7m8ys54M3MzfkqOqJkxjsPNTciymz9qfhEOb/AWTpPvnpnM9cJdJO8s/MvZRisLw2TTo1Sb6qKn50eqtRs2EOeoojalHqHCuMazyqiFVgj+pqVaekCD20Qh+KgTfT95gsdc24XkSBQxIjCxploF0hKi0EVZ3T9g8a2ndCf7eu4TtcwjZTAQMuu4LpW95wedDhz1n9NVPidKednHjvv3v900F5XwC8RNiUmJaAk6NcJnkaJKcIGZ+oYUUsiNXiTm7dYirVwsz7LZbTm6/ztFbp7RtsNh776FyoC262xkGjCrgwWd7fw51tDT9GqmEmIm6F2fw/BpBO9h8hOsujcgO3YtDD+d9N6I9zneazHO+Q6ZzWTafDqeLMFCKxqi7JqQP8XKCw5PShpR2FMC40Wk7nbvCNiabfBJ3PrYpZu0i4w6VXT5M6xiOOiZuHUgO0vG9gxaQBGkVDQ/ZbX6N7vTbNA9+geb0q3Bym657jZQc6qKVfvS5ihk9OI9UJ7A07c2lROwvqKsLxF0Qth/Trj8h7S7R7XMktFY1UhIqNbq4z8kX/wX66pjt7inar01jZAlVbfsp2lhobIEO1UiIAUekPr6Fa36J7lEL/TVwORJzdcaE9/JYijllnMgpKm6PsrT161K24Rt0hUWAmSAjOYDBAPLSMNIzISBrz+PaKfNb/pgac6bXTM1O+3u3/JQs+HEdmBBR1tmLj1eb6CukTjOxSUX4LL3LY+JI4nG+xjUV2njccUV17IlA30e016FyocWTZ7XXTdSuRP47M5OEJdIkhg0lCpqsWERdO5a3T9k9P6W6/RZ8+i2kn+B/FBPR1Gww/D2ZzBdI/DOTzoxvTFWFz1L9XsYEpoRHh3dKTmXXku1GBN0YCFacNGaggcnCEad2UCoGwDXTyVGU3eaK6uiY5dkK5zxKpG13SEau1NgPJitXr/D1gpQsdFbE4eoa8RBDxtARY4UQ8WyI2w8tcmQiOWlu48vHZhwPG409Url/f3Zcm29Tx/tzH2LamOGrQEQwD7280YaBCEzyMqQs9jQjFga/rMzT7TMxHxx56QXLoqyb4pieEilFYoTdBu3fZ3f9hP7kt1jc+yrVrZ9FmtdAVySWhNgTuw3idtQ+mgdNOwgR3fbE3RO22/eh+wD6S+h3kPosV3lK4XOA6vgucXHGdrNF+x2kSFU1uPoI8UvKmtIUCWFLiltznIfOav4C/vg21dmvEJ48Af4JSD+OrU7X/N4cHvCOi2JZytmkqJIroNFQQNCGC/PvIUAgM9TDCEBlr+4zmUPNK0yDcV9N7hj/nSZZSm4Ls+z/Q8erTfSTolFwlQeJGf5Aho0mvkZjg3O1YYuc1MRlgkVAscQfTSlH6kieyJHQO2SEjREhA96ZTS2BqkOikkL2JeRDQ6LrheVJA7sVbFZQVRYllMYBH+3u00nYCy0bNvnohHmhJj7598Wk/uUTPj2vs78n0iVgpgsFjaT4hNQ/xzd3LbvWbQcaJuKyNF42kcE24Boj+DikanBOCNtrQr/B7QyALMZIDIpbrrKTMHP0lIAFrrbooGqh2ZynxBhsLmSEIhAiEj4lrh9aqKcqYzm9fQn+ZUOiN/feoWNCpEccnGx+VJOAx6DCQ5rV5BUlz6EQ3mFtQFkrh8sv7DOtvYihg4yuMGxFJDL4MgQbL817JIJur4i7azYXnyAn/xh3dAtXn8HRXfBLXAykfk3fb6HbWqnH3uG0QfoO7Z8jwfwrpAyCKFlrc3n+XMTVSthdGVpD6nAitmwIpNSimK9OHLiqQqVBUsA5D7GzJCqXaF5/i3j9VbT9DkIoYsyhER/+lRvzYuPjciKckh3xEjHIhR4LHc3zK9P79p/jbjz35t/72r4eOH9z8nXQBub0olTq+gxB/xUn+t6xvAsSnxN2z4ldT50JCKrEIKR4i8jr+MUpVROJriXsEs6dQdXYJox5MTs3JOTYj45SXEmvJw99lvotHBBLyAnZbJBLw0Xn8ScKT59nExRwg8tOAL6mRHWy4KahhC8O+9pfrLzgus/7felr5nR7eN4j5GtAwofo1fdYnPwqqVoaMqMGqy0unuQkl9tz4I5w9SmyOAGfsfZzFrT2nUV69JGYAjGCLO7gjxaE1EJODtMU0L4FVtY070nJIkVSzO10hegrnmt08z3o1kbvbkTvvEDauzE2e+Oj03OT7Rcz/EXGpXeza2TOdMjrahoieICIyxBCmu8dLp9fP9ckS6t0It1ZbsEYrTQlDMWsqbP7J2IKJVN1eGnaoN016flDVKyuMCWEMXa5RdY/J97gKZIJC0Yc7VEiJdVJLcQ507MUt0i/heAp1adCCiDdoCWK9zjvbedkf17M5QxVFQ1b6lWNP7pH6E4wILTSzykB3WeE8zEcxo8a25VrDA5EENaYuSxkwj8Zs/KMLOSNqLovWG86TYDcJ/x7Gvzs2pu/ZYDdKElf8sLXluOVJvpSQXKP6J9/jG420CVDcZ2m4KcNuIqOBl1c0es16TrA8i2a975Ah7Mkq0x8BMPpScU6VJx9Ml/85Q/bYJKjhiY2tJhIUamqNd3uCWSnZrl98O6XBJuZKqkvmZhp2vjLBscumUv/n8Hi994zkpByX9r7nF+kHeH6B1Tbb0AGTxvAx7CEEPUKLJD6FL+6g6zOSC6hsSP1W+hzDHfqUW1JoQca6pPG8PM7K3No5jexUojdjqQxh9DmuXLeTEPi8lT0SPcp7eVPckWpwsBmpGxvNOd/Td2x4yX7krTNi5tsuPnYz78twzpmZ04k/uHR4+bWYcynGPNjUyzxbarez9s2/pgUXRBF9cac7of06aAB6zB2kyVaNL6s0YgY4BmS2ZQWwUHAlzlmCHMd/D+5IxaplRmTJmL7jDo+hnAXM10J5DKKSAQX0FxASRULA47JmIqETMsjsW8zFEeFw7TPEoRQnMCT1NfxmErrmsurSkXSFhUDyMs3k6QfpewXbrUpHKIcPLM//uTxnP45/0Pmj5rJJuN7Ri3x5WGbrzTRV5Tu+hx2AQk1XlOWzjMKtTpcMund9eDaFuQKthDXl9R3e9xJQ8ihBkP8eZa2yrMsw2syqmrhgSb5YIshawg2l5Kdwhsk/IT0/OO8IaaKmZmEZLhp7NW+hDFi9heJcP+eFx0vkiY+H/GfkpDxKeXdJd3dloiGx/SbT+HuV6A5g3Sdx85NskwFt6jwywapDbwqajQNq3JIFFJIxBAsbNZD0yzYbNfQR8SbVGcg9Ursd+YvSAoZV8dls04hkpWcE6++BZtHOSZ+Gs76suOmpHWYOUwl9JIONhJ2I7PzZ8yfae0c2fP+7i1zmIZ3jCY2JucncArT+2e2n0Lgy3VTbaP8O72m3DtNEhufPTNClLboPo6l5BEQ06hnD5E8Rjrcb3Q3J5QlSLvH6PY71PUvE+MCJSeCTSRhKUxMTXAjI55CNAEBIXUbUvcRsEVLEEZJlhzgOcoYTdo/FSARkBrTiIotXybX7Ydlc3MLDkrdhMnDZOaUUQucPmR6fN79P6EVKubgL0zpJccrTfQtNOMW4BBnESTFblpl6cRJhYqhF2rMESHOsjnDxSV+9RpRXTY3Z07v1XruLJt3jBKHHIgx+AEGJqtqtubitRdF9JLu2XfQ8ycQEwX2V5gKFIcJ/rg5pltLUAz3X24YcqfX6/xW3T//eY78nFE5mTwqEwcVUI9ygsgxcXdBIzXp+I7VqQ0bM7GUROSwI26fkggseM2qZBFM4odRQotkRmqRQKntzY7sSvEVh/dC0mCZv0PFLI86bzg7JLx0uPb7dE9+C/oNBRvnM7s9PQ4IfuOenW7QF2/CWep/EQomzzPJuJyfgXVMnpvy2hlt+lrakK+T4V0H+gGZEI7mnFlEUGbkJctUB1NPJkcyGiWm62LezNzTg5FpCcmRWpMeDP0bwgon/g8VhX5HuPptju6/Q+/epY+V5c1otEprztBcbQijmZ8SWcgy2HSHQPuM1P7E7lPPbL4mQtWo2yqz/AwYxs54VZjx3HFKC5PIJ4omnzf+OOa2RvfH76b5d+/4vNt3j65oZrDIZ+cFv9JE3+GpTr9G131K6p4jfWdmFJ1KDjUqAcsCPaaqlvTVNXBNvPwxzbGnOb1Li0k+zolh+SwEaUYrpyVuhUyQ8gAORF/MkZjrraKKI+C27xM++g50PT5VFPvbTXlRXzgR9ri5dFjuGq+4edc+nPLv7phu2ilhmD5QsNG5Q+2/SmwWxLBB+i2Lkzu0/Y60brO5RUgxgAboNyiBkJI5/7yzmgXRsOoFQX1liJzVkoTgFkdm7vFmtqkrq18bW8voda4y/4yrLAdDAAlUPKF//E9ht0WSR9TgoE0DyeFawzBNTR2H+j2V/m584IUXyfy6UihjiOHPmuR0TczV/Al5Lo8cVP0XmaUOCBI3lsNBiWBCjGO+oiSDvcgkUBhQIW3F9zUl+BOgM7JUnrVqN/BCmQU5mG0f0ES6fka7/E2Wd0DdF+ljk5n/0raUE1RTJqHJcjbEm/zmIpWu6S6/DeHTnI1d2jrdVzq2YzaUbr6HJJuWBrNsESTKmsmaiLqhb6WvI8Of7qU9DWoI6Z6P75w5zje1zK6bH+N85pl5OaAP8IoTfe3WHFWBk7ff5fr8mO7qCtq1gW2pWpy2ODQJKfXQQ7U4pVr2pN1T0vZTdu9fc/LeL+OOztjlzeW8s1odS9Ba8V6gE1hXVrQjZilkiEfXXPwDSuTDUt4nfPz/Rj55guubMWUfwVLniyNtnBbQmzkWY2/Hn4NOnvmV4zkLWZwfhyTJ6ffCaPdLs2vLdknaIHIb8Q9gcQzVAuhpL3/A0ckvUq9u03ZbNPUmPyloUotr7nuSRlLa4ZdHJvP0rZm7nMd7Kxqe/JIuRBant+hCj6aejI1K6HpzsnuHOiugnsRq/zpXI0B4tiZevgH6NnhBtUeJ2cxzCTxDZI1g8d2kkK1QSirhkDfG6tDm0mGcpvLwQSJcsofzZx2YTU6/l6ks6JiZlDKRn4GcMl1BOvlmQiRmK2LUTPbNVWNEkRvmeWhXweg5iA81HZeKAVuoRIugWVOYmqjMyTiIOyUUWMe1J5jkr7EjPPsOO91QnV7A8ot07j7QoHiiOEvQdLsM370CLJhA+gu68yek3TXoXZQjhA2qa2MMZEhmzfkLyhC8UaA1RAXTfBqSHoEeoWVPiUFoWIy+VQEz8ppme3mPc4xzkkNDC4Od7fPZ+Mrsr9Hktn9duXTgphQ8rhcaB/aOV5ro011y+dt/lcW9X+Lk9pfo777Jbr2m315D15sjKdvjVWti8jhZUC2O6bqP0XCObhPX3/8Wyy/8FEd3btHhSE4tIqSGVKlh83twSSB5VCPSexQ3OKVM0hfwiWrxCL3823Qf/DP8JlrG4BB9kSU3HQuFT6dzNAVMCfD82J/+m8c+oTq0UV+gW2TmND5C9q4XoEa4jXN3wVcEbRFpEPHo9gnd+cc0t79EWN0hrp+hGnHiiKpo3NqYpZ2l78cWqSpj1EnB1VAJzlc4b9EbmoTFckHoe+J2S9/1aBLEN6jzVszE14YFJB5xNcICd/ILLL72y7jabMH2/oiEFm2viJtnpM1j0uZTaH+C8DEW2dGD9rnrByI65NAYHx79+QYex3Ukxjq/7kUJYMMM5AiXAzN4UyfRQfOct24qOOy188aSyAT6Ri+nwsrkq1LTeZpHgmSHbiFScxC50aY/J3iamZ6oIn1LfPYjYvccf+c96ju/iDRfB27jpcKnSN8lUqxIboXSmAO3rfB3j6lPf8YwgsKG1F2RukuIGcIh7bBatqUmgWKFUTLzcoLICufPcL7Cu4oUOzRtiGGDhsek/kMcD0EuJmHYE6ldRzZ6yISzX7rh5fT5d6u+F8rzInvC/Hilib6qg3XDtt2wfX6Je+2E5v57eIIR/Wj2bxSk3RATdAi1W0K1Ai6RmND1Jduf/JBqd5/69dukqrafusatHKkGDSBLSCHH9VduhE3JmZtVvaVpPkZ2f4ft9/4uXF7ntV9sgXsb/BBXnzlqHfsK/HAM8/cyYj7dxBMzwR7BkhvflXuz1DXlAVqhchvn74GrSWIhapJ6K3tIR//8u/jmhOXRHXYpENsLvPf4uiYmq2erSUECiRZJyeLwk1poa1KoMnxv2tF2azPt9IbjLmL4+eJrK2NZ1agz8w7OW8HypsLdOiWqudyGuscA8QSv96jTe7gQYdvSP39I/+x3SFffh/5DkOcgG8hQuTZO02SX/R1q54t+NMzAKKbP5mbY/C9QHgZdYS8k89BMTZu0f24AgivMfMZkDj3k0BcZimOQIN0Q8z1EQhXBcrZ+R1OJFBTOfWY5S2bSeROtCkF+bYLQoZdb+vUT5PknVHd/Qn30BRRPu1sT+mPqs5/FOQvfTIqtj8UKWZjWUPm7VqQ8xpy5n/M0NBJTHHaIm8Bdu6ylFDt+xDQCp2r0I2xJ68fE7Qe4+G2QD1FpX7CzMkObjXVhxDBCdxw4dBzPKeM4wNLH62VK7qda6IuPV5roI6e4s3+N6vW7uHsr9KhGFrWF6wVnYF44BM/C3yPGROhbtK9B78PFNYjgRM2xe/6Ifv0Yd7TE3bmD3D5lUZ3ibnviEmINodhfdxkLRjoqv6PSZ9TdD+ge/iO2H/0O+myDy2XmVKemHDVOkWut5o4MXZrGERyQBybENy/PG8Avunf9uJDnzy3EZ0oEJiadafyyZq0Gh8oRuNdRdwQSTP2ViCcgVCAtKT6je7rm5M0/zPLsNTaXidA+xzUNFaekvs/mWzMBOBXMBmobTQvcQopW6Uqq3Fdn8AvVElcdZVgND74285KrTGtwnt4JKarBAXi1Wq2NJfGoQuwg9Mlwg6ol/vg9Fm+8g17/YeL5J8SrT9Dtj6H7EaqfIlyaljLZPuN8jsTqsORd5n50pBZiViKJ0mAems7JNEt36uCdS2zzFTMluNa2m6GAI6eZk4BiWiltLUf2xGtucC6VqRmj3QhWERLm5sC5iSyfH+zKOr9UxrbPMW8SmlPmJTmrR3z5mLgTkn9ElBpZvEX92s8gNMSuJ6Y2B1aMEX2kROwZouikpOE7M+8kNQgHKRnNknuQs8oNzqPM9Rg6K3WF3LpPdXyftP4CafOboP8UkR3DHp8NdOnbTZOPvDRcm9nY7MsLc9AGGfKOiuj40sdOjlea6MvimJNf+ArxKNGFHX24hI2ad78PpuqLB+cJdW0IfEdHVH4FcckuVsQnT4m6xNcNrjKurc8vCZeX8PgW7dMT3O0GXSj1cUNde1K/RdtnuO4RbD9Brx7SPf+E7fNH6G6DtAGXfF48448t52LDPWBjmyVugN4wLRze9DdOD88rX5frp9LmIY4/iS9WYZasAyRdIdV9qG6h2pomnwy9EukNCkHXEC9I3Y9Y647VW/8NmuPbtEQrmO6VyltoVJoYPVPqc1azYHHkxggk1xdO4rLpZ4FUR6apVbXZ9L2HusZVNTgr2GKZ1rYG6sajCwakQvGwqCygJ/SmEQYVRBPueEV19FWq8GXovkm4+Jj4/Nvo+rchfR/0EsNrgX2Hq5JpwkuFqUNj/wLb7Gy+lCE9nGIymZsG54R8SjQPS/eHm6nzCxTGMMYRoKwQzBn5uuFrGt876Jk3pNVREp0s2L1+TPdQQKjNSRoSKXVQVSzP3iZWt+hDuaaMWcpE3oHzpv2nlMttluZmSYDKsvxViTrRzlVyqo4ViRdVkvYUlFPD50qkWvCn9xH9Jrp9BvwEcwAeGvA9cj0guk4Z7s09vj+y0/0qN66SLPTaN1Fflj8wHq820W8cm/qctI3ENuSQP8vos7GOg6MvdAGqDqkCsa6pmlOWX/x54usXtOfPcP0lVThH0iXaBkJ/AtsVcr4hXp2T0pbgNsAVTp9C+xHp8sfI9RX0PS5laOeS0etyppwUcl+OfSnqc/V0/ntQ+eXF7FtufGBOTDjw/eQemS7AXDPAvYU0d0lsifHCFjQ9VucVYrQMXWKHqBAvv80WR/3gV6mXt0iuJu6u6EOHqBXvVtKAq4/UiFSo1IirEF+TMEnfgLsW4M00p1WDVpVVSPMOWVRURwawZrU6BLTCe5Pug2aoDAWpLOTTL5zZgNseuoSG3spk5g3u6orq/peo7rxNePZThE//Fmz/MegT6/dsBG8S7SG88sYcaRHxD+pgh4lD0SrGJ798Dif3vPD83nHDSSt7y6dkHIzS+8xxPSRxjctzvCa34Yb9aa/Fw9IendY6edgoOrmhLeKBZkFIJpV7iRZzJDbnClbQx1eGz4SQoqBBTaNUYwyGsxhzhTZrt5AQsboOqj2SejS1lg+iLusumqcmEgX88jape88KpGtZJwf2WGF4uX9l3EQqZoT/IGRGOT01IU2JPZi2kudHDY5k1BFefLzSRD+RSLsOuoj0Dk0eokXIjGYQZ/Z3gD6iYUfoIqH3yLJiefYaR2cN2w9/QFz/Flyfk64qJH0Ff/Y6vnGksMXFa4hPid1DUvsI2Z3jug7Xx2y+UdIstT5LZpnojxmQpczcKPFNIyxGoUBww/BPay2NkR9lL+xjhBSJk5m6zvD5JqbI3kYvv0sikNaIu0tVnxJ4jqbnoGsGM1UaMQQtKS5vzfSMdP4PaMMVywf/PFRvElavEWJEYyKFFrOZ15QIhuKMxXnU1dluXyO+At+g1dLqz1YVWldo5XGrGrcUUs0AkueSoEFM2I9qYX3ijX9UlvuVFLSpcL5Cm4R0NaltYRfQPhE1En2PeKF67Ys0x/9d4sevEy/+S0iPmEMZaJ6L+QadSl9lhqeWjbR35eGszNnM5mtfoNbNnqocchq++Ng3xcwPKQ3XsQ06ex+MdVinEUAwaLejzH+g/SO2UIEptlcWqZ1BcrXLM8nVgHrLz5AUTBNPZn4t73XOQVVZgl+9YrE4Jqk3C5DmNzvw3hP7HjR71PqWFLakuEPjFdpfQ2oRTUNEXtEkVKxgOl6geg0NC0SuJl2c7m5g8JNAcSAPDt0C/T3s1yl0iOT2yewZc3+JjN/l6lk2Y+kzRc7PJPoi8ueB/w7wSFV/Pn93F/i/A+8BPwb+dVV9LqbD/J+BfxUraPk/VtXfzPf8KeB/nR/776rqX/isd5MU2gSdz/VKPb5ukKayYXUOqTxJYq6ulVU6jdCBamIbAsuTFcfvfJnr699Cr6+R9QNcc4b3iRTXJLaQdtDvkLZHW3ChQXQJhMz1p4UwHIYi6fISLyF5+fWJ2YaY2ugmI4uVeDQ4gUFyUT9w72KrFBKOjjHee1SXb4IFHiIWh3S+yXeSQDoCHxPjOZrKWOYHa5FSXM5qLvKfGOjV9fdp2VHf/Sb+6GtIcxfVCk2RFFtSsKpnJb9CnMuEv0J8g1Q5OsdX2cTjofJI5aD2gxUq5UgqUCQoqUvQKU4cUvuhFECKioaUb7D2G+NKSF1RVQ0SlNj3VjM2JnpVfHOH5s1fZZc+Ri//FoI564opaghFPDDC4zzvV0TbH/PDRHo+bwftBXsEvhCI6RY/9M79lpZn+BdfNhPcR23Q/jImKMOaL8AUc8OEMB2pdKB3RUiaCyiSCV4RSKzs5hZY453VxaDv0bC14ILcDnVC8mLAh6Eh1mvwS0RqVD2KB61Mw6w8Gno09qS4JvZX0K8NETSskdQxhM9aYe3sX1parojz4BYI1bAPx58p+umk1wcK9bC/Xib2/rkxp1CQUfjYf/40OujFq8yOzyPp/1+Bfw/4i5Pv/h3gr6vqnxWRfyf//b8E/tvA1/LPHwL+feAPZSbxZ4B/LrfnN0Tkr6jq85e+OSm0BoDkFksrWL5ooMrI8padQSWK9ELftVbYeTqWKdEmRe59gZOv/jGuPvmvwN9FlqdE15NiJKUWSS0SO1P9kiDU4BrULyymOwYMu18pTk+ZSdkM0qwdhRoXTozFLecEIpEG5ZTkTkCOQRY2uX5lEjDOAK3iFZqeE3UDaYfIBkeLEhnVuXK8KA54TggG/BAk+yV6kj6FkJlb9j0MNH9YyGmA+tBSeIYEqSNdv0/bnlPf+Yjq1k/jFm8SqyOgRtPCkmtizGUVAalAGrRqTNovUppzWZqPJs31AUKmuZXkerrkamcub0rQkGZmAomG+0Pq0BSRENG+t87XDVV1ZP4brUhJ6EMkRujkNap7f4R+/Tto+JCZvXwYD/Y+FNk2EzxhQjRevgFvPOiFN+zP6fy7ISPzBlMaCY2qzO6dDBf7a8S+2nufkLFzRkYzI/hluSOT8SiaQzlSzsV4wWuHS/0gXBA36PYn1He+DnFJ7HpIWyQGRDtSkZIdaO+hqgn9DqmWiF8hsiT5RRbeEin2pH5niYTdBrqNYfEHi+bS1A1CjkqDcwvELUiuwUmNE4gaJkM3F45Kx0pa18DCB7s+A00oTnQdIgDThNkWS4FOrj8kSJQ5Fj4TYpPPQfRV9W+JyHt7X/9J4F/Mn/8C8GsY0f+TwF9UE8f+nojcFpE387V/TVWfWdvkrwF/AvgPX/52yeF7C6SpwHt6V5xOJslLNG+8eIdfrtBcjHuQVIPF2O8uG2699gusvrxm96OnpMqRxMr7mY16lwl7kWo8IguDEEgBXG/qpBYkO5cp0VSy04Fgmlqm+XoDjEJWOL2Lyuto/SYs3sYfvY47uo1bHJvJo66haiwZqe9JXQvxGunO0c1T0vrHpN330PghwiXQIgM+d9lsocwe80WiB35PCOzwnUniskcobuYayyD9EiOkp/SfPiOcf4/q1ru4s3eo6tehvkWShUXZ5CxMAxC7R6xO0WZp8NkumuMuBovg6DNBS4a3I85ZdSa3AF8bno/k2IXs69FkTTI0z4B2JsW5FEmhQ2MgVBVaH+GaBlctcK6hqWv6ZmFRYbe/jDv/edLzx4huMQe4Tun+jMHr1NwyGa0yGzfo2nQP35gbuKG+3Xj2gdN7+sbocz1gxhkaUVo3I03z55X1fkPLKL8MGVWwNJbhHQoF4nga1bQ/RocZGWaqk8qyrEMgnP+A1Z1fQI++TgpA31tpztgNWriEXFEt9lYbICS0EQsIcGbfNyGvR/se6Tpc36GhM79TSlBKVNKAX+CrY5yrc6CBx7kFXiORtcG96CQYYuCi059Dx7TfboDbKLaCEShiai/YH7v5u0bN6uVga/B7t+k/UNVP8ueHwIP8+W3gg8l1H+bvXvT9jUNE/jTwpwFo3qZeNKj3tnw05VT7wbiBuhzlkPFqXNPgGiH1kRDCEK+rO8duc8zy3W+wu/pnpOs8XKqIRiMyuSyjklEcKSX6zBSjacO+k1Yz8ubAmQXL8Mu4IKIrlLuovAnVl5HVV/B3v4C/cxtdrUhNRXKFbCc0KinvHhHFew9JkRjxChI26PoJ6eLHhItvk7b/FA2PEL1khB3Y20wvYf46/6dQhPznQYivTHGKVhEHRika0RjQ+Al99xief4vOHyGLE9zy2Gri5noISc9g9UeR++8idYO6Halfo+0aQo/EMMb7Z1hs9RXiVtAossyVtBwUhFRVrJCHGuAjKRJ2W9hdEmMP2g0Q2MFdmCmgbnC+Qeoj0uIMVx0jiyX16ZdoL3/DzAgy6/3NNXvoXB5H2883N+tNos38PQczY/NZnc7vPlMficm8zcWhOM7t/L79RVK0O9PwBn1iAhFR7iuS6E0Dz/T9h/pySIwQSkF4i5h3oIG4eUS8+hbL1++jq1v0XYOm2qCeQzbHJM1e/gxHoB5cj0pAXUK8hfhqyJp7SBbLn6Y+uTJWFb5aUDUC7AgxInLLsIDSBsKngBWDV0p0UObXB0ZzHLPpEcaPQzWvAmRVRly5sQ8nmsL0PZ9Pq/z/giNXVVU+q1TL7+55fw74cwBy8k2lEovtjpnQuKw0ObKZxD4XuSqgVN7hqwbtnKmCCqRE33lkdQu5/QYaL0z1V0s8Im5IYQ3aZ4btUK2AGsv8aMzerFuLYBGfmbsM3N4GXTEo2CWid1G+BM1PU937GvWDt5Fbx4SFJ4gJFZbtG/OiS6OGoqB4Ysb7Sc7aJPUp/uiU+vUvsOi+SXz+Y/pH36K//IfQfYjjmpEQT7W9A4TnAFEfV+xUnRylFrl5YX5Xlngk229jQOMWZQ3bp0M2gSCoNCBvU71xDPWSVAVSu4H1Oew2lqRTIG3LRshY7VqJzUW1QBaJ5LxV+QIsJts2sUowCTAlC9rvtphTWkcpt3ew8yRfQ7WFRUtadvTVEnf8DtSvQXyCahrT6G5EWhySVj/reNH1h7Sy+bnRNHdIMn+Zaj+V6tmb48NtErC6ATOmvxdGOqkcJdnsOZKffXiQ+btmAofsn895LlKZUNfvaB9/G798i7r6GWIVjXgP0Xw+tyznCSi2r5LVXU4uCwlSgwTwDa6KpLDLGIpi2m2GVnbO49nRbz8lhg0sFjTLE2oS7eaHEN8H7SY9yeOrHABL3F8j07nTm5dOzs1gqfOcDeN2Y8w+3/F7JfqfisibqvpJNt88yt9/BLw7ue6d/N1HjOag8v2vffZrlJh6k6YjDKXDytp1kwWc0RlJiRDVaJCzcL9hkytGyI/OYBvR1kqvacyOKd1ZyrbWJCoshrzBOSP4mmpUmyzxl4U+ib3Xys5zH+FL+OOfY/HgZ/Bv3CfdXtDnqBINmFUoxxRLTAY3mwl/ieWRBKX4BC5LfyJE8agTWNyBN+4gr/0szfM/SPzkbxLPfwPXF+IPVqpv3LgikkMp99XPm4tm+s0+yR9IzWDmmEp0WSubMYVRXhEEqVbUi9foqgjpGhfWSFxD2hgjVjMNOJd9J86DaxBXo16QuiZ5j5VSlVxG0ROvE/TGSKvaERuHtAlkBxqyj1zyT0RdTsoJEdUWJwGV20hzglu9Q9r9AItAKhJvmfPPf4hMAPJ+V8dhwn+TiNxszVgGtmgNh699MfvZJ8RMJNVCrIrWkAWWaR2DiaZj9+49TA49r1ybUFqctiZ8oWh06GbN5tH3qW+dkvpjNO0QF6hqUO9Iwecay2LMIjOg2nu0qdBmAWoQ7b5KuCrSRYcGu8eRET0lINoSt49J/VPTYpq3qMSjmw+J23+A6BOsqtZeIt+NPSIcjM1/6QIqBF8Zx0ZmUzmft/Gvz4O/83sl+n8F+FPAn82//9PJ9/8zEflLmCP3IjOG/xL434vInXzdvwL8rz7zLapoCBbmR4VNphixdzpk3mkBTnKYjTdgk58v10rAe8R7NDmkOYNlBLeEtDQ0gHaHcI6mDkkRL8cICyP6IqhbkWRFSkeIXKG6xoo0k7G+a1RPUX0PWf0ii7d/jubdNwhnC7bGizKsg5qfYSD4WS0dFkaGlgBb/JpjcX1WP8XUXxXJMNIO/ILq9Z9mcfcd+k9/kfDh3yCtv4VLjxDpBoJzCK553HZTJrCvcr/4uBkeeugxMtn0WTNzR7hljfdraJ+h3TPor5BuSwzXJN2ARlL2nYj3IAvUvw5uBc0x1I6KBkWJIaBdpPEOTYluvSWmAHFL2J4j7VN8KmPhCl2wraWTCJBwjEsPaJZ3icd32J3XkDFap4ztxXK17kVTFYPB/sjefMI8GWty3UDBde9nfHIh8Dff86I5172/yx9jqHBu1IHW7hNrmVw7ZqjOyZ/M75swCwCnUkBtbd9LROltX0mDyApJK9L6mtg8xPt3CSGhfUesEq521FVFSgtisDh/1JhtJOLo8M6kLYkbYntB7Hb2DiegNc47vARSXBP6p2j73Nq2eEBdvwXdc3ZXfxtJPwDZjULNbEzG8SjYQuMV4zUy3DLfgTefN/WHsOfULc/cE7g+4/g8IZv/ISalvyYiH2JROH8W+Msi8m8DPwH+9Xz5f46Fa34fC9n8t3JDn4nI/w74B/m6/21x6n7G20lqaH2UgspjtOTQP0P4M8KpOkqzYBKhOoFKUG9WQq1O4LiCJlnm3/Jt5Pg9uH4fff5D2F6SWCJyBK4hSW2mHQFxG0QvSPrEbOlsMjO/S6p+lurBH2D51a/AvRVbByGbkgkgQY3ARLM7kkpyTzL7tRbiP1V/8yZKedO4TDQBYjTHlfdEX5P8Ke7tP8jy9nt0H/0dwuO/iXQ/AL0mqzlMF8V8ke1Lg2mQNMyu6rMqv09ERlV+qHE7W4Rl0bphsZrdVvFc0j56SLj6BOk2Fj3Vd5A2oNs8JoAKyTmQFdLUSLMl1ddInXC9EruOuD7HEYjREXdASEjt8CLEsEO7c2LY2hjkHTdzwIqZ2HS9JFw8hdUpPn5kKlnRtmbJSdm5e4N4T6TfqSloBk0MY0nEA1J44RqF+irD+jb+KcP3N46JED6+d1/KFqbZ4Adk09lxk5ztd3l6RofvtFB+LTbzclnMfRJGgiZ4zcRaHEIN2oAsELfCyxHiHH3XE69+TH0mNKs3iXJKbDekviVVHb7uaJolUBOSEFNH3F0bKlBbKrmtLV07gwA6B5VUkHpi95w+PIPYgpzh6zs0xw8Q2bK7+Efo7ttI2lDQesYxm07GlNAXTjYJgZ5M1HCfmgHUnra/j8oemor5MnnzZxP66fF5onf+By849ccPXKvA//QFz/nzwJ//3TROANEKpQJfQe1xlcNV5sAt16CaQ7LzRpNMoBw54gPUG6EJSZG6guNjXFDDheGEdPs2NV9g0f4K4eKKuO2sHqtmprJs8OLQtCNtzqF/CNffg/YcTcfo8c+x+OovUX/5Pn3j6CNoC9pqNk9qpt86m0/Ji2KUBwtxGTpnn1NRW8hqA8P3EhX1Ec2QBXr0gObL/y249Qa7H/8X6OafIHqNNeTAxj6oE062+hDRNL13kowkCYvymNqaJ+0fFmmWgBSEFvrHxPYK2vMc/dMb7EMKBtJWfBtZE1KJiAoLL3SxRbcB2ELYwfknwCUx1qC3qBYnpD5QV2VYR0c9MFZwEmu/as4aTpYzIdtP6bY/gmRS/pgEo7mvTMxxujeghcFOv9JsVmNuejk45nnwZrS0MFAZIwQPzNr+kw6RpEPHqC+Mc/y7M0nJ0Gcrcj+VSI3JjJrmNEnM5fOCkaPGmDvHCMc4OTE8JkmoXuNTS9w+pZdLVictzfG7xOoOfbclhGtSvyb6S6p6RV0tqf0CfEdSj/a5SHvoc1U7EJdM0I89XXeFxhaRM2RxhPcrqrpG02Pa818ntT9A2OSw1cl4lan6TFv+5MxEq7NVtc8QJs/IjHM+2nlfSRpnVx2f53ilM3JRWDTHtAo0nuqkRhZCJGYNoEihORpCdTD7UGEY61ZbGefysGabuvNicd8KJEu57hWib3DHt/AYn0mSnag1+BWIKu3VFp68TXp8Fy6e4usvcPy1r5DeOmILxJ1CJ0irSE9m1C5Hv+XNoRHUNBKnHo3RwMNiQmOW7n0mNCIWtSRiMCKCpZ+nnIaeLBFJAkhVkaqGUJ1QPfgDrJpTdj8+Ip3/BqJP5tL+Ie10/zDOmzWOeeRUuWBMmd+nRjJ7jg7XA+ka7T6lpqELAdIO1WBOU50kVWUqWe6tak9TQ9dfkbrI7lrxRGT9zCCUWdCsBOc8u25DOmpsM2rRNjKhlpJtmybZneCc4LUjtg/RcAml8MvQsSLtmzZkPZ8WEdlfwjph7IdI/Z5jeEji0clvzUiaeoOX3BDLh+9NeDgkf8rsmxfJ9XuS+2ceuvfbxmf4vF9ta8RfwMKjTxF3jMgCpEbUg0uIe47SE8OOpD1ODYIlba7Z6Y7F0SWu/gK13MJVdwjxmNRf0e12CM8Rr7jFEr84xlcLyIXNVa1gUlRHSI4UewRHvbqP+KXF52tHaD+g3/wm0n4X0Z2BNwJKGrN0ign2xgBPJH7dH5+9GZ7E8M/ZAROCP623PD325upFayIfrzbRFwHv8JUnOEVrM8MLDlLMmZ4WB4+TQYDQSpHakBdTIf4Y3ZKiUfYmQaaUVe6IQQdEI26IGsWv3bjVG0FV8MdLoEKPFtD1LB/cJS49bQexUzMB7yLap4HgW/EQGIiGOqb4Z+J9xvZJOUEsmc1eBHGClQw0acKXEMWUiKFF2w5iNg9lZhBTIFYV7s7P0Rzfofv+KenRf4ULG0ZP8os29OT7gpgoyuFiLQL4jGToQKu9Z/g8njn01RwvKJesH/86R/d+GpWOPm7siRkYTVGzaJV+5zlJaYumS2tKH02CrzzOQSRCvCS2peiLI/YxMw83EO8hdFGSaTGaEK1wTqhcJIRPSd0zRDssAc6Ei6k0Zj0Xxlj3vXEbLsz+poEtzon8jFkOn7MmsRcUN1z7GZt6uHpw2E/bbM+4+eRsGi2MqSQ8QEG933v+KDyUZLQbpqRhaPb7l3/EIVgYrrg6R9C0JL0mabToutgzi0bDIWo+AI0X7NpHVCcfUC++SuXftiQqOUJ7iH00XPx+Q9y2Nh7aZ+0tILLCL+7h6iXJVwgB6oU1Ol7Q989I2w8hbFEWOCJmq9VhDMfY+jFLZiTl46zdHLvpp4kANcz5NLO3XDkJ8Tz0zJeE+U6PV5roqwidBhDB1Q5qhYXgvEDOpLSamYL0YjVyRZHaIY1Da4VKzAdAni9kyPDEDWtpjDwYCEKWRJJJ5rpLbPtkBLYPJnUvlzRv3qatIG2BTUQ6jKF0GQYgh5U6l7ULMUsGao7noqCoCOKzTdONcb/OFf9EkZsmhEsE7zwpOlJrOQlWSDxB8qSUSM2SuHibxVf+ZfruI9LTb1k8PYeX40i+JlfMNq/9MRKPERtklIjz5s8oV0o13FHuFe3Q7iN2T7e46gSXKpBjVGtm5SMnEqJIIoVrNutHKEuIFRCJGsw34wSCSYX0AamPyPYaYx5SZVNUiWiKI0ibOmpfkfQZsXsGqcvrYuz3MF4Dhvlh4jm2O/djEGon51+mWe1J+faxSMt7E3X4z8n4jX+/2MijQ3tsxepA8Me7X6AVZAl3jFDaG6sX3gejf6UnpZaiUZaIMzNhjPkCNjSZGSVwGtHUEsIz0uITqtWXcPUDRG+Z0c0pqpbo6KRCEZLWaCZ74hrLy6iPSf0al9ZIeILGc9PyQofXCNzKvXiGVWSbro3S5dKXz0d4Z6MzG56JlK+f93mf/33wihN9nEKVQHpSFKSt8csa3wi+xqBUzTJAqaWavEIDLIBKLNs/m5stU9NooniGFEIBpBJDhszx5gXl1nKJTItIIUEXYNeiTcXy5ITkIG4VXUcLDezIUPp5sYsYNgymWZiEbm1wZV6ndKCsAhEkTTfMiHIyvUcy/hC9QJ9IOeSzhJKq9KhWhPpLLL/0r7HZPEY3HyASh0061Ub3ZRBmbRx0HkoZuKndlolEaPkLo0llMG3o5MqUSO1jUncB7ghfB9SdoJRwO7tvAOEC2+Tba3xdMIrGEErBD9oOmhPbNJqfIA+2hcYakJxqyPZZwftA0meE/rHlYQxga2VE4rjL900n+wS4EMCyaQui6eeQ0G+M/+zjdHML7Nt6BqIzS+I/8I6bUui0LwfzNw68fvrdSJ/0wIkDD1AAC5NV3Q1lC+2cUFA4Z1Lw8G8ambEqLiiEj+nb57j6FF+9hrhjKncb5BbKEpfhO1zRcJ2SaEEukRhx/Udo9x369hMj+AQ8Nc6d4qpjkFNSqDMk8wUiHXPTXMmLmSa1eUo0lLl9J87zQ4rTdHBlOsCjsDXb+8M/nyFI7B2vNtEHxAeTxpMjXQe6FKhSgz8SxClxF4nXAemVhEcXFa6uSK4g2hnB1gQuQcmedQAOYgnjzxadQdAXQ2tMzlAlJXpC7wxsadGwOKnR2hF2CruEaxPSqQFCJSib3VIHoiUCeSPcolmaKptrCNnMG27YN2kI3pmtA8QwbCS321lIo0rua5zDMgg1oaqobn2D5gv/It0P/xPDtKG8dz/hqBzKrLLTQCvmUrsqpIK+KMKQwakcfLYB0kULr43OHLSpI8YNrlrh6vvgz4jJ2dhMMkJJO+g2iJzgfAJJtj5UQSvQOvcrZiHUauZatE0g6Q5oKTH7ThJKR2JLCudWSEUDUuz0h4j1nmNbdWr22qeMmfgXtW5YYHuX7o37/Bkv+u4F309eO14zEvry3024s+kTpyGE+1I/s4Cd6ZO5ceX0GVMBoURPlbErUhaAwS8oo7BAZs5jhEsWCKZ1ePsNqd+Q3GNwS8S/hq/u4dwtxFVmGtQ1KtvsOqlRvUvol4TNdyB+jNMdooGCsRXcOc4f490tpDrGxTOrya1XQItKcVBnv0tOJFRtrB8IZpbpc/sP77Vp6POIwwPD/lEbo5FKTId1Esr4OSj/q030VQmhg6AgBr+r247e9aRdIPXBQMJ2Cd2qUenXT3G+zsRvktOUMLNOwOCZ0+gUU1U05pSoPPaFXpVk44JCDOAWC5xz9FuIbYQuIV0iddHK/ZWws8wwUuxNeElVrstph4hpFSk7Yocwt3EA8qSOEr7kRDPNyU/eewSLQIjFr1GkXYlIShDsmS01zRt/CPfkN+DJsxds+UPzwAEpNX+pbnIub74XZYgUlb28WcvGFywmuyOFLcQdrr5H1dxFZWkJbQlT0yQCOwg7vGtIzuLsteAi5WLYmnI5PA0WfqdZBdOAFdXsgR5VO6dpY7beVKT8A12emV7AcirKd4fGcYqJMhuhzz4mF8pn3HXwrNyctImsOPw13Cs3r91/BzLt0TRTd0/DG8Zo2oaX9/qlgu/0m7wlpn4SKMKSzYOkHDoX12jwRNmB64jxGRovQXImrVsg9VtIuI30lzh2CP1EA7Z9lPQClR1OFjh/C3VnEI5RNsA2j00ZF4/oAmiyczYgekXRhOYrYdq7iRB4YBTmNXb3Z7wIb3rjCYeOV57o+743DZ0KSYrzoN2GtF7DpjVPbWhgt0JOF/h6gYuQWkt8cmrQDTEDQxEVLCowV3KCggczLOgsxGmUYbJKe8r49h2kTi32vo9or2PsvaQMFJkl5Wip4IYhP9lurqI8cIg+AkZHcg4xK9EsRfIuhFMEnDcseVUr8I5HY4Z2EEGSywQ1oeqJ9X2qN/4g/fl3kXg9kcinHZ1NwvzrQa0uEpaZcGTY+MoYn74vcureT/G8lxfkLDZdk2JPjDuq5h6VOyUU6VCjxfGnDZKOco4GGXvJxliSFu6Oxg3EtdnoU4voBtI62wQzM0hdNjPorJ0Dq51ljjJIdvM+lc974u9ArGzHm4T8OQihTj9O3683zo9niqRfxnyf8DJ50j4rmUvi8v9p72xD7LjKOP77372b0G5eumlLCGltEqliPtkYSj60/SRpErTxBSQiNL6ACAoWEYkEpF+r6AdRLIrFVqotosV8ERtF9FOqbdw2qe02mxjRsE0wFTfkZXfvzOOH88y9527u3uam2Zm57vnB7J373JnZ/zxn5pkzz5w5J1o9XvKqS0n7p16/L9zPnrWH8EvUqiweXaJ9RyUIzT7jLXeOs66qkuEVryZmPupOdhnyGWSzob4tC2Wvi5DfTEPNruOw0+TUUwE2T64s9OGjNai5CmyUho2FI79R3L14Oti8lsksPuouFO8hRL7qvvnpKnTaF562ya46HeMNde4W+gf+egf9PCebnUM0UbNBPpczsiKH1hXswgxcvALZCrDVoLWMrroZRkXrSk5+eRbmjEyjoSvm0Tw0gTSFYFx0tlQ4KM+xzFMTzQZqqnNyxnFrZAQh79c79Oxn8943UGbhxSvwRiyhr/bQxtig1fLcsoUH0A3vGlmN0FLHwkVDI75M1gppmNx7/rNWJ9XsA5HkIzmMKjz8lfmdRJjyPEPtF8AAGuSs4Kbx99G6aS3ZpYvtni3aTQUXPauLoy0+sELLHFH0e9IuOF++COi9AmSMUQyYEbabA7Nk8+fJs0uMrFzPyOitmIksc1/ks8haNPKm/7fwNxz4oWuFBhnzrUuQeRcMliPmyO0Cll1EVrQMyaL/HfTHaYQunX17MdSCbwv2t3gYu2j796tP1nbA91q22l1aX71qd4gNF1X10Fs8Jym+dT8B6CR/2pKse8vtmn2RVghdp2LtIf36XdQWC0pRZQZviu37G7piwJvZdrbZ6eK50TnOVOTWRwgDi4TWYDlh+MOG3yk3KN77uILUgsYYeTaKmPfTQJ31283sGj6M4gUgp6ExULPjJ8DIyJkHm/ULjLeU85RvcQG1rvOp2wtdqd/iQmhdya7oMpe3v6t9rvWpTIRt9V+gShSGpZmsWscA3Ab8u2oRAzBMeodJKwyX3mHSCknvtXCXmd3e64d61/Rh0sy2Vy3iWpH0YtK7NAyTVhguvcOkFZLed8q1vbebSCQSif8LUtBPJBKJZUTdg/4PqxYwIEnv0jFMWmG49A6TVkh63xG1fpCbSCQSiRtL3Wv6iUQikbiBpKCfSCQSy4jaBn1JuyRNSpqSdKAGeu6U9AdJf5P0qqQvu/1RSWckTfi0J1rn665/UtKDFWg+LemY63rRbeskHZZ0wj/H3S5J33W9r0jaVrLW90Y+nJA0I+mRuvhX0hOSzkk6HtkG9qWk/b78CUn7S9b7LUmvu6bnJN3i9k2SLkc+fjxa5wN+DE35Pr39e/43RuvA5V5WzFhE77OR1tOSJtxeqW97Yma1mwivep4EthD6zHwZ2Fqxpg3ANp9fDbwBbAUeBb7aY/mtrnslsNn3Z6RkzaeB2xbYvgkc8PkDwGM+vwf4DeE9wR3ACxWX/5vAXXXxL/AAsA04fr2+BNYBp/xz3OfHS9S7E2j6/GOR3k3xcgu282ffB/k+7S5J60DlXmbM6KV3we/fBr5RB9/2mupa078XmDKzU2Y2BzwD7K1SkJlNm9lRn78AvAZs7LPKXuAZM5s1s78Txg2+d+mVvi17gSd9/kngI5H9KQscAW6RtKECfRCG4jxpZv/os0yp/jWzPwFv9dAwiC8fBA6b2Vtm9h/gMLCrLL1m9ryZFSNxHAHu6LcN17zGzI5YiFJP0dnHJdXah8XKvbSY0U+v19Y/Afy83zbK8m0v6hr0NwL/jL7/i/4BtlQkbQLuAV5w05f8lvmJ4hafeuyDAc9LeknS59223symff5NYL3P10FvwT66T5q6+ndQX9ZBc8FnCbXLgs2S/irpj5Lud9tGgsaCsvUOUu518e39wFkzOxHZauXbugb92iJpFfBL4BEzmwF+ALwbeD8wTbi1qwv3mdk2YDfwRUkPxD96DaNWbXYlrQAeAn7hpjr7t00dfbkYkg4SuoB82k3TwLvM7B7gK8DPJK2pSp8zFOXeg0/SXWGpnW/rGvTPAHdG3+9wW6VIGiUE/KfN7FcAZnbWzDIzy4Ef0UkxVL4PZnbGP88Bz7m2s0Xaxj/P+eKV63V2A0fN7CzU278M7svKNUv6NPAh4FN+ocJTJed9/iVCbvw9ri1OAZWm9zrKvQ6+bQIfA54tbHX0bV2D/l+AuyVt9prfPuBQlYI8V/dj4DUz+05kj/PeHwWKJ/qHgH2SVkraDNxNeHBTlt4xSauLecJDvOOuq2g1sh/4daT3YW95sgP4b5S6KJOumlJd/RtpGMSXvwV2Shr3dMVOt5WCpF3A14CHzOxSZL9dPqKPpC0EX55yzTOSdvjx/3C0j0utddByr0PM+CDwupm10zZ19O2SPym+3onQAuINwpXxYA303Ee4fX8FmPBpD/BT4JjbDwEbonUOuv5JSnoyH/3vLYQWDC8DrxY+BG4Ffg+cAH4HrHO7gO+73mPA9gp8PAacB9ZGtlr4l3AhmgbmCfnXz12PLwm59CmfPlOy3ilC3rs4fh/3ZT/ux8gEcBT4cLSd7YSAexL4Hv4WfwlaBy73smJGL71u/wnwhQXLVurbXlPqhiGRSCSWEXVN7yQSiURiCUhBP5FIJJYRKegnEonEMiIF/UQikVhGpKCfSCQSy4gU9BOJRGIZkYJ+IpFILCP+ByoTaxD163vUAAAAAElFTkSuQmCC",
-                        "text/plain": [
-                            "<Figure size 432x288 with 1 Axes>"
-                        ]
-                    },
-                    "metadata": {
-                        "needs_background": "light"
-                    },
-                    "output_type": "display_data"
-                }
-            ],
-            "source": [
-                "vidcap = cv2.VideoCapture(\"/tmp/sample_video.mp4\")\n",
-                "success, image = vidcap.read()\n",
-                "image = image[:, :, ::-1]\n",
-                "# Note that frameNumber 1 in the annotation is frame index 0s\n",
-                "count = 1\n",
-                "while success and count < 20:\n",
-                "    plt.figure(1)\n",
-                "    plt.imshow(image)\n",
-                "    plt.title('frameNumber ' + str(count))\n",
-                "    plt.pause(0.25)\n",
-                "    plt.clf()\n",
-                "    success, image = vidcap.read()\n",
-                "    count += 1\n",
-                "    if success and count < 20:\n",
-                "        clear_output(wait=True)\n",
-                "    image = image[:, :, ::-1]"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 13,
-            "id": "vanilla-bridges",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "headers = {\"Authorization\": f\"Bearer {API_KEY}\"}\n",
-                "annotations = ndjson.loads(requests.get(annotations_url, headers=headers).text)\n",
-                "# Make it easy to lookup\n",
-                "annotations = {annot[\"frameNumber\"]: annot for annot in annotations}\n",
-                "print(annotations[1])"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 14,
-            "id": "abandoned-knight",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "def visualize_bbox(image: np.ndarray, tool: Dict[str, Any]) -> np.ndarray:\n",
-                "    \"\"\"\n",
-                "    Draws a bounding box on an image\n",
-                "    \n",
-                "    Args:\n",
-                "        image (np.ndarray): image to draw a bounding box onto\n",
-                "        tool (Dict[str,any]): Dict response from the export\n",
-                "    Returns:\n",
-                "        image with a bounding box drawn on it.\n",
-                "    \"\"\"\n",
-                "    start = (int(tool[\"bbox\"][\"left\"]), int(tool[\"bbox\"][\"top\"]))\n",
-                "    end = (int(tool[\"bbox\"][\"left\"] + tool[\"bbox\"][\"width\"]),\n",
-                "           int(tool[\"bbox\"][\"top\"] + tool[\"bbox\"][\"height\"]))\n",
-                "    return cv2.rectangle(image, start, end, (255, 0, 0), 5)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "excess-hamburg",
-            "metadata": {},
-            "source": [
-                "#### Visualize annotations overlaid onto individual frames"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 15,
-            "id": "balanced-investment",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "vidcap = cv2.VideoCapture('/tmp/sample_video.mp4')\n",
-                "success, image = vidcap.read()\n",
-                "image = image[:, :, ::-1]\n",
-                "# Note that frameNumber 1 in the annotation is frame index 0\n",
-                "count = 1\n",
-                "\n",
-                "while success and count < 20:\n",
-                "    annotation = annotations.get(count)\n",
-                "    if annotation is not None:\n",
-                "        for tool in annotation['objects']:\n",
-                "            if 'bbox' in tool:\n",
-                "                image = visualize_bbox(image.astype(np.uint8), tool)\n",
-                "    plt.figure(1)\n",
-                "    plt.imshow(image)\n",
-                "    plt.title('frameNumber ' + str(count))\n",
-                "    plt.pause(0.25)\n",
-                "    plt.clf()\n",
-                "\n",
-                "    success, image = vidcap.read()\n",
-                "    count += 1\n",
-                "    if success and count < 20:\n",
-                "        clear_output(wait=True)\n",
-                "    image = image[:, :, ::-1]"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python 3",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.9.2"
-        }
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "db768cda",
+      "metadata": {
+        "id": "db768cda"
+      },
+      "source": [
+        "<td>\n",
+        "   <a target=\"_blank\" href=\"https://labelbox.com\" ><img src=\"https://labelbox.com/blog/content/images/2021/02/logo-v4.svg\" width=256/></a>\n",
+        "</td>"
+      ]
     },
-    "nbformat": 4,
-    "nbformat_minor": 5
+    {
+      "cell_type": "markdown",
+      "id": "cb5611d0",
+      "metadata": {
+        "id": "cb5611d0"
+      },
+      "source": [
+        "<td>\n",
+        "<a href=\"https://colab.research.google.com/github/Labelbox/labelbox-python/blob/develop/examples/label_export/video.ipynb\" target=\"_blank\"><img\n",
+        "src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>\n",
+        "</td>\n",
+        "\n",
+        "<td>\n",
+        "<a href=\"https://github.com/Labelbox/labelbox-python/tree/develop/examples/label_export/video.ipynb\" target=\"_blank\"><img\n",
+        "src=\"https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white\" alt=\"GitHub\"></a>\n",
+        "</td>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "employed-baptist",
+      "metadata": {
+        "id": "employed-baptist"
+      },
+      "source": [
+        "# Video Data Export\n",
+        "Export labels from video annotation projects."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "located-egyptian",
+      "metadata": {
+        "id": "located-egyptian"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install -q labelbox numpy matplotlib ipython"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "supported-shield",
+      "metadata": {
+        "id": "supported-shield"
+      },
+      "outputs": [],
+      "source": [
+        "from labelbox import Client\n",
+        "from matplotlib import pyplot as plt\n",
+        "from IPython.display import clear_output\n",
+        "import numpy as np\n",
+        "import json\n",
+        "import ndjson\n",
+        "import requests\n",
+        "import cv2\n",
+        "from typing import Dict, Any\n",
+        "import os"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "nominated-press",
+      "metadata": {
+        "id": "nominated-press"
+      },
+      "outputs": [],
+      "source": [
+        "# Pick a video project with completed bounding box labels\n",
+        "PROJECT_ID = \"cktu4ft8q3xvy0y6t41p5dh9g\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "7457a04f",
+      "metadata": {
+        "id": "7457a04f"
+      },
+      "source": [
+        "# API Key and Client\n",
+        "Provide a valid api key below in order to properly connect to the Labelbox Client."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "aerial-general",
+      "metadata": {
+        "id": "aerial-general"
+      },
+      "outputs": [],
+      "source": [
+        "# Add your api key\n",
+        "API_KEY = \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJja3R1NGZ0N28zeHZxMHk2dDd6NGtoa3R5Iiwib3JnYW5pemF0aW9uSWQiOiJja3R1NGZ0N2UzeHZwMHk2dGd2MjRkOW13IiwiYXBpS2V5SWQiOiJja3Z2Z2ViYjUyZWpiMHphejNqOHVhNGt2Iiwic2VjcmV0IjoiMGFiZWM5ZjI4YzY3OTNiNTE5Mjk1MjJmZThjNDBhMGMiLCJpYXQiOjE2MzY2NjU1MjcsImV4cCI6MjI2NzgxNzUyN30.F61IZPYWCBAtXI30W2h0NgKRFkOGm4LIJwd0aJ9EZ-I\"\n",
+        "client = Client(api_key=API_KEY)\n",
+        "project = client.get_project(PROJECT_ID)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "finished-helicopter",
+      "metadata": {
+        "id": "finished-helicopter"
+      },
+      "source": [
+        "### Export the labels"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "gothic-investing",
+      "metadata": {
+        "id": "gothic-investing"
+      },
+      "outputs": [],
+      "source": [
+        "export_url = project.export_labels()\n",
+        "\n",
+        "# labels can also be exported with `start` and `end` filters\n",
+        "# export_url = project.export_labels(start=\"2020-01-01\", end=\"2020-01-02\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "temporal-citation",
+      "metadata": {
+        "id": "temporal-citation"
+      },
+      "outputs": [],
+      "source": [
+        "print(export_url)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "sustained-retro",
+      "metadata": {
+        "id": "sustained-retro"
+      },
+      "outputs": [],
+      "source": [
+        "exports = requests.get(export_url).json()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "crude-sender",
+      "metadata": {
+        "id": "crude-sender"
+      },
+      "source": [
+        "To get more information on the fields in the label payload, follow [our documentation here](https://docs.labelbox.com/data-model/en/index-en#label)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Note that for a video export, a list of exports is created, with one export per data row\n",
+        "type(exports)"
+      ],
+      "metadata": {
+        "id": "3CqHTL0zUBzM"
+      },
+      "id": "3CqHTL0zUBzM",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "human-beginning",
+      "metadata": {
+        "id": "human-beginning"
+      },
+      "outputs": [],
+      "source": [
+        "# Let's check out the export for the first data row (video)\n",
+        "exports[0]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# View some specific fields of the export\n",
+        "print(\"Label ID:\", exports[0]['DataRow ID'])\n",
+        "print(\"Created By:\", exports[0]['Created By'])\n",
+        "print(\"Created At:\", exports[0]['Created At'])\n",
+        "print(\"Reviews:\", exports[0]['Reviews'])"
+      ],
+      "metadata": {
+        "id": "nbW2XAXKUtBY"
+      },
+      "id": "nbW2XAXKUtBY",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# View the video in your browser by clicking on the link produced\n",
+        "video_url = exports[0][\"Labeled Data\"]\n",
+        "print(video_url)"
+      ],
+      "metadata": {
+        "id": "GfYvJchcVL6e"
+      },
+      "id": "GfYvJchcVL6e",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "id": "adaptive-format",
+      "metadata": {
+        "id": "adaptive-format"
+      },
+      "source": [
+        "### View the annotation data\n",
+        "The label for each frame of the video must be fetched individually."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "crazy-swing",
+      "metadata": {
+        "id": "crazy-swing"
+      },
+      "outputs": [],
+      "source": [
+        "# Grab the annotations url\n",
+        "annotations_url = exports[0][\"Label\"][\"frames\"]\n",
+        "print(annotations_url)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Provide the appropriate authorization to view the labeled frames\n",
+        "headers = {\"Authorization\": f\"Bearer {API_KEY}\"}\n",
+        "annotations = ndjson.loads(requests.get(annotations_url, headers=headers).text)"
+      ],
+      "metadata": {
+        "id": "u3q_cLKzVkZ8"
+      },
+      "id": "u3q_cLKzVkZ8",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Make the data easy to lookup by assigning each frame its frame number\n",
+        "annotations = {annot[\"frameNumber\"]: annot for annot in annotations}\n",
+        "\n",
+        "# Grab the first frame and print the contents\n",
+        "first_frame = annotations[1]\n",
+        "print(json.dumps(first_frame, indent=2))"
+      ],
+      "metadata": {
+        "id": "UadFAlS5hJon"
+      },
+      "id": "UadFAlS5hJon",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Grab values of the first object in the first annotation\n",
+        "print(\"schemaId:\", first_frame['objects'][0]['schemaId'])\n",
+        "print(\"title:\", first_frame['objects'][0]['title'])\n",
+        "print(\"is a keyframe?:\", first_frame['objects'][0]['keyframe'])\n",
+        "print(\"bbox dimensions:\", first_frame['objects'][0]['bbox'])"
+      ],
+      "metadata": {
+        "id": "N9fBeuosWmdF"
+      },
+      "id": "N9fBeuosWmdF",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Visualize annotations"
+      ],
+      "metadata": {
+        "id": "uMFffzIKY_jc"
+      },
+      "id": "uMFffzIKY_jc"
+    },
+    {
+      "cell_type": "markdown",
+      "id": "legitimate-poland",
+      "metadata": {
+        "id": "legitimate-poland"
+      },
+      "source": [
+        "Turn video into individual frames"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "thermal-conditioning",
+      "metadata": {
+        "id": "thermal-conditioning"
+      },
+      "outputs": [],
+      "source": [
+        "# Store the video url in a file\n",
+        "with open(\"/tmp/sample_video.mp4\", \"wb\") as file:\n",
+        "    file.write(requests.get(video_url).content)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "framed-harris",
+      "metadata": {
+        "id": "framed-harris"
+      },
+      "outputs": [],
+      "source": [
+        "vidcap = cv2.VideoCapture(\"/tmp/sample_video.mp4\")\n",
+        "success, image = vidcap.read()\n",
+        "image = image[:, :, ::-1]\n",
+        "# Note that frameNumber 1 in the annotation is frame index 0s\n",
+        "count = 1\n",
+        "while success and count < 20:\n",
+        "    plt.figure(1)\n",
+        "    plt.imshow(image)\n",
+        "    plt.title('frameNumber ' + str(count))\n",
+        "    plt.pause(0.25)\n",
+        "    plt.clf()\n",
+        "    success, image = vidcap.read()\n",
+        "    count += 1\n",
+        "    if success and count < 20:\n",
+        "        clear_output(wait=True)\n",
+        "    image = image[:, :, ::-1]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "abandoned-knight",
+      "metadata": {
+        "id": "abandoned-knight"
+      },
+      "outputs": [],
+      "source": [
+        "# Helper function\n",
+        "def visualize_bbox(image: np.ndarray, tool: Dict[str, Any]) -> np.ndarray:\n",
+        "    \"\"\"\n",
+        "    Draws a bounding box on an image\n",
+        "    \n",
+        "    Args:\n",
+        "        image (np.ndarray): image to draw a bounding box onto\n",
+        "        tool (Dict[str,any]): Dict response from the export\n",
+        "    Returns:\n",
+        "        image with a bounding box drawn on it.\n",
+        "    \"\"\"\n",
+        "    start = (int(tool[\"bbox\"][\"left\"]), int(tool[\"bbox\"][\"top\"]))\n",
+        "    end = (int(tool[\"bbox\"][\"left\"] + tool[\"bbox\"][\"width\"]),\n",
+        "           int(tool[\"bbox\"][\"top\"] + tool[\"bbox\"][\"height\"]))\n",
+        "    return cv2.rectangle(image, start, end, (255, 0, 0), 5)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "excess-hamburg",
+      "metadata": {
+        "id": "excess-hamburg"
+      },
+      "source": [
+        "Overlay annotations on frames"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "balanced-investment",
+      "metadata": {
+        "id": "balanced-investment"
+      },
+      "outputs": [],
+      "source": [
+        "vidcap = cv2.VideoCapture('/tmp/sample_video.mp4')\n",
+        "success, image = vidcap.read()\n",
+        "image = image[:, :, ::-1]\n",
+        "# Note that frameNumber 1 in the annotation is frame index 0\n",
+        "count = 1\n",
+        "\n",
+        "while success and count < 20:\n",
+        "    annotation = annotations.get(count)\n",
+        "    if annotation is not None:\n",
+        "        for tool in annotation['objects']:\n",
+        "            if 'bbox' in tool:\n",
+        "                image = visualize_bbox(image.astype(np.uint8), tool)\n",
+        "    plt.figure(1)\n",
+        "    plt.imshow(image)\n",
+        "    plt.title('frameNumber ' + str(count))\n",
+        "    plt.pause(0.25)\n",
+        "    plt.clf()\n",
+        "\n",
+        "    success, image = vidcap.read()\n",
+        "    count += 1\n",
+        "    if success and count < 20:\n",
+        "        clear_output(wait=True)\n",
+        "    image = image[:, :, ::-1]"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.9.2"
+    },
+    "colab": {
+      "name": "[REVISED] video.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
Significantly revised the text and video export notebooks to demonstrate how to parse through the exports in both cases, which was especially needed for video example, and how to convert annotation types to ndjson for text. I also removed the very project-specific example at the end of the original text notebook, which had no reusability. Additionally, the video export notebook also came with a project ID, but the visualization task at the end is well-written and applies to all projects, so I kept it.