### PR TITLE
[AL-2327] Update to logic for fetching metadata from DataRow exports

### DIFF
--- a/labelbox/schema/batch.py
+++ b/labelbox/schema/batch.py
@@ -105,9 +105,8 @@ class Batch(DbObject):
                 response.raise_for_status()
                 reader = ndjson.reader(StringIO(response.text))
                 # TODO: Update result to parse customMetadata when resolver returns
-                return (Entity.DataRow(self.client, {
-                    **result, 'customMetadata': []
-                }) for result in reader)
+                return (Entity.DataRow(self.client, {**result})
+                        for result in reader)
             elif res["status"] == "FAILED":
                 raise LabelboxError("Data row export failed.")
 

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -410,9 +410,8 @@ class Dataset(DbObject, Updateable, Deletable):
                 response.raise_for_status()
                 reader = ndjson.reader(StringIO(response.text))
                 # TODO: Update result to parse customMetadata when resolver returns
-                return (Entity.DataRow(self.client, {
-                    **result, 'customMetadata': []
-                }) for result in reader)
+                return (Entity.DataRow(self.client, {**result})
+                        for result in reader)
             elif res["status"] == "FAILED":
                 raise LabelboxError("Data row export failed.")
 


### PR DESCRIPTION
update to files to be able to handle pulling in metadata from datarows

previously, we had to accommodate metadata by filling it in with an empty list. once the following PR is approved, this should be checked and validated again, and should be able to correctly fetch metadata from areas where we export datarows vs. just the label

https://github.com/Labelbox/intelligence/pull/8565