### PR TITLE
Update basics.ipynb with link to getting API key

### DIFF
--- a/examples/basics/basics.ipynb
+++ b/examples/basics/basics.ipynb
@@ -43,7 +43,7 @@
     "The quick version is basically just\n",
     "1. `!pip install labelbox`\n",
     "2. `export LABELBOX_API_KEY=\"<your_api_key>\"`\n",
-    "* Get this from the UI under (Account -> API -> Create API Key)\n",
+    "* Get this from the UI under (Workspace settings -> API -> Create API Key)\n",
     "* You can also set the api_key below in the notebook.\n",
     "\n",
     "This only works for cloud deployments.\n",


### PR DESCRIPTION
The API key location has been changed to being under `Workspace settings` rather than `Account`