### PR TITLE
[AL-2193] Deprecation message for Python 3.6

### DIFF
--- a/labelbox/__init__.py
+++ b/labelbox/__init__.py
@@ -1,6 +1,13 @@
 name = "labelbox"
 __version__ = "3.19.1"
 
+import sys
+import warnings
+
+if sys.version_info < (3, 7):
+    warnings.warn("""Python 3.6 will no longer be actively supported 
+    starting 06/01/2022. Please upgrade to Python 3.7 or higher.""")
+
 from labelbox.client import Client
 from labelbox.schema.project import Project
 from labelbox.schema.model import Model


### PR DESCRIPTION
We will be no longer supporting 3.6 starting 6/1/22. We will support 3.7-3.9