### PR TITLE
[AL-3169] Update to shapely geoms

### DIFF
--- a/labelbox/data/serialization/coco/instance_dataset.py
+++ b/labelbox/data/serialization/coco/instance_dataset.py
@@ -28,15 +28,14 @@ def mask_to_coco_object_annotation(
     xmin, ymin, xmax, ymax = shapely.bounds
     # Iterate over polygon once or multiple polygon for each item
     area = shapely.area
-    if shapely.type == 'Polygon':
-        shapely = [shapely]
 
     return COCOObjectAnnotation(
         id=annot_idx,
         image_id=image_id,
         category_id=category_id,
         segmentation=[
-            np.array(s.exterior.coords).ravel().tolist() for s in shapely.geoms
+            np.array(s.exterior.coords).ravel().tolist()
+            for s in ([shapely] if shapely.type == "Polygon" else shapely.geoms)
         ],
         area=area,
         bbox=[xmin, ymin, xmax - xmin, ymax - ymin],

--- a/labelbox/data/serialization/coco/instance_dataset.py
+++ b/labelbox/data/serialization/coco/instance_dataset.py
@@ -36,7 +36,7 @@ def mask_to_coco_object_annotation(
         image_id=image_id,
         category_id=category_id,
         segmentation=[
-            np.array(s.exterior.coords).ravel().tolist() for s in shapely
+            np.array(s.exterior.coords).ravel().tolist() for s in shapely.geoms
         ],
         area=area,
         bbox=[xmin, ymin, xmax - xmin, ymax - ymin],


### PR DESCRIPTION
Iterating over multipart in shapely can now be done using `object.geoms` which returns a list.

Code is updated so that we now iterate over the list result of the `object`

Current documentation from shapely:

`...Members of a multi-point collection are accessed via the geoms property or via the iterator protocol using in or list()...`
[link to shapely manual](https://shapely.readthedocs.io/en/stable/manual.html)

```
pprint.pprint(list(points.geoms))
[<shapely.geometry.point.Point object at 0x...>,
 <shapely.geometry.point.Point object at 0x...>]
```

Since we are expecting everything to be multicollection objects outside of just a polygon, we run `.geoms` against anything that is not polygon here.