### PR TITLE
[X-0] Adjust integration tests to explicitly define queue mode

### DIFF
--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -125,7 +125,8 @@ def ontology():
 
 @pytest.fixture
 def configured_project(client, ontology, rand_gen, image_url):
-    project = client.create_project(name=rand_gen(str))
+    project = client.create_project(name=rand_gen(str),
+                                    queue_mode=QueueMode.Dataset)
     dataset = client.create_dataset(name=rand_gen(str))
     editor = list(
         client.get_labeling_frontends(
@@ -143,7 +144,8 @@ def configured_project(client, ontology, rand_gen, image_url):
 
 @pytest.fixture
 def configured_project_pdf(client, ontology, rand_gen, pdf_url):
-    project = client.create_project(name=rand_gen(str))
+    project = client.create_project(name=rand_gen(str),
+                                    queue_mode=QueueMode.Dataset)
     dataset = client.create_dataset(name=rand_gen(str))
     editor = list(
         client.get_labeling_frontends(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -160,7 +160,8 @@ def pdf_url(client):
 
 @pytest.fixture
 def project(client, rand_gen):
-    project = client.create_project(name=rand_gen(str))
+    project = client.create_project(name=rand_gen(str),
+                                    queue_mode=QueueMode.Dataset)
     yield project
     project.delete()
 
@@ -346,7 +347,8 @@ def configured_project_with_label(client, rand_gen, image_url, project, dataset,
 
 @pytest.fixture
 def configured_project_with_complex_ontology(client, rand_gen, image_url):
-    project = client.create_project(name=rand_gen(str))
+    project = client.create_project(name=rand_gen(str),
+                                    queue_mode=QueueMode.Dataset)
     dataset = client.create_dataset(name=rand_gen(str), projects=project)
     data_row = dataset.create_data_row(row_data=image_url)
     editor = list(

--- a/tests/integration/test_filtering.py
+++ b/tests/integration/test_filtering.py
@@ -2,14 +2,15 @@ import pytest
 
 from labelbox import Project
 from labelbox.exceptions import InvalidQueryError
+from labelbox.schema.queue_mode import QueueMode
 
 
 # Avoid assertions using equality to prevent intermittent failures due to
 # other builds simultaneously adding projects to test org
 def test_where(client):
-    p_a = client.create_project(name="a")
-    p_b = client.create_project(name="b")
-    p_c = client.create_project(name="c")
+    p_a = client.create_project(name="a", queue_mode=QueueMode.Dataset)
+    p_b = client.create_project(name="b", queue_mode=QueueMode.Dataset)
+    p_c = client.create_project(name="c", queue_mode=QueueMode.Dataset)
 
     def _get(f, where=None):
         date_where = Project.created_at >= p_a.created_at

--- a/tests/integration/test_relationships.py
+++ b/tests/integration/test_relationships.py
@@ -1,10 +1,12 @@
 import pytest
 
 from labelbox.exceptions import InvalidQueryError
+from labelbox.schema.queue_mode import QueueMode
 
 
 def test_project_dataset(client, rand_gen):
-    project = client.create_project(name=rand_gen(str))
+    project = client.create_project(name=rand_gen(str),
+                                    queue_mode=QueueMode.Dataset)
     dataset = client.create_dataset(name=rand_gen(str))
 
     assert len(list(project.datasets())) == 0
@@ -17,7 +19,8 @@ def test_project_dataset(client, rand_gen):
     assert {ds.uid for ds in project.datasets()} == {dataset.uid}
     assert {pr.uid for pr in dataset.projects()} == {project.uid}
 
-    project_2 = client.create_project(name=rand_gen(str))
+    project_2 = client.create_project(name=rand_gen(str),
+                                      queue_mode=QueueMode.Dataset)
 
     # Currently it's not possible to connect a project and dataset
     # by updating dataset.

--- a/tests/integration/test_sorting.py
+++ b/tests/integration/test_sorting.py
@@ -1,14 +1,21 @@
 import pytest
 
 from labelbox import Project
+from labelbox.schema.queue_mode import QueueMode
 
 
 @pytest.mark.xfail(reason="Relationship sorting not implemented correctly "
                    "on the server-side")
 def test_relationship_sorting(client):
-    a = client.create_project(name="a", description="b")
-    b = client.create_project(name="b", description="c")
-    c = client.create_project(name="c", description="a")
+    a = client.create_project(name="a",
+                              description="b",
+                              queue_mode=QueueMode.Dataset)
+    b = client.create_project(name="b",
+                              description="c",
+                              queue_mode=QueueMode.Dataset)
+    c = client.create_project(name="c",
+                              description="a",
+                              queue_mode=QueueMode.Dataset)
 
     dataset = client.create_dataset(name="Dataset")
     a.datasets.connect(dataset)


### PR DESCRIPTION
Due to recent changes to default createProject behavior, we've started to default to `batches` if no queue mode is provided. Thus, we need to adjust integration tests.

Since the default behavior change is already on staging, I've run e2e tests against it. They all pass.

Tandem PR in API that adjusts the behavior: https://github.com/Labelbox/intelligence/pull/11294