### PR TITLE
[AL-2196] Test Update for Test batch

### DIFF
--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -16,7 +16,6 @@ def big_dataset(dataset: Dataset):
     task.wait_till_done()
 
     yield dataset
-    dataset.delete()
 
 
 def test_create_batch(configured_project: Project, big_dataset: Dataset):

--- a/tests/integration/test_data_row_metadata.py
+++ b/tests/integration/test_data_row_metadata.py
@@ -46,7 +46,6 @@ def big_dataset(dataset: Dataset, image_url):
     task.wait_till_done()
 
     yield dataset
-    dataset.delete()
 
 
 def make_metadata(dr_id) -> DataRowMetadata:


### PR DESCRIPTION
We did not have logging for it before, but this was updated - deleting a dataset twice technically tries to delete a nonexistent dataset. Because of this, the SDK tests now fail from test_batch.py. This update removes the double delete problem