### PR TITLE
[AC-242] Add error message detail to the LabelboxError when data row uploads fail.

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -381,9 +381,13 @@ class Client:
                 "Failed to upload, unknown cause", e)
 
         if not file_data or not file_data.get("uploadFile", None):
+            try:
+                errors = response.json().get("errors", [])
+                error_msg = next(iter(errors), {}).get("message", "Unknown error")
+            except Exception as e:
+                error_msg = "Unknown error"
             raise labelbox.exceptions.LabelboxError(
-                "Failed to upload, message: %s" % file_data or
-                file_data.get("error"))
+                "Failed to upload, message: %s" % error_msg)
 
         return file_data["uploadFile"]["url"]
 

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -383,7 +383,8 @@ class Client:
         if not file_data or not file_data.get("uploadFile", None):
             try:
                 errors = response.json().get("errors", [])
-                error_msg = next(iter(errors), {}).get("message", "Unknown error")
+                error_msg = next(iter(errors), {}).get("message",
+                                                       "Unknown error")
             except Exception as e:
                 error_msg = "Unknown error"
             raise labelbox.exceptions.LabelboxError(


### PR DESCRIPTION
**Before**
```log
    raise labelbox.exceptions.LabelboxError(
labelbox.exceptions.LabelboxError: Failed to upload, message: None('Failed to upload, message: None', None)
```

**After**
```log
    raise labelbox.exceptions.LabelboxError(
labelbox.exceptions.LabelboxError: Failed to upload, message: File upload error - invalid file extension for for file geomap.tif('Failed to upload, message: File upload error - invalid file extension for for file geomap.tif', None)
```