### PR TITLE
[X-0] Fix M1 test issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apt install -y libsm6 \
                 ffmpeg \
                 libfontconfig1 \
                 libxrender1 \
-                libgl1-mesa-glx
+                libgl1-mesa-glx \
+                libgeos-dev
 
 WORKDIR /usr/src/labelbox
 COPY requirements.txt /usr/src/labelbox


### PR DESCRIPTION
Running tests locally on Mac M1's was failing with ```OSError: Could not find lib geos_c or load any of its variants ['libgeos_c.so.1', 'libgeos_c.so'].```

Adding `libgeos-dev` to the install list in Dockerfile resolves the issue.