### PR TITLE
[CCV-1501] Add two new attachment types - raw_text and text_file

### DIFF
--- a/labelbox/schema/asset_attachment.py
+++ b/labelbox/schema/asset_attachment.py
@@ -9,7 +9,7 @@ class AssetAttachment(DbObject):
     """ Asset attachment provides extra context about an asset while labeling.
 
     Attributes:
-        attachment_type (str): IMAGE, VIDEO, TEXT, IMAGE_OVERLAY, or HTML
+        attachment_type (str): IMAGE, VIDEO, TEXT, IMAGE_OVERLAY, HTML, RAW_TEXT, or TEXT_FILE
         attachment_value (str): URL to an external file or a string of text
     """
 
@@ -19,6 +19,8 @@ class AssetAttachment(DbObject):
         TEXT = "TEXT"
         IMAGE_OVERLAY = "IMAGE_OVERLAY"
         HTML = "HTML"
+        RAW_TEXT = "RAW_TEXT"
+        TEXT_FILE = "TEXT_FILE"
 
     for topic in AttachmentType:
         vars()[topic.name] = topic.value

--- a/labelbox/schema/asset_attachment.py
+++ b/labelbox/schema/asset_attachment.py
@@ -9,7 +9,7 @@ class AssetAttachment(DbObject):
     """ Asset attachment provides extra context about an asset while labeling.
 
     Attributes:
-        attachment_type (str): IMAGE, VIDEO, IMAGE_OVERLAY, HTML, RAW_TEXT, or TEXT_FILE. TEXT attachment type is deprecated.
+        attachment_type (str): IMAGE, VIDEO, IMAGE_OVERLAY, HTML, RAW_TEXT, or TEXT_URL. TEXT attachment type is deprecated.
         attachment_value (str): URL to an external file or a string of text
     """
 
@@ -20,7 +20,7 @@ class AssetAttachment(DbObject):
         IMAGE_OVERLAY = "IMAGE_OVERLAY"
         HTML = "HTML"
         RAW_TEXT = "RAW_TEXT"
-        TEXT_FILE = "TEXT_FILE"
+        TEXT_URL = "TEXT_URL"
 
     for topic in AttachmentType:
         vars()[topic.name] = topic.value

--- a/labelbox/schema/asset_attachment.py
+++ b/labelbox/schema/asset_attachment.py
@@ -9,7 +9,7 @@ class AssetAttachment(DbObject):
     """ Asset attachment provides extra context about an asset while labeling.
 
     Attributes:
-        attachment_type (str): IMAGE, VIDEO, TEXT, IMAGE_OVERLAY, HTML, RAW_TEXT, or TEXT_FILE
+        attachment_type (str): IMAGE, VIDEO, IMAGE_OVERLAY, HTML, RAW_TEXT, or TEXT_FILE. TEXT attachment type is deprecated.
         attachment_value (str): URL to an external file or a string of text
     """
 


### PR DESCRIPTION
This change is allowing us to use Python SDK to set new attachment types for text - RAW_TEXT and TEXT_FILE.

More documentation about this change is available [here](https://github.com/Labelbox/intelligence/pull/9837)  