### PR TITLE
increase mea upload timeout

### DIFF
--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -43,7 +43,7 @@ class ModelRun(DbObject):
         COMPLETE = "COMPLETE"
         FAILED = "FAILED"
 
-    def upsert_labels(self, label_ids, timeout_seconds=60):
+    def upsert_labels(self, label_ids, timeout_seconds=3600):
         """ Adds data rows and labels to a Model Run
         Args:
             label_ids (list): label ids to insert
@@ -76,7 +76,7 @@ class ModelRun(DbObject):
             }})['MEALabelRegistrationTaskStatus'],
                                      timeout_seconds=timeout_seconds)
 
-    def upsert_data_rows(self, data_row_ids, timeout_seconds=60):
+    def upsert_data_rows(self, data_row_ids, timeout_seconds=3600):
         """ Adds data rows to a Model Run without any associated labels
         Args:
             data_row_ids (list): data row ids to add to mea


### PR DESCRIPTION
Previously mea only supported 2k data rows so uploads were basically instant. Now that the limit has been raised substantially the client is timing out.

Ideally we will return an object representing the async task that allows users to check the status as needed. Currently the backend does not expose an endpoint compatible with out `Task` abstraction. Therefore, we have chosen not to introduce another async concept and this function will simply be blocking.