### PR TITLE
[AL-2218] Adding optional metadata_fields to create_data_row()

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -90,6 +90,7 @@ class Client:
             'Authorization': 'Bearer %s' % api_key,
             'X-User-Agent': f'python-sdk {SDK_VERSION}'
         }
+        self.data_row_metadata_ontology = None
 
     @retry.Retry(predicate=retry.if_exception_type(
         labelbox.exceptions.InternalServerError))
@@ -648,7 +649,9 @@ class Client:
             DataRowMetadataOntology: The ontology for Data Row Metadata for an organization
 
         """
-        return DataRowMetadataOntology(self)
+        if self.data_row_metadata_ontology is None:
+            self.data_row_metadata_ontology = DataRowMetadataOntology(self)
+        return self.data_row_metadata_ontology
 
     def get_model(self, model_id) -> Model:
         """ Gets a single Model with the given ID.

--- a/labelbox/orm/model.py
+++ b/labelbox/orm/model.py
@@ -54,6 +54,17 @@ class Field:
         def name(self):
             return self.enum_cls.__name__
 
+    class ListType:
+
+        def __init__(self, list_cls: type):
+            self.list_cls = list_cls
+
+        @property
+        def name(self):
+            if self.list_cls.__name__ == "DataRowMetadataField":
+                return "[DataRowMetadataFieldInput!]"
+            return self.list_cls.__name__
+
     class Order(Enum):
         """ Type of sort ordering. """
         Asc = auto()
@@ -91,8 +102,12 @@ class Field:
     def Json(*args):
         return Field(Field.Type.Json, *args)
 
+    @staticmethod
+    def List(list_cls: type, *args):
+        return Field(Field.ListType(list_cls), *args)
+
     def __init__(self,
-                 field_type: Union[Type, EnumType],
+                 field_type: Union[Type, EnumType, ListType],
                  name,
                  graphql_name=None):
         """ Field init.

--- a/labelbox/orm/query.py
+++ b/labelbox/orm/query.py
@@ -41,7 +41,7 @@ def results_query_part(entity):
         entity (type): The entity which needs fetching.
     """
     # Query for fields
-    fields = [field.graphql_name for field in entity.fields()]
+    fields = [field.graphql_name if field.graphql_name != "metadataFields" else "metadataFields { value schemaId }" for field in entity.fields()]
 
     # Query for cached relationships
     fields.extend([

--- a/labelbox/orm/query.py
+++ b/labelbox/orm/query.py
@@ -41,7 +41,10 @@ def results_query_part(entity):
         entity (type): The entity which needs fetching.
     """
     # Query for fields
-    fields = [field.graphql_name if field.graphql_name != "metadataFields" else "metadataFields { value schemaId }" for field in entity.fields()]
+    fields = [
+        field.graphql_name if field.graphql_name != "metadataFields" else
+        "metadataFields { value schemaId }" for field in entity.fields()
+    ]
 
     # Query for cached relationships
     fields.extend([

--- a/labelbox/schema/data_row.py
+++ b/labelbox/schema/data_row.py
@@ -5,6 +5,7 @@ from typing import List, Dict, Union, TYPE_CHECKING
 from labelbox.orm import query
 from labelbox.orm.db_object import DbObject, Updateable, BulkDeletable
 from labelbox.orm.model import Entity, Field, Relationship
+from labelbox.schema.data_row_metadata import DataRowMetadataField
 
 if TYPE_CHECKING:
     from labelbox import AssetAttachment
@@ -34,6 +35,7 @@ class DataRow(DbObject, Updateable, BulkDeletable):
     updated_at = Field.DateTime("updated_at")
     created_at = Field.DateTime("created_at")
     media_attributes = Field.Json("media_attributes")
+    metadata_fields = Field.List(DataRowMetadataField, "metadata_fields")
 
     # Relationships
     dataset = Relationship.ToOne("Dataset")

--- a/labelbox/schema/data_row.py
+++ b/labelbox/schema/data_row.py
@@ -1,11 +1,10 @@
 import logging
-from datetime import datetime
-from typing import List, Dict, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from labelbox.orm import query
 from labelbox.orm.db_object import DbObject, Updateable, BulkDeletable
 from labelbox.orm.model import Entity, Field, Relationship
-from labelbox.schema.data_row_metadata import DataRowMetadataField
+from labelbox.schema.data_row_metadata import DataRowMetadataField # type: ignore
 
 if TYPE_CHECKING:
     from labelbox import AssetAttachment

--- a/labelbox/schema/data_row_metadata.py
+++ b/labelbox/schema/data_row_metadata.py
@@ -230,7 +230,8 @@ class DataRowMetadataOntology:
                     self._refresh_ontology()
                     if f["schemaId"] not in self.fields_by_id:
                         raise ValueError(
-                            f"Schema Id `{f['schemaId']}` not found in ontology")
+                            f"Schema Id `{f['schemaId']}` not found in ontology"
+                        )
 
                 schema = self.fields_by_id[f["schemaId"]]
                 if schema.kind == DataRowMetadataKind.enum:

--- a/labelbox/schema/data_row_metadata.py
+++ b/labelbox/schema/data_row_metadata.py
@@ -136,6 +136,10 @@ class DataRowMetadataOntology:
             str,
             DataRowMetadataSchema] = self._make_name_index(self.custom_fields)
 
+    def _refresh_ontology(self):
+        self._raw_ontology = self._get_ontology()
+        self._build_ontology()
+
     @staticmethod
     def _make_name_index(fields: List[DataRowMetadataSchema]):
         index = {}
@@ -221,6 +225,13 @@ class DataRowMetadataOntology:
         for dr in unparsed:
             fields = []
             for f in dr["fields"]:
+                if f["schemaId"] not in self.fields_by_id:
+                    # Update metadata ontology if field can't be found
+                    self._refresh_ontology()
+                    if f["schemaId"] not in self.fields_by_id:
+                        raise ValueError(
+                            f"Schema Id `{f['schemaId']}` not found in ontology")
+
                 schema = self.fields_by_id[f["schemaId"]]
                 if schema.kind == DataRowMetadataKind.enum:
                     continue
@@ -295,9 +306,8 @@ class DataRowMetadataOntology:
                     data_row_id=m.data_row_id,
                     fields=list(
                         chain.from_iterable(
-                            self._parse_upsert(m) for m in m.fields))).dict(
+                            self.parse_upsert(m) for m in m.fields))).dict(
                                 by_alias=True))
-
         res = _batch_operations(_batch_upsert, items, self._batch_size)
         return res
 
@@ -393,14 +403,17 @@ class DataRowMetadataOntology:
                                  data_row_ids,
                                  batch_size=self._batch_size)
 
-    def _parse_upsert(
+    def parse_upsert(
             self, metadatum: DataRowMetadataField
     ) -> List[_UpsertDataRowMetadataInput]:
         """Format for metadata upserts to GQL"""
 
         if metadatum.schema_id not in self.fields_by_id:
-            raise ValueError(
-                f"Schema Id `{metadatum.schema_id}` not found in ontology")
+            # Update metadata ontology if field can't be found
+            self._refresh_ontology()
+            if metadatum.schema_id not in self.fields_by_id:
+                raise ValueError(
+                    f"Schema Id `{metadatum.schema_id}` not found in ontology")
 
         schema = self.fields_by_id[metadatum.schema_id]
 
@@ -428,8 +441,11 @@ class DataRowMetadataOntology:
         deletes = set()
         for schema_id in delete.fields:
             if schema_id not in self.fields_by_id:
-                raise ValueError(
-                    f"Schema Id `{schema_id}` not found in ontology")
+                # Update metadata ontology if field can't be found
+                self._refresh_ontology()
+                if schema_id not in self.fields_by_id:
+                    raise ValueError(
+                        f"Schema Id `{schema_id}` not found in ontology")
 
             schema = self.fields_by_id[schema_id]
             # handle users specifying enums by adding all option enums

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -83,9 +83,12 @@ class Dataset(DbObject, Updateable, Deletable):
         if DataRow.metadata_fields.name in kwargs:
             mdo = self.client.get_data_row_metadata_ontology()
             metadata_fields = kwargs[DataRow.metadata_fields.name]
-            metadata = list(chain.from_iterable(
-                            mdo.parse_upsert(m) for m in metadata_fields))
-            kwargs[DataRow.metadata_fields.name] = [md.dict(by_alias=True) for md in metadata]
+            metadata = list(
+                chain.from_iterable(
+                    mdo.parse_upsert(m) for m in metadata_fields))
+            kwargs[DataRow.metadata_fields.name] = [
+                md.dict(by_alias=True) for md in metadata
+            ]
 
         return self.client._create(DataRow, kwargs)
 

--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -1,11 +1,36 @@
 from tempfile import NamedTemporaryFile
 import uuid
 import time
+from datetime import datetime
 
 import pytest
 import requests
 
 from labelbox import DataRow
+from labelbox.schema.data_row_metadata import DataRowMetadataField
+
+
+SPLIT_SCHEMA_ID = "cko8sbczn0002h2dkdaxb5kal"
+TEST_SPLIT_ID = "cko8scbz70005h2dkastwhgqt"
+EMBEDDING_SCHEMA_ID = "ckpyije740000yxdk81pbgjdc"
+TEXT_SCHEMA_ID = "cko8s9r5v0001h2dk9elqdidh"
+CAPTURE_DT_SCHEMA_ID = "cko8sdzv70006h2dk8jg64zvb"
+
+
+def make_metadata_fields():
+    embeddings = [0.0] * 128
+    msg = "A message"
+    time = datetime.utcnow()
+
+    fields=[
+        DataRowMetadataField(schema_id=SPLIT_SCHEMA_ID,
+                                value=TEST_SPLIT_ID),
+        DataRowMetadataField(schema_id=CAPTURE_DT_SCHEMA_ID, value=time),
+        DataRowMetadataField(schema_id=TEXT_SCHEMA_ID, value=msg),
+        DataRowMetadataField(schema_id=EMBEDDING_SCHEMA_ID,
+                                value=embeddings),
+    ]
+    return fields
 
 
 def test_get_data_row(datarow, client):
@@ -107,7 +132,6 @@ def test_data_row_large_bulk_creation(dataset, image_url):
     assert len(list(dataset.data_rows())) == n_local + n_urls
 
 
-@pytest.mark.xfail(reason="DataRow.dataset() relationship not set")
 def test_data_row_single_creation(dataset, rand_gen, image_url):
     client = dataset.client
     assert len(list(dataset.data_rows())) == 0
@@ -120,6 +144,30 @@ def test_data_row_single_creation(dataset, rand_gen, image_url):
     assert requests.get(image_url).content == \
         requests.get(data_row.row_data).content
     assert data_row.media_attributes is not None
+
+    with NamedTemporaryFile() as fp:
+        data = rand_gen(str).encode()
+        fp.write(data)
+        fp.flush()
+        data_row_2 = dataset.create_data_row(row_data=fp.name)
+        assert len(list(dataset.data_rows())) == 2
+        assert requests.get(data_row_2.row_data).content == data
+
+
+def test_data_row_single_creation_with_metadata(dataset, rand_gen, image_url):
+    client = dataset.client
+    assert len(list(dataset.data_rows())) == 0
+
+    data_row = dataset.create_data_row(row_data=image_url, metadata_fields=make_metadata_fields())
+
+    assert len(list(dataset.data_rows())) == 1
+    assert data_row.dataset() == dataset
+    assert data_row.created_by() == client.get_user()
+    assert data_row.organization() == client.get_organization()
+    assert requests.get(image_url).content == \
+        requests.get(data_row.row_data).content
+    assert data_row.media_attributes is not None
+    assert len(data_row.metadata_fields) == 5
 
     with NamedTemporaryFile() as fp:
         data = rand_gen(str).encode()

--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -9,7 +9,6 @@ import requests
 from labelbox import DataRow
 from labelbox.schema.data_row_metadata import DataRowMetadataField
 
-
 SPLIT_SCHEMA_ID = "cko8sbczn0002h2dkdaxb5kal"
 TEST_SPLIT_ID = "cko8scbz70005h2dkastwhgqt"
 EMBEDDING_SCHEMA_ID = "ckpyije740000yxdk81pbgjdc"
@@ -22,13 +21,11 @@ def make_metadata_fields():
     msg = "A message"
     time = datetime.utcnow()
 
-    fields=[
-        DataRowMetadataField(schema_id=SPLIT_SCHEMA_ID,
-                                value=TEST_SPLIT_ID),
+    fields = [
+        DataRowMetadataField(schema_id=SPLIT_SCHEMA_ID, value=TEST_SPLIT_ID),
         DataRowMetadataField(schema_id=CAPTURE_DT_SCHEMA_ID, value=time),
         DataRowMetadataField(schema_id=TEXT_SCHEMA_ID, value=msg),
-        DataRowMetadataField(schema_id=EMBEDDING_SCHEMA_ID,
-                                value=embeddings),
+        DataRowMetadataField(schema_id=EMBEDDING_SCHEMA_ID, value=embeddings),
     ]
     return fields
 
@@ -158,7 +155,8 @@ def test_data_row_single_creation_with_metadata(dataset, rand_gen, image_url):
     client = dataset.client
     assert len(list(dataset.data_rows())) == 0
 
-    data_row = dataset.create_data_row(row_data=image_url, metadata_fields=make_metadata_fields())
+    data_row = dataset.create_data_row(row_data=image_url,
+                                       metadata_fields=make_metadata_fields())
 
     assert len(list(dataset.data_rows())) == 1
     assert data_row.dataset() == dataset


### PR DESCRIPTION
Changes:
- Adding metadata_fields as an optional parameter to create_data_row()
- Setting metadata_fields as a new Field in DataRow as a new field type, List
- Adjusting graphql query parameters to adjust for metadataFields
- Caching metadata ontology

Heads up:
- Thinking of a major version upgrade from 3.20.x to 3.21.0 for the overall change. I will make this version upgrade once all parts of the TDD are implemented

Tests:
- Added a case for setting metadata_fields for data row integration test