### PR TITLE
Check if export download url is None before returning

### DIFF
--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -333,7 +333,7 @@ class Project(DbObject, Updateable, Deletable):
         while True:
             res = self.client.execute(query_str, {id_param: self.uid})
             res = res["exportLabels"]
-            if not res["shouldPoll"]:
+            if not res["shouldPoll"] and res["downloadUrl"] is not None:
                 url = res['downloadUrl']
                 if not download:
                     return url


### PR DESCRIPTION
This prevents the export from returning None as the url, unless a timeout occurs.