### PR TITLE
[AL-0] Picsum Alternative

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@ import time
 import uuid
 from enum import Enum
 from types import SimpleNamespace
+import random
 
 import pytest
 import requests
@@ -18,7 +19,8 @@ from labelbox.schema.annotation_import import LabelImport
 from labelbox.schema.invite import Invite
 from labelbox.schema.user import User
 
-IMG_URL = "https://picsum.photos/200/300"
+dimension = random.randint(128, 1024)
+IMG_URL = f"http://via.placeholder.com/{dimension}/{dimension}"
 
 
 class Environ(Enum):
@@ -317,6 +319,7 @@ def configured_project_with_label(client, rand_gen, image_url, project, dataset,
     project.create_label = create_label
     project.create_label()
     label = next(project.labels())
+    print(f"this is a label: \n{label}")
     yield [project, dataset, datarow, label]
 
     for label in project.labels():


### PR DESCRIPTION
8/3/2022 - Using IMG_URL=picsum... is giving an error `invalid magic bytes for file`

This is circumvented by using alternative websites. This PR is to use an alternative lorem image generator. 