### PR TITLE
Added .PNG for image type detection

### DIFF
--- a/labelbox/data/serialization/labelbox_v1/label.py
+++ b/labelbox/data/serialization/labelbox_v1/label.py
@@ -213,7 +213,7 @@ class LBV1Label(BaseModel):
         elif self._has_object_annotations():
             return 'image'
         else:
-            if self._row_contains((".jpg", ".png", ".jpeg")) and self._is_url():
+            if self._row_contains((".jpg", ".png", ".PNG", ".jpeg")) and self._is_url():
                 return 'image'
             elif (self._row_contains((".txt", ".text", ".html")) and
                   self._is_url()) or not self._is_url():


### PR DESCRIPTION
For https://github.com/Labelbox/labelbox-python/issues/740  Some devices can create photos with capitalised .PNG such as Iphones.