### PR TITLE
[AL-0] Update to bulk create data row test

### DIFF
--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -159,7 +159,8 @@ def test_data_row_large_bulk_creation(dataset, image_url):
         }] * n_local + [fp.name] * n_urls)
     task.wait_till_done()
     assert task.status == "COMPLETE"
-    assert len(list(dataset.data_rows())) == n_local + n_urls
+    # assert len(list(dataset.data_rows())) == n_local + n_urls
+    assert len(list(dataset.export_data_rows())) == n_local + n_urls
 
 
 def test_data_row_single_creation(dataset, rand_gen, image_url):

--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -159,7 +159,6 @@ def test_data_row_large_bulk_creation(dataset, image_url):
         }] * n_local + [fp.name] * n_urls)
     task.wait_till_done()
     assert task.status == "COMPLETE"
-    # assert len(list(dataset.data_rows())) == n_local + n_urls
     assert len(list(dataset.export_data_rows())) == n_local + n_urls
 
 


### PR DESCRIPTION
`Dataset.data_rows()` is running slow. Because the test being modified is not explicitly testing the effectiveness of the above, and because `Dataset.export_data_rows()` has been recently updated and optimized, we will be using this in the test moving forward.