### PR TITLE
[AL-2954] Add video point and polyline support in annotation serialization

### DIFF
--- a/labelbox/data/serialization/ndjson/label.py
+++ b/labelbox/data/serialization/ndjson/label.py
@@ -1,6 +1,6 @@
 from itertools import groupby
 from operator import itemgetter
-from typing import Dict, Generator, List, Tuple, Union
+from typing import Any, Dict, Generator, List, Tuple, Union
 from collections import defaultdict
 import warnings
 
@@ -51,7 +51,6 @@ class NDLabel(BaseModel):
                 if isinstance(annotation, NDSegments):
                     annots.extend(
                         NDSegments.to_common(annotation, annotation.schema_id))
-
                 elif isinstance(annotation, NDObjectType.__args__):
                     annots.append(NDObject.to_common(annotation))
                 elif isinstance(annotation, NDClassificationType.__args__):
@@ -62,12 +61,15 @@ class NDLabel(BaseModel):
                 else:
                     raise TypeError(
                         f"Unsupported annotation. {type(annotation)}")
-            data = self._infer_media_type(annotations)(uid=data_row_id)
+            data = self._infer_media_type(annots)(uid=data_row_id)
             yield Label(annotations=annots, data=data)
 
     def _infer_media_type(
-        self, annotations: List[Union[NDObjectType, NDClassificationType]]
-    ) -> Union[TextEntity, TextData, ImageData]:
+        self, annotations: List[Union[TextEntity, VideoClassificationAnnotation,
+                                      VideoObjectAnnotation, ObjectAnnotation,
+                                      ClassificationAnnotation, ScalarMetric,
+                                      ConfusionMatrixMetric]]
+    ) -> Union[TextData, VideoData, ImageData]:
         types = {type(annotation) for annotation in annotations}
         if TextEntity in types:
             return TextData
@@ -100,7 +102,6 @@ class NDLabel(BaseModel):
         for annotation_group in video_annotations.values():
             consecutive_frames = cls._get_consecutive_frames(
                 sorted([annotation.frame for annotation in annotation_group]))
-
             if isinstance(annotation_group[0], VideoClassificationAnnotation):
                 annotation = annotation_group[0]
                 frames_data = []

--- a/labelbox/data/serialization/ndjson/label.py
+++ b/labelbox/data/serialization/ndjson/label.py
@@ -1,6 +1,6 @@
 from itertools import groupby
 from operator import itemgetter
-from typing import Any, Dict, Generator, List, Tuple, Union
+from typing import Dict, Generator, List, Tuple, Union
 from collections import defaultdict
 import warnings
 

--- a/tests/data/assets/ndjson/video_import.json
+++ b/tests/data/assets/ndjson/video_import.json
@@ -1,1 +1,94 @@
-[{"answer": {"schemaId": "ckrb1sfl8099g0y91cxbd5ftb"}, "schemaId": "ckrb1sfjx099a0y914hl319ie", "dataRow": {"id": "ckrb1sf1i1g7i0ybcdc6oc8ct"}, "uuid": "f6879f59-d2b5-49c2-aceb-d9e8dc478673", "frames": [{"start": 30, "end": 35}, {"start": 50, "end": 51}]}, {"answer": [{"schemaId": "ckrb1sfl8099e0y919v260awv"}], "schemaId": "ckrb1sfkn099c0y910wbo0p1a", "dataRow": {"id": "ckrb1sf1i1g7i0ybcdc6oc8ct"}, "uuid": "d009925d-91a3-4f67-abd9-753453f5a584", "frames": [{"start": 0, "end": 5}]}, {"answer": "a value", "schemaId": "ckrb1sfkn099c0y910wbo0p1a", "dataRow": {"id": "ckrb1sf1i1g7i0ybcdc6oc8ct"}, "uuid": "d009925d-91a3-4f67-abd9-753453f5a584"}]
+[
+    {
+        "answer": {"schemaId": "ckrb1sfl8099g0y91cxbd5ftb"},
+        "schemaId": "ckrb1sfjx099a0y914hl319ie",
+        "dataRow": {"id": "ckrb1sf1i1g7i0ybcdc6oc8ct"},
+        "uuid": "f6879f59-d2b5-49c2-aceb-d9e8dc478673",
+        "frames": [{"start": 30, "end": 35}, {"start": 50, "end": 51}]
+    },
+    {
+        "answer": [{"schemaId": "ckrb1sfl8099e0y919v260awv"}],
+        "schemaId": "ckrb1sfkn099c0y910wbo0p1a",
+        "dataRow": {"id": "ckrb1sf1i1g7i0ybcdc6oc8ct"},
+        "uuid": "d009925d-91a3-4f67-abd9-753453f5a584",
+        "frames": [{"start": 0, "end": 5}]
+    },
+    {
+        "answer": "a value",
+        "schemaId": "ckrb1sfkn099c0y910wbo0p1a",
+        "dataRow": {"id": "ckrb1sf1i1g7i0ybcdc6oc8ct"},
+        "uuid": "d009925d-91a3-4f67-abd9-753453f5a584"
+    },
+    {
+        "classifications": [],
+        "schemaId": "cl5islwg200gfci6g0oitaypu",
+        "dataRow": {"id": "ckrb1sf1i1g7i0ybcdc6oc8ct"},
+        "uuid": "6f7c835a-0139-4896-b73f-66a6baa89e94",
+        "segments": [
+            {
+                "keyframes": [
+                    {
+                        "frame": 1,
+                        "line": [{"x": 10.0, "y": 10.0}, {"x": 100.0, "y": 100.0}, {"x": 50.0, "y": 30.0}]
+                    }
+                ]
+            },
+            {
+                "keyframes": [
+                    {
+                        "frame": 5,
+                        "line": [{"x": 100.0, "y": 10.0}, {"x": 50.0, "y": 100.0}, {"x": 50.0, "y": 30.0}]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "classifications": [],
+        "schemaId": "cl5it7ktp00i5ci6gf80b1ysd",
+        "dataRow": {"id": "ckrb1sf1i1g7i0ybcdc6oc8ct"},
+        "uuid": "f963be22-227b-4efe-9be4-2738ed822216",
+        "segments": [
+            {
+                "keyframes": [
+                    {
+                        "frame": 1,
+                        "point": {"x": 10.0, "y": 10.0}
+                    }
+                ]
+            },
+            {
+                "keyframes": [
+                    {
+                        "frame": 5,
+                        "point": {"x": 50.0, "y": 50.0}
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "classifications": [],
+        "schemaId": "cl5iw0roz00lwci6g5jni62vs",
+        "dataRow": {"id": "ckrb1sf1i1g7i0ybcdc6oc8ct"},
+        "uuid": "13b2ee0e-2355-4336-8b83-d74d09e3b1e7",
+        "segments": [
+            {
+                "keyframes": [
+                    {
+                        "frame": 1,
+                        "bbox": {"top": 10.0, "left": 5.0, "height": 100.0, "width": 150.0}
+                    }
+                ]
+            },
+            {
+                "keyframes": [
+                    {
+                        "frame": 5,
+                        "bbox": {"top": 300.0, "left": 200.0, "height": 400.0, "width": 150.0}
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/tests/data/serialization/ndjson/test_video.py
+++ b/tests/data/serialization/ndjson/test_video.py
@@ -9,4 +9,4 @@ def test_video():
 
     res = NDJsonConverter.deserialize(data).as_list()
     res = list(NDJsonConverter.serialize(res))
-    assert res == [data[2], data[0], data[1]]
+    assert res == [data[2], data[0], data[1], data[3], data[4], data[5]]


### PR DESCRIPTION
- Added video point and video polyline support for serialization/deserialization, along with test cases
- fixed deserialization to pass in uuid for video annotations
- fixed infer_media_type()