### PR TITLE
[QQC-755] Allow to pass batch consensus settings when creating a batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # In progress
 ## Changed
 * Default behavior for metrics to not include subclasses in the calculation.
+* Updated `create_batch` method to accept consensus settings.
 
 ## Fixed
 * Polygon extraction from masks creating invalid polygons. This would cause issues in the coco converter.

--- a/labelbox/schema/batch.py
+++ b/labelbox/schema/batch.py
@@ -32,6 +32,7 @@ class Batch(DbObject):
     created_at = Field.DateTime("created_at")
     updated_at = Field.DateTime("updated_at")
     size = Field.Int("size")
+    consensus_settings = Field.Json("consensus_settings_json")
 
     # Relationships
     created_by = Relationship.ToOne("User")

--- a/labelbox/schema/consensus_settings.py
+++ b/labelbox/schema/consensus_settings.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class ConsensusSettings(BaseModel):
+    """Container for holding consensus quality settings
+
+    >>> ConsensusSettings(
+    >>>    numberOfLabels = 2,
+    >>>    coveragePercentage = 0.2
+    >>>  )
+
+    Args:
+        numberOfLabels: Number of labels for consensus
+        coveragePercentage: Percentage of data rows to be labeled more than once
+    """
+
+    numberOfLabels: int
+    coveragePercentage: float

--- a/labelbox/schema/consensus_settings.py
+++ b/labelbox/schema/consensus_settings.py
@@ -1,18 +1,18 @@
-from pydantic import BaseModel
+from labelbox.utils import _CamelCaseMixin
 
 
-class ConsensusSettings(BaseModel):
+class ConsensusSettings(_CamelCaseMixin):
     """Container for holding consensus quality settings
 
     >>> ConsensusSettings(
-    >>>    numberOfLabels = 2,
-    >>>    coveragePercentage = 0.2
+    >>>    number_of_labels = 2,
+    >>>    coverage_percentage = 0.2
     >>>  )
 
     Args:
-        numberOfLabels: Number of labels for consensus
-        coveragePercentage: Percentage of data rows to be labeled more than once
+        number_of_labels: Number of labels for consensus
+        coverage_percentage: Percentage of data rows to be labeled more than once
     """
 
-    numberOfLabels: int
-    coveragePercentage: float
+    number_of_labels: int
+    coverage_percentage: float

--- a/labelbox/schema/data_row_metadata.py
+++ b/labelbox/schema/data_row_metadata.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Dict, Union, Callable, Type, Any, Generator
 from pydantic import BaseModel, conlist, constr
 
 from labelbox.schema.ontology import SchemaId
-from labelbox.utils import camel_case
+from labelbox.utils import _CamelCaseMixin
 
 
 class DataRowMetadataKind(Enum):
@@ -34,13 +34,6 @@ DataRowMetadataSchema.update_forward_refs()
 
 Embedding: Type[List[float]] = conlist(float, min_items=128, max_items=128)
 String: Type[str] = constr(max_length=500)
-
-
-class _CamelCaseMixin(BaseModel):
-
-    class Config:
-        allow_population_by_field_name = True
-        alias_generator = camel_case
 
 
 # Metadata base class

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -16,6 +16,7 @@ from labelbox.orm import query
 from labelbox.orm.db_object import DbObject, Updateable, Deletable
 from labelbox.orm.model import Entity, Field, Relationship
 from labelbox.pagination import PaginatedCollection
+from labelbox.schema.consensus_settings import ConsensusSettings
 from labelbox.schema.media_type import MediaType
 from labelbox.schema.queue_mode import QueueMode
 from labelbox.schema.resource_tag import ResourceTag
@@ -561,7 +562,11 @@ class Project(DbObject, Updateable, Deletable):
         timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         self.update(setup_complete=timestamp)
 
-    def create_batch(self, name: str, data_rows: List[str], priority: int = 5):
+    def create_batch(self,
+                     name: str,
+                     data_rows: List[str],
+                     priority: int = 5,
+                     consensus_settings: Optional[ConsensusSettings] = None):
         """Create a new batch for a project. Batches is in Beta and subject to change
 
         Args:
@@ -603,9 +608,14 @@ class Project(DbObject, Updateable, Deletable):
         params = {
             "projectId": self.uid,
             "batchInput": {
-                "name": name,
-                "dataRowIds": dr_ids,
-                "priority": priority
+                "name":
+                    name,
+                "dataRowIds":
+                    dr_ids,
+                "priority":
+                    priority,
+                "consensusSettings":
+                    consensus_settings.dict() if consensus_settings else None
             }
         }
 

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -605,17 +605,15 @@ class Project(DbObject, Updateable, Deletable):
             }
         """ % (method, method, query.results_query_part(Entity.Batch))
 
+        consensus_settings_dict = consensus_settings.dict(
+        ) if consensus_settings else None
         params = {
             "projectId": self.uid,
             "batchInput": {
-                "name":
-                    name,
-                "dataRowIds":
-                    dr_ids,
-                "priority":
-                    priority,
-                "consensusSettings":
-                    consensus_settings.dict() if consensus_settings else None
+                "name": name,
+                "dataRowIds": dr_ids,
+                "priority": priority,
+                "consensusSettings": consensus_settings_dict
             }
         }
 

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -566,14 +566,14 @@ class Project(DbObject, Updateable, Deletable):
                      name: str,
                      data_rows: List[str],
                      priority: int = 5,
-                     consensus_settings: Optional[ConsensusSettings] = None):
+                     consensus_settings: Optional[Dict[str, float]] = None):
         """Create a new batch for a project. Batches is in Beta and subject to change
 
         Args:
             name: a name for the batch, must be unique within a project
             data_rows: Either a list of `DataRows` or Data Row ids
             priority: An optional priority for the Data Rows in the Batch. 1 highest -> 5 lowest
-
+            consensus_settings: An optional dictionary with consensus settings: {'number_of_labels': 3, 'coverage_percentage': 0.1}
         """
 
         # @TODO: make this automatic?
@@ -605,15 +605,16 @@ class Project(DbObject, Updateable, Deletable):
             }
         """ % (method, method, query.results_query_part(Entity.Batch))
 
-        consensus_settings_dict = consensus_settings.dict(
-        ) if consensus_settings else None
+        if consensus_settings:
+            consensus_settings = ConsensusSettings(**consensus_settings).dict(
+                by_alias=True)
         params = {
             "projectId": self.uid,
             "batchInput": {
                 "name": name,
                 "dataRowIds": dr_ids,
                 "priority": priority,
-                "consensusSettings": consensus_settings_dict
+                "consensusSettings": consensus_settings
             }
         }
 

--- a/labelbox/utils.py
+++ b/labelbox/utils.py
@@ -1,4 +1,5 @@
 import re
+from pydantic import BaseModel
 
 
 def _convert(s, sep, title):
@@ -23,3 +24,10 @@ def title_case(s):
 def snake_case(s):
     """ Converts a string in [snake|camel|title]case to snake_case. """
     return _convert(s, "_", lambda i: False)
+
+
+class _CamelCaseMixin(BaseModel):
+
+    class Config:
+        allow_population_by_field_name = True
+        alias_generator = camel_case

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -177,7 +177,9 @@ def batch_project(client, rand_gen):
 
 @pytest.fixture
 def consensus_project(client, rand_gen):
-    project = client.create_project(name=rand_gen(str), auto_audit_percentage=0)
+    project = client.create_project(name=rand_gen(str),
+                                    auto_audit_percentage=0,
+                                    queue_mode=QueueMode.Dataset)
     yield project
     project.delete()
 

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -1,7 +1,6 @@
 import pytest
 
 from labelbox import Dataset, Project
-from labelbox.schema.queue_mode import QueueMode
 
 IMAGE_URL = "https://storage.googleapis.com/diagnostics-demo-data/coco/COCO_train2014_000000000034.jpg"
 
@@ -37,6 +36,19 @@ def test_create_batch(batch_project: Project, big_dataset: Dataset):
     batch = batch_project.create_batch("test-batch", data_rows, 3)
     assert batch.name == "test-batch"
     assert batch.size == len(data_rows)
+
+
+def test_create_batch_with_consensus_settings(batch_project: Project,
+                                              big_dataset: Dataset):
+    data_rows = [dr.uid for dr in list(big_dataset.export_data_rows())]
+    consensus_settings = {"coverage_percentage": 0.1, "number_of_labels": 3}
+    batch = batch_project.create_batch("batch with consensus settings",
+                                       data_rows,
+                                       3,
+                                       consensus_settings=consensus_settings)
+    assert batch.name == "batch with consensus settings"
+    assert batch.size == len(data_rows)
+    assert batch.consensus_settings == consensus_settings
 
 
 def test_archive_batch(batch_project: Project, small_dataset: Dataset):


### PR DESCRIPTION
Tandem PR in API that needs to be merged before this: https://github.com/Labelbox/intelligence/pull/11383 (done)

This is part of project paradigm which is set to release on 2nd November. As part of the changes, we'll prefer customers to provide consensus settings per batch, rather than per project.

Updates to our SDK documentation are coming after this PR gets in.