### PR TITLE
update create data row row_data to accept dict

### DIFF
--- a/labelbox/schema/data_row.py
+++ b/labelbox/schema/data_row.py
@@ -1,5 +1,6 @@
 import logging
 from typing import TYPE_CHECKING
+import json
 
 from labelbox.orm import query
 from labelbox.orm.db_object import DbObject, Updateable, BulkDeletable
@@ -63,6 +64,14 @@ class DataRow(DbObject, Updateable, BulkDeletable):
         super().__init__(*args, **kwargs)
         self.attachments.supports_filtering = False
         self.attachments.supports_sorting = False
+
+    def update(self, **kwargs):
+        # Convert row data to string if it is an object
+        # All other updates pass through
+        row_data = kwargs.get("row_data")
+        if isinstance(row_data, dict):
+            kwargs['row_data'] = json.dumps(kwargs['row_data'])
+        super().update(**kwargs)
 
     @staticmethod
     def bulk_delete(data_rows) -> None:

--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -459,6 +459,13 @@ def test_data_row_update(dataset, rand_gen, image_url):
     data_row.update(external_id=external_id_2)
     assert data_row.external_id == external_id_2
 
+    data_row.update(row_data="123")
+    assert data_row.row_data == "123"
+
+    # tileLayer becomes a media attribute
+    data_row.update(row_data={'pdfUrl': "123", "tileLayerUrl": "123"})
+    assert data_row.row_data == "123"
+
 
 def test_data_row_filtering_sorting(dataset, image_url):
     task = dataset.create_data_rows([


### PR DESCRIPTION
We recently updated the backend to accept row data as stringified json to support data rows that are composed of multiple pieces of information. In #734 we changed the SDK to support this for data row creation as well.

This pr is to change that behavior for data row update.
