### PR TITLE
handle empty annotations

### DIFF
--- a/labelbox/data/annotation_types/data/raster.py
+++ b/labelbox/data/annotation_types/data/raster.py
@@ -128,7 +128,6 @@ class RasterData(BaseModel, ABC):
         """
         response = requests.get(self.url)
         if response.status_code in [500, 502, 503, 504]:
-            breakpoint()
             raise InternalServerError(response.text)
         response.raise_for_status()
         return response.content

--- a/labelbox/data/serialization/coco/categories.py
+++ b/labelbox/data/serialization/coco/categories.py
@@ -1,4 +1,5 @@
 import sys
+from hashlib import md5
 
 from pydantic import BaseModel
 
@@ -11,4 +12,5 @@ class Categories(BaseModel):
 
 
 def hash_category_name(name: str) -> int:
-    return hash(name) + sys.maxsize
+    return int.from_bytes(
+        md5(name.encode('utf-8')).hexdigest().encode('utf-8'), 'little')


### PR DESCRIPTION
the coco converter fails if the annotations are empty. Now we simply skip those anntotations. I also updated the retry logic for failed mask downloads so that it will be more robust.