### PR TITLE
retry on ConnectTimeout errors

### DIFF
--- a/labelbox/exceptions.py
+++ b/labelbox/exceptions.py
@@ -90,6 +90,10 @@ class TimeoutError(LabelboxError):
     pass
 
 
+class ConnectTimeoutError(TimeoutError):
+    """Raised when a request times out while trying to connect to a remote server."""
+
+
 class InvalidAttributeError(LabelboxError):
     """ Raised when a field (name or Field instance) is not valid or found
     for a specific DB object type. """


### PR DESCRIPTION
* We now retry the request when a ConnectionError is encountered
* Added tests to make sure that the ConnectionError is being retried
* Added a timeout arg to upload_file so that it doesn't hang indefinitely
* Modified the timeout for execute so that the connection timeout is short and the read timeout is long. This way retries on connection issues will happen quickly instead of waiting 30 seconds. 
------ 
* Error handling should be simplified. Also upload_file should also use execute but it is too much of a risk to change without a lot of testing. We should follow up in a separate PR. 