### PR TITLE
Ze/add links webhooks notebook

### DIFF
--- a/examples/project_configuration/webhooks.ipynb
+++ b/examples/project_configuration/webhooks.ipynb
@@ -2,31 +2,50 @@
     "cells": [
         {
             "cell_type": "markdown",
-            "id": "registered-pressure",
-            "metadata": {},
             "source": [
-                "# Webhook Configuration"
-            ]
+                "<td>\n",
+                "   <a target=\"_blank\" href=\"https://labelbox.com\" ><img src=\"https://labelbox.com/blog/content/images/2021/02/logo-v4.svg\" width=256/></a>\n",
+                "</td>"
+            ],
+            "metadata": {}
         },
         {
             "cell_type": "markdown",
-            "id": "surface-message",
-            "metadata": {},
             "source": [
-                "* Webhooks are supported for the following events:\n",
-                "    1. label_created\n",
-                "    2. label_updated\n",
-                "    3. label_deleted\n",
-                "    4. review_created\n",
-                "    5. review_updated"
-            ]
+                "<td>\n",
+                "<a href=\"https://colab.research.google.com/github/Labelbox/labelbox-python/blob/develop/examples/project_configuration/webhooks.ipynb\" target=\"_blank\"><img\n",
+                "src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>\n",
+                "</td>\n",
+                "\n",
+                "<td>\n",
+                "<a href=\"https://github.com/Labelbox/labelbox-python/blob/develop/examples/project_configuration/webhooks.ipynb\" target=\"_blank\"><img\n",
+                "src=\"https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white\" alt=\"GitHub\"></a>\n",
+                "</td>"
+            ],
+            "metadata": {}
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "# Webhook Configuration"
+            ],
+            "metadata": {}
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "Webhooks are supported for the following events:\n",
+                "* label_created\n",
+                "* label_updated\n",
+                "* label_deleted\n",
+                "* review_created\n",
+                "* review_updated"
+            ],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "authentic-necessity",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "!pip install labelbox\n",
                 "!pip install requests\n",
@@ -34,14 +53,13 @@
                 "!pip install hashlib\n",
                 "!pip install flask\n",
                 "!pip install Werkzeug"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "responsible-clinton",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "from labelbox import Client, Webhook\n",
                 "from flask import Flask, request\n",
@@ -54,14 +72,13 @@
                 "import os\n",
                 "from getpass import getpass\n",
                 "import socket"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "foreign-theorem",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "# If you don't want to give google access to drive you can skip this cell\n",
                 "# and manually set `API_KEY` below.\n",
@@ -78,47 +95,44 @@
                 "    API_KEY = getpass(\"Please enter your labelbox api key\")\n",
                 "    if COLAB:\n",
                 "        envvar_handler.add_env(\"LABELBOX_API_KEY\", API_KEY)"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "satellite-impossible",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "# Set this to a project that you want to use for the webhook\n",
                 "PROJECT_ID = \"\"\n",
                 "# Only update this if you have an on-prem deployment\n",
                 "ENDPOINT = \"https://api.labelbox.com/graphql\""
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "clean-ireland",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "client = Client(api_key=API_KEY, endpoint=ENDPOINT)"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "bacterial-cheat",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "# We are using port 3001 for this example.\n",
                 "# Feel free to set to whatever port you want\n",
                 "WH_PORT = 3001"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "markdown",
-            "id": "owned-halifax",
-            "metadata": {},
             "source": [
                 "### Configure NGROK (Optional)\n",
                 "* If you do not have a public ip address then follow along\n",
@@ -128,44 +142,39 @@
                 "2. Download ngrok and extract the zip file\n",
                 "3. Add ngrok to your path\n",
                 "4. Add the authtoken `ngrok authtoken <token>`"
-            ]
+            ],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "aboriginal-antibody",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "if not COLAB:\n",
                 "    os.system(f\"ngrok http {WH_PORT} &\")"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "markdown",
-            "id": "fitted-adams",
-            "metadata": {},
             "source": [
                 "### Configure server to receive requests"
-            ]
+            ],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "stable-group",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "# This can be any secret that matches your webhook config (we will set later)\n",
                 "secret = b\"example_secret\""
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "limiting-variety",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "app = Flask(__name__)\n",
                 "\n",
@@ -196,49 +205,44 @@
                 "\n",
                 "thread = threading.Thread(target=lambda: run_simple(\"0.0.0.0\", WH_PORT, app))\n",
                 "thread.start()"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "markdown",
-            "id": "false-burlington",
-            "metadata": {},
             "source": [
                 "#### Test server"
-            ]
+            ],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "delayed-convention",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "print(requests.get(\"http://localhost:3001\").text)"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "markdown",
-            "id": "tribal-folks",
-            "metadata": {},
             "source": [
                 "### Create Webhook"
-            ]
+            ],
+            "metadata": {}
         },
         {
             "cell_type": "markdown",
-            "id": "enabling-yahoo",
-            "metadata": {},
             "source": [
                 "- Set ip address if your ip is publicly accessible.\n",
                 "- Otherwise use the following to get ngrok public_url"
-            ]
+            ],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "biblical-scottish",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "if not COLAB:\n",
                 "    res = requests.get(\"http://localhost:4040/api/tunnels\")\n",
@@ -253,14 +257,13 @@
                 "else:\n",
                 "    public_url = f\"http://{socket.gethostbyname(socket.getfqdn(socket.gethostname()))}\"\n",
                 "print(public_url)"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "raising-preservation",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "# Set project to limit the scope to a single project\n",
                 "project = client.get_project(PROJECT_ID)\n",
@@ -270,44 +273,40 @@
                 "                         url=public_url,\n",
                 "                         secret=secret.decode(),\n",
                 "                         project=project)"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "approximate-gothic",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "# Ok so we should be configured assuming everything is setup correctly.\n",
                 "# Go to the following url and make a new label to see if it works\n",
                 "print(f\"https://app.labelbox.com/projects/{PROJECT_ID}\")"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "worst-material",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "## Oops we made a mistake. The url was incorrect. We pointed the url to the hello world endpoint."
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "markdown",
-            "id": "interesting-satellite",
-            "metadata": {},
             "source": [
                 "### Update Webhook"
-            ]
+            ],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "stopped-steel",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "# url, topics, and status can all be updated\n",
                 "updated_url = f\"{public_url}/webhook-endpoint\"\n",
@@ -316,22 +315,20 @@
                 "# Go to the following url and try one last time.\n",
                 "# Any supported action should work (create, delete, update a label, or create, update, or delete a review)\n",
                 "print(f\"https://app.labelbox.com/projects/{PROJECT_ID}\")"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         },
         {
             "cell_type": "markdown",
-            "id": "streaming-generation",
-            "metadata": {},
             "source": [
                 "### List and delete all webhooks"
-            ]
+            ],
+            "metadata": {}
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "distant-commitment",
-            "metadata": {},
-            "outputs": [],
             "source": [
                 "# DELETE:\n",
                 "webhook.update(status=Webhook.Status.INACTIVE.value)\n",
@@ -346,7 +343,9 @@
                 "# for webhook in webhooks:\n",
                 "#    print(webhook)\n",
                 "#    webhook.update(status = Webhook.Status.INACTIVE.value)"
-            ]
+            ],
+            "outputs": [],
+            "metadata": {}
         }
     ],
     "metadata": {


### PR DESCRIPTION
Added the Labelbox header and the Github/Colab links to the top of the notebook so as to match all the other Colab tutorials we offer. I also revised the list of supported events to do away with the numbers, making the appearance consistent with our docs.