### PR TITLE
[AL-0] __init__ and changelog changes for 3.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Version 3.22.1 (2022-05-23)
+## Updated
+* Renamed `custom_metadata` to `metadata_fields` in DataRow
+
 # Version 3.22.0 (2022-05-20)
 ## Added
 * `Dataset.create_data_row()` and `Dataset.create_data_rows()` now uploads metadata to data row

--- a/labelbox/__init__.py
+++ b/labelbox/__init__.py
@@ -1,5 +1,5 @@
 name = "labelbox"
-__version__ = "3.22.0"
+__version__ = "3.22.1"
 
 import sys
 import warnings


### PR DESCRIPTION
Need to release this change when the backend changes for renaming customMetadata to metadataFields goes in