### PR TITLE
[AL-2619] Add 'metadata' field representing data row metadata as DataRowMetadat…

### DIFF
--- a/labelbox/orm/db_object.py
+++ b/labelbox/orm/db_object.py
@@ -70,15 +70,15 @@ class DbObject(Entity):
                         "field %s", value, field)
             elif isinstance(field.field_type, Field.EnumType):
                 value = field.field_type.enum_cls(value)
-            elif isinstance(field.field_type,
-                            Field.ListType) and field.name == "metadata":
-                mdo = self.client.get_data_row_metadata_ontology()
-                try:
-                    value = mdo.parse_metadata_fields(value)
-                except ValueError:
-                    logger.warning(
-                        "Failed to convert value '%s' to metadata for field %s",
-                        value, field)
+            elif isinstance(field.field_type, Field.ListType):
+                if field.field_type.list_cls.__name__ == "DataRowMetadataField":
+                    mdo = self.client.get_data_row_metadata_ontology()
+                    try:
+                        value = mdo.parse_metadata_fields(value)
+                    except ValueError:
+                        logger.warning(
+                            "Failed to convert value '%s' to metadata for field %s",
+                            value, field)
             setattr(self, field.name, value)
 
     def __repr__(self):

--- a/labelbox/orm/db_object.py
+++ b/labelbox/orm/db_object.py
@@ -70,6 +70,15 @@ class DbObject(Entity):
                         "field %s", value, field)
             elif isinstance(field.field_type, Field.EnumType):
                 value = field.field_type.enum_cls(value)
+            elif isinstance(field.field_type,
+                            Field.ListType) and field.name == "metadata":
+                mdo = self.client.get_data_row_metadata_ontology()
+                try:
+                    value = mdo.parse_metadata_fields(value)
+                except ValueError:
+                    logger.warning(
+                        "Failed to convert value '%s' to metadata for field %s",
+                        value, field)
             setattr(self, field.name, value)
 
     def __repr__(self):

--- a/labelbox/schema/batch.py
+++ b/labelbox/schema/batch.py
@@ -106,7 +106,8 @@ class Batch(DbObject):
                 reader = ndjson.reader(StringIO(response.text))
                 # TODO: Update result to parse metadataFields when resolver returns
                 return (Entity.DataRow(self.client, {
-                    **result, 'metadataFields': []
+                    **result, 'metadataFields': [],
+                    'customMetadata': []
                 }) for result in reader)
             elif res["status"] == "FAILED":
                 raise LabelboxError("Data row export failed.")

--- a/labelbox/schema/data_row.py
+++ b/labelbox/schema/data_row.py
@@ -21,8 +21,9 @@ class DataRow(DbObject, Updateable, BulkDeletable):
             Otherwise, it's treated as an external URL.
         updated_at (datetime)
         created_at (datetime)
-        media_attributes (dict): generated media attributes for the datarow
-        metadata_fields (list): metadata associated with the datarow
+        media_attributes (dict): generated media attributes for the data row
+        metadata_fields (list): metadata associated with the data row
+        metadata (list): metadata associated with the data row as list of DataRowMetadataField
 
         dataset (Relationship): `ToOne` relationship to Dataset
         created_by (Relationship): `ToOne` relationship to User
@@ -41,7 +42,6 @@ class DataRow(DbObject, Updateable, BulkDeletable):
         name="metadata_fields",
         result_subquery="metadataFields { schemaId name value kind }")
     metadata = Field.List(DataRowMetadataField,
-                          graphql_type="DataRowCustomMetadataUpsertInput!",
                           name="metadata",
                           graphql_name="customMetadata",
                           result_subquery="customMetadata { schemaId value }")

--- a/labelbox/schema/data_row.py
+++ b/labelbox/schema/data_row.py
@@ -36,10 +36,15 @@ class DataRow(DbObject, Updateable, BulkDeletable):
     created_at = Field.DateTime("created_at")
     media_attributes = Field.Json("media_attributes")
     metadata_fields = Field.List(
-        DataRowMetadataField,
+        dict,
         graphql_type="DataRowCustomMetadataUpsertInput!",
         name="metadata_fields",
         result_subquery="metadataFields { schemaId name value kind }")
+    metadata = Field.List(DataRowMetadataField,
+                          graphql_type="DataRowCustomMetadataUpsertInput!",
+                          name="metadata",
+                          graphql_name="customMetadata",
+                          result_subquery="customMetadata { schemaId value }")
 
     # Relationships
     dataset = Relationship.ToOne("Dataset")

--- a/labelbox/schema/data_row_metadata.py
+++ b/labelbox/schema/data_row_metadata.py
@@ -232,6 +232,16 @@ class DataRowMetadataOntology:
     def parse_metadata_fields(
             self, unparsed: List[Dict[str,
                                       Dict]]) -> List[DataRowMetadataField]:
+        """ Parse metadata fields as list of `DataRowMetadataField`
+
+        >>> mdo.parse_metadata_fields([metadata_fields])
+
+        Args:
+            unparsed: An unparsed list of metadata represented as a dict containing 'schemaId' and 'value'
+
+        Returns:
+            metadata: List of `DataRowMetadataField`
+        """
         parsed = []
         if isinstance(unparsed, dict):
             raise ValueError("Pass a list of dictionaries")

--- a/labelbox/schema/data_row_metadata.py
+++ b/labelbox/schema/data_row_metadata.py
@@ -1,6 +1,5 @@
 # type: ignore
 from datetime import datetime
-import warnings
 from copy import deepcopy
 from enum import Enum
 from itertools import chain
@@ -224,32 +223,41 @@ class DataRowMetadataOntology:
 
         for dr in unparsed:
             fields = []
-            for f in dr["fields"]:
-                if f["schemaId"] not in self.fields_by_id:
-                    # Update metadata ontology if field can't be found
-                    self.refresh_ontology()
-                    if f["schemaId"] not in self.fields_by_id:
-                        raise ValueError(
-                            f"Schema Id `{f['schemaId']}` not found in ontology"
-                        )
-
-                schema = self.fields_by_id[f["schemaId"]]
-                if schema.kind == DataRowMetadataKind.enum:
-                    continue
-                elif schema.kind == DataRowMetadataKind.option:
-                    field = DataRowMetadataField(schema_id=schema.parent,
-                                                 value=schema.uid)
-                elif schema.kind == DataRowMetadataKind.datetime:
-                    field = DataRowMetadataField(
-                        schema_id=schema.uid,
-                        value=datetime.fromisoformat(f["value"][:-1] +
-                                                     "+00:00"))
-                else:
-                    field = DataRowMetadataField(schema_id=schema.uid,
-                                                 value=f["value"])
-                fields.append(field)
+            if "fields" in dr:
+                fields = self.parse_metadata_fields(dr["fields"])
             parsed.append(
                 DataRowMetadata(data_row_id=dr["dataRowId"], fields=fields))
+        return parsed
+
+    def parse_metadata_fields(
+            self, unparsed: List[Dict[str,
+                                      Dict]]) -> List[DataRowMetadataField]:
+        parsed = []
+        if isinstance(unparsed, dict):
+            raise ValueError("Pass a list of dictionaries")
+
+        for f in unparsed:
+            if f["schemaId"] not in self.fields_by_id:
+                # Update metadata ontology if field can't be found
+                self.refresh_ontology()
+                if f["schemaId"] not in self.fields_by_id:
+                    raise ValueError(
+                        f"Schema Id `{f['schemaId']}` not found in ontology")
+
+            schema = self.fields_by_id[f["schemaId"]]
+            if schema.kind == DataRowMetadataKind.enum:
+                continue
+            elif schema.kind == DataRowMetadataKind.option:
+                field = DataRowMetadataField(schema_id=schema.parent,
+                                             value=schema.uid)
+            elif schema.kind == DataRowMetadataKind.datetime:
+                field = DataRowMetadataField(
+                    schema_id=schema.uid,
+                    value=datetime.fromisoformat(f["value"][:-1] + "+00:00"))
+            else:
+                field = DataRowMetadataField(schema_id=schema.uid,
+                                             value=f["value"])
+            parsed.append(field)
         return parsed
 
     def bulk_upsert(

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -442,7 +442,8 @@ class Dataset(DbObject, Updateable, Deletable):
                 reader = ndjson.reader(StringIO(response.text))
                 # TODO: Update result to parse metadataFields when resolver returns
                 return (Entity.DataRow(self.client, {
-                    **result, 'metadataFields': []
+                    **result, 'metadataFields': [],
+                    'customMetadata': []
                 }) for result in reader)
             elif res["status"] == "FAILED":
                 raise LabelboxError("Data row export failed.")

--- a/tests/integration/test_data_row_metadata.py
+++ b/tests/integration/test_data_row_metadata.py
@@ -1,4 +1,3 @@
-import time
 from datetime import datetime
 
 import pytest
@@ -282,3 +281,34 @@ def test_parse_raw_metadata(mdo):
     for row in parsed:
         for field in row.fields:
             assert mdo._parse_upsert(field)
+
+
+def test_parse_raw_metadata_fields(mdo):
+    example = [
+        {
+            'schemaId': 'cko8s9r5v0001h2dk9elqdidh',
+            'value': 'my-new-message'
+        },
+        {
+            'schemaId': 'cko8sbczn0002h2dkdaxb5kal',
+            'value': {}
+        },
+        {
+            'schemaId': 'cko8sbscr0003h2dk04w86hof',
+            'value': {}
+        },
+        {
+            'schemaId': 'cko8sdzv70006h2dk8jg64zvb',
+            'value': '2021-07-20T21:41:14.606710Z'
+        },
+        {
+            'schemaId': FAKE_SCHEMA_ID,
+            'value': 0.5
+        },
+    ]
+
+    parsed = mdo.parse_metadata_fields(example)
+    assert len(parsed) == 4
+
+    for field in parsed:
+        assert mdo._parse_upsert(field)


### PR DESCRIPTION
…aFields

- Add new field 'metadata' for data_row, which represents the serialized metadata fields off of a data row
- 'metadata' uses customMetadata resolver to retrieve a flattened view of metadata, and uses mdo.parse_metadata_fields to convert the dict --> DataRowMetadataField format
- Added test cases for them