### PR TITLE
[QQC-558] Remove test code updating queue_mode for a Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# Version 0.0.0 (YYYY-MM-DD) - In Progress
+
+### Added
+### Changed
+* Updated docs for deprecated methods `_update_queue_mode` and `get_queue_mode` in `Project`
+    * Use the `queue_mode` attribute in `Project` to get and set the queue mode instead
+### Fixed
+
 # Version 3.27.1 (2022-09-16)
 ### Changed
 * Removed `client.get_data_rows_for_global_keys` until further notice
@@ -17,7 +25,7 @@
 ### Changed
 * Increase scalar metric value limit to 100m
 * Added deprecation warnings when updating project `queue_mode`
-## Fixed
+### Fixed
 * Fix bug in `feature_confusion_matrix` and `confusion_matrix` causing FPs and FNs to be capped at 1 when there were no matching annotations 
 
 # Version 3.26.2 (2022-09-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 * Updated docs for deprecated methods `_update_queue_mode` and `get_queue_mode` in `Project`
     * Use the `queue_mode` attribute in `Project` to get and set the queue mode instead
+    * For more information, visit https://docs.labelbox.com/reference/migrating-to-workflows#upcoming-changes
 ### Fixed
 
 # Version 3.27.1 (2022-09-16)

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -611,7 +611,7 @@ class Client:
 
         Attribute values are passed as keyword arguments.
 
-        >>> project = client.create_project(name="<project_name>", description="<project_description>")
+        >>> project = client.create_project(name="<project_name>", description="<project_description>", queue_mode=QueueMode.Batch)
 
         Args:
             **kwargs: Keyword arguments with Project attribute values.

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -107,8 +107,6 @@ class Project(DbObject, Updateable, Deletable):
                 auto_audit_percentage <= 1.0
             Attempting to switch between benchmark and consensus modes is an invalid operation and will result
             in an error.
-
-        For more information, visit https://docs.labelbox.com/reference/migrating-to-workflows#upcoming-changes
         """
 
         media_type = kwargs.get("media_type")

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -95,7 +95,9 @@ class Project(DbObject, Updateable, Deletable):
         Args:
             kwargs: a dictionary containing attributes to be upserted
 
-        Note that the quality setting cannot be changed after a project has been created. The quality mode
+        Note that the queue_mode cannot be changed after a project has been created.
+
+        Additionally, the quality setting cannot be changed after a project has been created. The quality mode
             for a project is inferred through the following attributes:
             Benchmark:
                 auto_audit_number_of_labels = 1
@@ -105,10 +107,9 @@ class Project(DbObject, Updateable, Deletable):
                 auto_audit_percentage <= 1.0
             Attempting to switch between benchmark and consensus modes is an invalid operation and will result
             in an error.
+
+        For more information, visit https://docs.labelbox.com/reference/migrating-to-workflows#upcoming-changes
         """
-        mode: Optional[QueueMode] = kwargs.pop("queue_mode", None)
-        if mode:
-            self._update_queue_mode(mode)
 
         media_type = kwargs.get("media_type")
         if media_type:
@@ -623,6 +624,8 @@ class Project(DbObject, Updateable, Deletable):
         go through a migration to have the queue mode changed. Users should specify the
         queue mode for a project during creation if a non-default mode is desired.
 
+        For more information, visit https://docs.labelbox.com/reference/migrating-to-workflows#upcoming-changes
+
         Args:
             mode: the specified queue mode
 
@@ -668,6 +671,8 @@ class Project(DbObject, Updateable, Deletable):
         Deprecation notice: This method is deprecated and will be removed in
         a future version. To obtain the queue mode of a project, simply refer
         to the queue_mode attribute of a Project.
+
+        For more information, visit https://docs.labelbox.com/reference/migrating-to-workflows#upcoming-changes
 
         Returns: the QueueMode for this project
 

--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -160,19 +160,20 @@ def configured_project_pdf(client, ontology, rand_gen, pdf_url):
 
 @pytest.fixture
 def configured_project_without_data_rows(client, configured_project, rand_gen):
-    project = client.create_project(name=rand_gen(str))
+    project = client.create_project(name=rand_gen(str),
+                                    description=rand_gen(str),
+                                    queue_mode=QueueMode.Batch)
     editor = list(
         client.get_labeling_frontends(
             where=LabelingFrontend.name == "editor"))[0]
     project.setup_editor(configured_project.ontology())
-    project.update(queue_mode=QueueMode.Batch)
     yield project
     project.delete()
 
 
 @pytest.fixture
 def prediction_id_mapping(configured_project):
-    #Maps tool types to feature schema ids
+    # Maps tool types to feature schema ids
     ontology = configured_project.ontology().normalized
     result = {}
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,6 +16,7 @@ from labelbox.orm import query
 from labelbox.pagination import PaginatedCollection
 from labelbox.schema.annotation_import import LabelImport
 from labelbox.schema.invite import Invite
+from labelbox.schema.queue_mode import QueueMode
 from labelbox.schema.user import User
 
 IMG_URL = "https://picsum.photos/200/300.jpg"
@@ -160,6 +161,14 @@ def pdf_url(client):
 @pytest.fixture
 def project(client, rand_gen):
     project = client.create_project(name=rand_gen(str))
+    yield project
+    project.delete()
+
+
+@pytest.fixture
+def batch_project(client, rand_gen):
+    project = client.create_project(name=rand_gen(str),
+                                    queue_mode=QueueMode.Batch)
     yield project
     project.delete()
 

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -32,46 +32,41 @@ def small_dataset(dataset: Dataset):
     yield dataset
 
 
-def test_create_batch(configured_project: Project, big_dataset: Dataset):
-    configured_project.update(queue_mode=QueueMode.Batch)
-
+def test_create_batch(batch_project: Project, big_dataset: Dataset):
     data_rows = [dr.uid for dr in list(big_dataset.export_data_rows())]
-    batch = configured_project.create_batch("test-batch", data_rows, 3)
+    batch = batch_project.create_batch("test-batch", data_rows, 3)
     assert batch.name == "test-batch"
     assert batch.size == len(data_rows)
 
 
-def test_archive_batch(configured_project: Project, small_dataset: Dataset):
+def test_archive_batch(batch_project: Project, small_dataset: Dataset):
     data_rows = [dr.uid for dr in list(small_dataset.export_data_rows())]
-    configured_project.update(queue_mode=QueueMode.Batch)
-    batch = configured_project.create_batch("batch to archive", data_rows)
+    batch = batch_project.create_batch("batch to archive", data_rows)
     batch.remove_queued_data_rows()
     exported_data_rows = list(batch.export_data_rows())
 
     assert len(exported_data_rows) == 0
 
 
-def test_delete(configured_project: Project, small_dataset: Dataset):
+def test_delete(batch_project: Project, small_dataset: Dataset):
     data_rows = [dr.uid for dr in list(small_dataset.export_data_rows())]
-    configured_project.update(queue_mode=QueueMode.Batch)
-    batch = configured_project.create_batch("batch to delete", data_rows)
+    batch = batch_project.create_batch("batch to delete", data_rows)
     batch.delete()
 
-    assert len(list(configured_project.batches())) == 0
+    assert len(list(batch_project.batches())) == 0
 
 
-def test_batch_project(configured_project: Project, small_dataset: Dataset):
+def test_batch_project(batch_project: Project, small_dataset: Dataset):
     data_rows = [dr.uid for dr in list(small_dataset.export_data_rows())]
-    configured_project.update(queue_mode=QueueMode.Batch)
-    batch = configured_project.create_batch(
-        "batch to test project relationship", data_rows)
+    batch = batch_project.create_batch("batch to test project relationship",
+                                       data_rows)
     project_from_batch = batch.project()
 
-    assert project_from_batch.uid == configured_project.uid
-    assert project_from_batch.name == configured_project.name
+    assert project_from_batch.uid == batch_project.uid
+    assert project_from_batch.name == batch_project.name
 
 
-def test_export_data_rows(configured_project: Project, dataset: Dataset):
+def test_export_data_rows(batch_project: Project, dataset: Dataset):
     n_data_rows = 5
     task = dataset.create_data_rows([
         {
@@ -82,8 +77,7 @@ def test_export_data_rows(configured_project: Project, dataset: Dataset):
     task.wait_till_done()
 
     data_rows = [dr.uid for dr in list(dataset.export_data_rows())]
-    configured_project.update(queue_mode=QueueMode.Batch)
-    batch = configured_project.create_batch("batch test", data_rows)
+    batch = batch_project.create_batch("batch test", data_rows)
 
     result = list(batch.export_data_rows())
     exported_data_rows = [dr.uid for dr in result]
@@ -95,23 +89,19 @@ def test_export_data_rows(configured_project: Project, dataset: Dataset):
 @pytest.mark.skip(
     reason="Test cannot be used effectively with MAL/LabelImport. \
 Fix/Unskip after resolving deletion with MAL/LabelImport")
-def test_delete_labels(configured_project_with_label):
-    project, dataset, _, _ = configured_project_with_label
-
-    data_rows = [dr.uid for dr in list(dataset.export_data_rows())]
-    project.update(queue_mode=QueueMode.Batch)
-    batch = project.create_batch("batch to delete labels", data_rows)
+def test_delete_labels(batch_project, small_dataset):
+    data_rows = [dr.uid for dr in list(small_dataset.export_data_rows())]
+    batch = batch_project.create_batch("batch to delete labels", data_rows)
 
 
 @pytest.mark.skip(
     reason="Test cannot be used effectively with MAL/LabelImport. \
 Fix/Unskip after resolving deletion with MAL/LabelImport")
-def test_delete_labels_with_templates(configured_project: Project,
+def test_delete_labels_with_templates(batch_project: Project,
                                       small_dataset: Dataset):
     data_rows = [dr.uid for dr in list(small_dataset.export_data_rows())]
-    configured_project.update(queue_mode=QueueMode.Batch)
-    batch = configured_project.create_batch(
-        "batch to delete labels w templates", data_rows)
+    batch = batch_project.create_batch("batch to delete labels w templates",
+                                       data_rows)
     exported_data_rows = list(batch.export_data_rows())
     res = batch.delete_labels(labels_as_template=True)
     exported_data_rows = list(batch.export_data_rows())

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -207,7 +207,7 @@ def test_queue_mode(configured_project: Project):
     assert configured_project.queue_mode == QueueMode.Dataset
 
 
-def test_batches(configured_project: Project, dataset: Dataset, image_url):
+def test_batches(batch_project: Project, dataset: Dataset, image_url):
     task = dataset.create_data_rows([
         {
             "row_data": image_url,
@@ -215,14 +215,13 @@ def test_batches(configured_project: Project, dataset: Dataset, image_url):
         },
     ] * 2)
     task.wait_till_done()
-    configured_project.update(queue_mode=QueueMode.Batch)
     data_rows = [dr.uid for dr in list(dataset.export_data_rows())]
     batch_one = 'batch one'
     batch_two = 'batch two'
-    configured_project.create_batch(batch_one, [data_rows[0]])
-    configured_project.create_batch(batch_two, [data_rows[1]])
+    batch_project.create_batch(batch_one, [data_rows[0]])
+    batch_project.create_batch(batch_two, [data_rows[1]])
 
-    names = set([batch.name for batch in list(configured_project.batches())])
+    names = set([batch.name for batch in list(batch_project.batches())])
     assert names == {batch_one, batch_two}
 
 


### PR DESCRIPTION
Updating a project's queue mode will soon be disallowed through the API service, so this PR migrates the test code to instead set the queue mode upon project creation.