### PR TITLE
Include metadata in bulk create conversation in create_data_rows

### DIFF
--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -295,8 +295,8 @@ class Dataset(DbObject, Updateable, Deletable):
             def check_message_keys(message):
                 accepted_message_keys = set([
                     "messageId", "timestampUsec", "content", "user", "align",
-                    "canLabel"
-                ])
+                    "canLabel", "metadata_fields"
+                ])   
                 for key in message.keys():
                     if not key in accepted_message_keys:
                         raise KeyError(

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -296,7 +296,7 @@ class Dataset(DbObject, Updateable, Deletable):
                 accepted_message_keys = set([
                     "messageId", "timestampUsec", "content", "user", "align",
                     "canLabel", "metadata_fields"
-                ])   
+                ])
                 for key in message.keys():
                     if not key in accepted_message_keys:
                         raise KeyError(

--- a/tests/integration/media/bulk_conversation_metadata.json
+++ b/tests/integration/media/bulk_conversation_metadata.json
@@ -1,0 +1,121 @@
+[
+    {
+        "externalId": "Convo-123",
+        "attachments": [
+            {
+                "type": "TEXT",
+                "value": "IOWA, Zone 2232, June 2022 [Text string]"
+            },
+            {
+                "type": "IMAGE",
+                "value": "https://storage.googleapis.com/labelbox-sample-datasets/Docs/disease_attachment.jpeg"
+            }
+        ],
+        "metadata_fields":[{
+            "schema_id": "cl9hb5j187j5l071l47gu34uk",
+            "value": "tag_string1"
+        }],
+        "type": "application/vnd.labelbox.conversational",
+        "version": 1,
+        "conversationalData": [
+            {
+                "messageId": "message-0",
+                "timestampUsec": 1530718491,
+                "content": "I love iphone! i just bought new iphone! :smiling_face_with_3_hearts: :calling:",
+                "user": {
+                    "userId": "Bot 002",
+                    "name": "Bot"
+                },
+                "align": "left",
+                "canLabel": false
+            },
+            {
+                "messageId": "message-1",
+                "timestampUsec": 1530718503,
+                "content": "Thats good for you, i'm not very into new tech",
+                "user": {
+                    "userId": "User 00686",
+                    "name": "User"
+                },
+                "align": "right",
+                "canLabel": true
+            },
+            {
+                "messageId": "message-2",
+                "timestampUsec": 1530718516,
+                "content": "I am a college student and i am a college student :female-teacher::skin-tone-2:",
+                "user": {
+                    "userId": "Bot 002",
+                    "name": "Bot"
+                },
+                "align": "left",
+                "canLabel": false
+            },
+            {
+                "messageId": "message-3",
+                "timestampUsec": 1530718528,
+                "content": "I am go to gym and live on donations :woman-lifting-weights::skin-tone-6:",
+                "user": {
+                    "userId": "User 00686",
+                    "name": "User"
+                },
+                "align": "right",
+                "canLabel": true
+            }
+        ]
+    },
+    {
+        "externalId": "Convo-456",
+        "attachments": [
+            {
+                "type": "TEXT",
+                "value": "IOWA, Zone 1234567, July 2022 [Text string]"
+            },
+            {
+                "type": "IMAGE",
+                "value": "https://storage.googleapis.com/labelbox-sample-datasets/Docs/disease_attachment.jpeg"
+            }
+        ],
+        "metadata_fields": [{
+            "schema_id": "cl9hb5j187j5l071l47gu34uk",
+            "value": "tag_string2"
+        }],
+        "type": "application/vnd.labelbox.conversational",
+        "version": 1,
+        "conversationalData": [
+            {
+                "messageId": "message-0",
+                "timestampUsec": 1530718491,
+                "content": "I love iphone! i just bought new iphone! :smiling_face_with_3_hearts: :calling:",
+                "user": {
+                    "userId": "Bot 002",
+                    "name": "Bot"
+                },
+                "align": "left",
+                "canLabel": false
+            },
+            {
+                "messageId": "message-1",
+                "timestampUsec": 1530718503,
+                "content": "Thats good for you, i'm not very into new tech",
+                "user": {
+                    "userId": "User 00686",
+                    "name": "User"
+                },
+                "align": "right",
+                "canLabel": true
+            },
+            {
+                "messageId": "message-2",
+                "timestampUsec": 1530718516,
+                "content": "I am a college student and i am a college student :female-teacher::skin-tone-2:",
+                "user": {
+                    "userId": "Bot 002",
+                    "name": "Bot"
+                },
+                "align": "left",
+                "canLabel": false
+            }
+        ]
+    }
+]


### PR DESCRIPTION
I have included the `metadata_fields` as an accepted key to the validation method of each message with creating multiple messages.