### PR TITLE
Ability to bulk upload conversations using Dataset.create_data_rows() + update staging URL

### DIFF
--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -288,21 +288,25 @@ class Dataset(DbObject, Updateable, Deletable):
             Args:
                 conversational_data (list): list of dictionaries.
             """
+
             def check_message_keys(message):
                 accepted_message_keys = set([
-                    "messageId", "timestampUsec", "content", "user", "align", "canLabel"])
+                    "messageId", "timestampUsec", "content", "user", "align",
+                    "canLabel"
+                ])
                 for key in message.keys():
                     if not key in accepted_message_keys:
                         raise KeyError(
-                            f"Invalid {key} key found! Accepted keys in messages list is {accepted_message_keys}")
+                            f"Invalid {key} key found! Accepted keys in messages list is {accepted_message_keys}"
+                        )
 
-            if conversational_data and not isinstance(conversational_data, list):
+            if conversational_data and not isinstance(conversational_data,
+                                                      list):
                 raise ValueError(
                     f"conversationalData must be a list. Found {type(conversational_data)}"
                 )
 
-            [check_message_keys(message)
-                for message in conversational_data]
+            [check_message_keys(message) for message in conversational_data]
 
         def parse_metadata_fields(item):
             metadata_fields = item.get('metadata_fields')
@@ -360,9 +364,10 @@ class Dataset(DbObject, Updateable, Deletable):
                         "version": version,
                         "messages": messages
                     }
-                conversationUrl = self.client.upload_data(json.dumps(one_conversation),
-                                                          content_type="application/json",
-                                                          filename="conversational_data.json")
+                conversationUrl = self.client.upload_data(
+                    json.dumps(one_conversation),
+                    content_type="application/json",
+                    filename="conversational_data.json")
                 item["row_data"] = conversationUrl
 
             # Convert all payload variations into the same dict format

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -294,7 +294,7 @@ class Dataset(DbObject, Updateable, Deletable):
                 for key in message.keys():
                     if not key in accepted_message_keys:
                         raise KeyError(
-                            f"Invalid {key} key found! Accepted keys in messages list is ")
+                            f"Invalid {key} key found! Accepted keys in messages list is {accepted_message_keys}")
 
             if conversational_data and not isinstance(conversational_data, list):
                 raise ValueError(
@@ -348,19 +348,22 @@ class Dataset(DbObject, Updateable, Deletable):
 
             if "conversationalData" in item:
                 messages = item.pop("conversationalData")
+                version = item.pop("version")
+                type = item.pop("type")
+                if "externalId" in item:
+                    external_id = item.pop("externalId")
+                    item["external_id"] = external_id
                 validate_conversational_data(messages)
-                validate_attachments(item)
                 one_conversation = \
-                {
-                    "type": item["type"],
-                    "version": item["version"],
-                    "messages": messages
-                }
+                    {
+                        "type": type,
+                        "version": version,
+                        "messages": messages
+                    }
                 conversationUrl = self.client.upload_data(json.dumps(one_conversation),
                                                           content_type="application/json",
                                                           filename="conversational_data.json")
-                item["conversationalUrl"] = conversationUrl
-                return item
+                item["row_data"] = conversationUrl
 
             # Convert all payload variations into the same dict format
             item = format_row(item)

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -226,6 +226,7 @@ class Dataset(DbObject, Updateable, Deletable):
         >>>     {DataRow.row_data:"/path/to/file1.jpg"},
         >>>     "path/to/file2.jpg",
         >>>     {"tileLayerUrl" : "http://", ...}
+        >>>     {"conversation" : "{}", ...}
         >>>     ])
 
         For an example showing how to upload tiled data_rows see the following notebook:
@@ -280,6 +281,29 @@ class Dataset(DbObject, Updateable, Deletable):
                     )
             return attachments
 
+        def validate_conversational_data(conversational_data: list) -> None:
+            """
+            Checks each conversational message for keys expected as per https://docs.labelbox.com/reference/text-conversational#sample-conversational-json
+
+            Args:
+                conversational_data (list): list of dictionaries.
+            """
+            def check_message_keys(message):
+                accepted_message_keys = set([
+                    "messageId", "timestampUsec", "content", "user", "align", "canLabel"])
+                for key in message.keys():
+                    if not key in accepted_message_keys:
+                        raise KeyError(
+                            f"Invalid {key} key found! Accepted keys in messages list is ")
+
+            if conversational_data and not isinstance(conversational_data, list):
+                raise ValueError(
+                    f"conversationalData must be a list. Found {type(conversational_data)}"
+                )
+
+            [check_message_keys(message)
+                for message in conversational_data]
+
         def parse_metadata_fields(item):
             metadata_fields = item.get('metadata_fields')
             if metadata_fields:
@@ -321,6 +345,23 @@ class Dataset(DbObject, Updateable, Deletable):
             if "tileLayerUrl" in item:
                 validate_attachments(item)
                 return item
+
+            if "conversationalData" in item:
+                messages = item.pop("conversationalData")
+                validate_conversational_data(messages)
+                validate_attachments(item)
+                one_conversation = \
+                {
+                    "type": item["type"],
+                    "version": item["version"],
+                    "messages": messages
+                }
+                conversationUrl = self.client.upload_data(json.dumps(one_conversation),
+                                                          content_type="application/json",
+                                                          filename="conversational_data.json")
+                item["conversationalUrl"] = conversationUrl
+                return item
+
             # Convert all payload variations into the same dict format
             item = format_row(item)
             # Make sure required keys exist (and there are no extra keys)

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -226,7 +226,7 @@ class Dataset(DbObject, Updateable, Deletable):
         >>>     {DataRow.row_data:"/path/to/file1.jpg"},
         >>>     "path/to/file2.jpg",
         >>>     {"tileLayerUrl" : "http://", ...}
-        >>>     {"conversation" : "{}", ...}
+        >>>     {"conversationalData" : [...], ...}
         >>>     ])
 
         For an example showing how to upload tiled data_rows see the following notebook:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import time
@@ -189,6 +190,17 @@ def sample_video() -> str:
     path_to_video = 'tests/integration/media/cat.mp4'
     assert os.path.exists(path_to_video)
     return path_to_video
+
+
+@pytest.fixture
+def sample_bulk_conversation() -> list:
+    path_to_conversation = 'tests/integration/media/bulk_conversation.json'
+    assert os.path.exists(path_to_conversation)
+    # return path_to_conversation
+    
+    with open(path_to_conversation) as json_file:
+        conversations = json.load(json_file)
+    return conversations
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -197,7 +197,6 @@ def sample_bulk_conversation() -> list:
     path_to_conversation = 'tests/integration/media/bulk_conversation.json'
     assert os.path.exists(path_to_conversation)
 
-    
     with open(path_to_conversation) as json_file:
         conversations = json.load(json_file)
     return conversations
@@ -302,7 +301,7 @@ def configured_project_with_label(client, rand_gen, image_url, project, dataset,
 
     def create_label():
         """ Ad-hoc function to create a LabelImport
-        
+
         Creates a LabelImport task which will create a label
         """
         upload_task = LabelImport.create_from_objects(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -191,15 +191,12 @@ def iframe_url(environ) -> str:
 @pytest.fixture
 def sample_video() -> str:
     path_to_video = 'tests/integration/media/cat.mp4'
-    assert os.path.exists(path_to_video)
     return path_to_video
 
 
 @pytest.fixture
 def sample_bulk_conversation() -> list:
     path_to_conversation = 'tests/integration/media/bulk_conversation.json'
-    assert os.path.exists(path_to_conversation)
-
     with open(path_to_conversation) as json_file:
         conversations = json.load(json_file)
     return conversations

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -48,7 +48,7 @@ def graphql_url(environ: str) -> str:
     if environ == Environ.PROD:
         return 'https://api.labelbox.com/graphql'
     elif environ == Environ.STAGING:
-        return 'https://staging-api.labelbox.com/graphql'
+        return 'https://api.lb-stage.xyz/graphql'
     elif environ == Environ.ONPREM:
         hostname = os.environ.get('LABELBOX_TEST_ONPREM_HOSTNAME', None)
         if hostname is None:
@@ -196,7 +196,7 @@ def sample_video() -> str:
 def sample_bulk_conversation() -> list:
     path_to_conversation = 'tests/integration/media/bulk_conversation.json'
     assert os.path.exists(path_to_conversation)
-    # return path_to_conversation
+
     
     with open(path_to_conversation) as json_file:
         conversations = json.load(json_file)

--- a/tests/integration/media/bulk_conversation.json
+++ b/tests/integration/media/bulk_conversation.json
@@ -1,0 +1,113 @@
+[
+    {
+        "externalId": "Convo-123",
+        "attachments": [
+            {
+                "type": "TEXT",
+                "value": "IOWA, Zone 2232, June 2022 [Text string]"
+            },
+            {
+                "type": "IMAGE",
+                "value": "https://storage.googleapis.com/labelbox-sample-datasets/Docs/disease_attachment.jpeg"
+            }
+        ],
+        "type": "application/vnd.labelbox.conversational",
+        "version": 1,
+        "conversationalData": [
+            {
+                "messageId": "message-0",
+                "timestampUsec": 1530718491,
+                "content": "I love iphone! i just bought new iphone! :smiling_face_with_3_hearts: :calling:",
+                "user": {
+                    "userId": "Bot 002",
+                    "name": "Bot"
+                },
+                "align": "left",
+                "canLabel": false
+            },
+            {
+                "messageId": "message-1",
+                "timestampUsec": 1530718503,
+                "content": "Thats good for you, i'm not very into new tech",
+                "user": {
+                    "userId": "User 00686",
+                    "name": "User"
+                },
+                "align": "right",
+                "canLabel": true
+            },
+            {
+                "messageId": "message-2",
+                "timestampUsec": 1530718516,
+                "content": "I am a college student and i am a college student :female-teacher::skin-tone-2:",
+                "user": {
+                    "userId": "Bot 002",
+                    "name": "Bot"
+                },
+                "align": "left",
+                "canLabel": false
+            },
+            {
+                "messageId": "message-3",
+                "timestampUsec": 1530718528,
+                "content": "I am go to gym and live on donations :woman-lifting-weights::skin-tone-6:",
+                "user": {
+                    "userId": "User 00686",
+                    "name": "User"
+                },
+                "align": "right",
+                "canLabel": true
+            }
+        ]
+    },
+    {
+        "externalId": "Convo-456",
+        "attachments": [
+            {
+                "type": "TEXT",
+                "value": "IOWA, Zone 1234567, July 2022 [Text string]"
+            },
+            {
+                "type": "IMAGE",
+                "value": "https://storage.googleapis.com/labelbox-sample-datasets/Docs/disease_attachment.jpeg"
+            }
+        ],
+        "type": "application/vnd.labelbox.conversational",
+        "version": 1,
+        "conversationalData": [
+            {
+                "messageId": "message-0",
+                "timestampUsec": 1530718491,
+                "content": "I love iphone! i just bought new iphone! :smiling_face_with_3_hearts: :calling:",
+                "user": {
+                    "userId": "Bot 002",
+                    "name": "Bot"
+                },
+                "align": "left",
+                "canLabel": false
+            },
+            {
+                "messageId": "message-1",
+                "timestampUsec": 1530718503,
+                "content": "Thats good for you, i'm not very into new tech",
+                "user": {
+                    "userId": "User 00686",
+                    "name": "User"
+                },
+                "align": "right",
+                "canLabel": true
+            },
+            {
+                "messageId": "message-2",
+                "timestampUsec": 1530718516,
+                "content": "I am a college student and i am a college student :female-teacher::skin-tone-2:",
+                "user": {
+                    "userId": "Bot 002",
+                    "name": "Bot"
+                },
+                "align": "left",
+                "canLabel": false
+            }
+        ]
+    }
+]

--- a/tests/integration/test_client_errors.py
+++ b/tests/integration/test_client_errors.py
@@ -41,7 +41,7 @@ def test_semantic_error(client):
         client.execute("query {bbb {id}}", check_naming=False)
     assert excinfo.value.message.startswith("Cannot query field \"bbb\"")
 
-
+@pytest.mark.skip("failing with unreachable network")
 def test_timeout_error(client, project):
     time.sleep(60)  #Fails to connect if we don't wait
     with pytest.raises(labelbox.exceptions.TimeoutError) as excinfo:

--- a/tests/integration/test_client_errors.py
+++ b/tests/integration/test_client_errors.py
@@ -41,6 +41,7 @@ def test_semantic_error(client):
         client.execute("query {bbb {id}}", check_naming=False)
     assert excinfo.value.message.startswith("Cannot query field \"bbb\"")
 
+
 @pytest.mark.skip("failing with unreachable network")
 def test_timeout_error(client, project):
     time.sleep(60)  #Fails to connect if we don't wait

--- a/tests/integration/test_client_errors.py
+++ b/tests/integration/test_client_errors.py
@@ -42,9 +42,7 @@ def test_semantic_error(client):
     assert excinfo.value.message.startswith("Cannot query field \"bbb\"")
 
 
-@pytest.mark.skip("failing with unreachable network")
 def test_timeout_error(client, project):
-    time.sleep(60)  #Fails to connect if we don't wait
     with pytest.raises(labelbox.exceptions.TimeoutError) as excinfo:
         query_str = """query getOntology { 
         project (where: {id: $%s}) { 
@@ -53,7 +51,9 @@ def test_timeout_error(client, project):
                 } 
             }
         } """ % (project.uid)
-        client.execute(query_str, check_naming=False, timeout=0.01)
+
+        # Setting connect timeout to 30s, and read timeout to 0.01s
+        client.execute(query_str, check_naming=False, timeout=(30.0, 0.01))
 
 
 def test_query_complexity_error(client):

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import requests
 from labelbox import Dataset
@@ -99,6 +100,17 @@ def test_upload_video_file(dataset, sample_video: str) -> None:
         response = requests.head(url, allow_redirects=True)
         assert int(response.headers['Content-Length']) == content_length
         assert response.headers['Content-Type'] == 'video/mp4'
+
+
+def test_bulk_conversation(dataset, sample_bulk_conversation: list) -> None:
+    """
+    Tests that bulk conversations can be uploaded.
+
+    """
+    task = dataset.create_data_rows(sample_bulk_conversation)
+    task.wait_till_done()
+
+    assert len(list(dataset.data_rows())) == len(sample_bulk_conversation)
 
 
 def test_data_row_export(dataset, image_url):


### PR DESCRIPTION
### Brief Summary
Add multiple conversations from one JSON file using the create_data_rows function in the Dataset. The format expected is matching what is in the docs [here](https://docs.labelbox.com/reference/text-conversational). Also changed the staging URL used for pytest.

### Testing: 
The test ran checks for `Dataset.data_rows()` to match the length of the list passed in from the upload.

### Error checking added
Check for keys fields to be included in each message passed in the `conversationalData`.