### PR TITLE
[AL-2384] Increase create_batch timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-# Version 3.21.0
+# Version 3.21.1 (2022-05-12)
+## Updated
+  * `Project.create_batch()` timeout increased to 180 seconds
+
+# Version 3.21.0 (2022-05-11)
 ## Added
   * Projects can be created with a `media_type`
   * Added `media_type` attribute to `Project`

--- a/labelbox/__init__.py
+++ b/labelbox/__init__.py
@@ -1,5 +1,5 @@
 name = "labelbox"
-__version__ = "3.21.0"
+__version__ = "3.20.1"
 
 import sys
 import warnings

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -617,7 +617,9 @@ class Project(DbObject, Updateable, Deletable):
             }
         }
 
-        res = self.client.execute(query_str, params,
+        res = self.client.execute(query_str,
+                                  params,
+                                  timeout=180.0,
                                   experimental=True)["project"][method]
 
         res['size'] = len(dr_ids)


### PR DESCRIPTION
[JIRA ticket](https://labelbox.atlassian.net/browse/AL-2384)

Increases `Project.create_batch()` timeout, since for batch sizes > 10,000 thirty seconds usually isn't enough