### PR TITLE
[AL-3872] Fix SDK build tests

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -1178,9 +1178,13 @@ class Client:
                 errors.extend(
                     _format_failed_rows(data['deletedDataRowGlobalKeys'],
                                         "Data Row deleted"))
+
+                # Invalid results may contain empty string, so we must filter
+                # them prior to checking for PARTIAL_SUCCESS
+                filtered_results = list(filter(lambda r: r != '', results))
                 if not errors:
                     status = CollectionJobStatus.SUCCESS.value
-                elif errors and results:
+                elif errors and len(filtered_results) > 0:
                     status = CollectionJobStatus.PARTIAL_SUCCESS.value
                 else:
                     status = CollectionJobStatus.FAILURE.value

--- a/tests/integration/test_data_row_media_attributes.py
+++ b/tests/integration/test_data_row_media_attributes.py
@@ -1,5 +1,10 @@
+from time import sleep
+
+
 def test_export_empty_media_attributes(configured_project_with_label):
     project, _, _, _ = configured_project_with_label
+    # Wait for exporter to retrieve latest labels
+    sleep(10)
     labels = project.label_generator()
     label = next(labels)
     assert label.data.media_attributes == {}

--- a/tests/integration/test_data_row_metadata.py
+++ b/tests/integration/test_data_row_metadata.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from time import sleep
 
 import pytest
 import uuid
@@ -70,6 +71,8 @@ def make_metadata(dr_id) -> DataRowMetadata:
 
 def test_export_empty_metadata(configured_project_with_label):
     project, _, _, _ = configured_project_with_label
+    # Wait for exporter to retrieve latest labels
+    sleep(10)
     labels = project.label_generator()
     label = next(labels)
     assert label.data.metadata == []

--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -352,7 +352,8 @@ def test_create_data_rows_with_invalid_metadata(dataset, image_url):
         DataRow.metadata_fields: fields
     }])
     task.wait_till_done()
-    assert task.status == "FAILED"
+    assert task.status == "COMPLETE"
+    assert len(task.failed_data_rows) > 0
 
 
 def test_create_data_rows_with_metadata_missing_value(dataset, image_url):
@@ -632,7 +633,8 @@ def test_data_row_bulk_creation_with_same_global_keys(dataset, sample_image):
     }])
 
     task.wait_till_done()
-    assert task.status == "FAILED"
+    assert task.status == "COMPLETE"
+    assert len(task.failed_data_rows) > 0
     assert len(list(dataset.data_rows())) == 0
 
     task = dataset.create_data_rows([{

--- a/tests/integration/test_global_keys.py
+++ b/tests/integration/test_global_keys.py
@@ -251,9 +251,10 @@ def test_get_data_row_ids_for_invalid_global_keys(client, dataset, image_url):
     assert res['status'] == "PARTIAL SUCCESS"
 
     assert len(res['errors']) == 1
-    assert len(res['results']) == 1
+    assert len(res['results']) == 2
 
     assert res['errors'][0]['error'] == "Data Row not found"
     assert res['errors'][0]['global_key'] == gk_1
 
-    assert res['results'][0] == dr_2.uid
+    assert res['results'][0] == ''
+    assert res['results'][1] == dr_2.uid

--- a/tests/integration/test_task.py
+++ b/tests/integration/test_task.py
@@ -23,12 +23,11 @@ def test_task_errors(dataset, image_url):
     ])
     assert task in client.get_user().created_tasks()
     task.wait_till_done()
-    assert task.status == "FAILED"
+    assert task.status == "COMPLETE"
+    assert len(task.failed_data_rows) > 0
     assert task.errors is not None
-    assert 'message' in task.errors
-    with pytest.raises(Exception) as exc_info:
-        task.result
-    assert str(exc_info.value).startswith("Job failed. Errors : {")
+    assert 'message' in task.errors[0]
+    assert len(task.result) == 0
 
 
 def test_task_success_json(dataset, image_url):


### PR DESCRIPTION
- Changed failed_data_rows to a property
- Fixed issue with task always reporting warning, due to a bug with failed_data_rows check condition
- Fixed `test_create_data_rows_with_invalid_metadata` on assertions
- Fixed `test_get_data_row_ids_for_invalid_global_keys` to not falsely report PARTIAL SUCCESS
- Fixed `test_task_errors` on assertions