### PR TITLE
add get_one and get_many methods to paginated collection

### DIFF
--- a/labelbox/pagination.py
+++ b/labelbox/pagination.py
@@ -45,7 +45,7 @@ class PaginatedCollection:
         """
         self._fetched_all = False
         self._data: List[Dict[str, Any]] = []
-        self._data_ind = 0
+        self._data_index = 0
 
         pagination_kwargs = {
             'client': client,
@@ -62,11 +62,11 @@ class PaginatedCollection:
                 **pagination_kwargs)
 
     def __iter__(self):
-        self._data_ind = 0
+        self._data_index = 0
         return self
 
     def __next__(self):
-        if len(self._data) <= self._data_ind:
+        if len(self._data) <= self._data_index:
             if self._fetched_all:
                 raise StopIteration()
 
@@ -75,9 +75,35 @@ class PaginatedCollection:
             if len(page_data) == 0:
                 raise StopIteration()
 
-        rval = self._data[self._data_ind]
-        self._data_ind += 1
-        return rval
+        next_value = self._data[self._data_index]
+        self._data_index += 1
+        return next_value
+
+    def get_one(self):
+      """Iterates over self and returns first value
+      This method is idempotent
+      """
+      for value in self:
+          return value
+
+    def get_many(self, n: int):
+      """Iterates over self and returns first n results
+      This method is idempotent
+
+      Args:
+          n (int): Number of elements to retrieve
+      """
+      results = []
+      i = 0
+
+      for value in self:
+          if i >= n:
+            break
+
+          results.append(value)
+          i += 1
+
+      return results
 
 
 class _Pagination(ABC):

--- a/labelbox/pagination.py
+++ b/labelbox/pagination.py
@@ -45,7 +45,7 @@ class PaginatedCollection:
         """
         self._fetched_all = False
         self._data: List[Dict[str, Any]] = []
-        self._data_index = 0
+        self._data_ind = 0
 
         pagination_kwargs = {
             'client': client,
@@ -62,11 +62,11 @@ class PaginatedCollection:
                 **pagination_kwargs)
 
     def __iter__(self):
-        self._data_index = 0
+        self._data_ind = 0
         return self
 
     def __next__(self):
-        if len(self._data) <= self._data_index:
+        if len(self._data) <= self._data_ind:
             if self._fetched_all:
                 raise StopIteration()
 
@@ -75,9 +75,9 @@ class PaginatedCollection:
             if len(page_data) == 0:
                 raise StopIteration()
 
-        next_value = self._data[self._data_index]
-        self._data_index += 1
-        return next_value
+        rval = self._data[self._data_ind]
+        self._data_ind += 1
+        return rval
 
     def get_one(self):
         """Iterates over self and returns first value

--- a/labelbox/pagination.py
+++ b/labelbox/pagination.py
@@ -80,30 +80,30 @@ class PaginatedCollection:
         return next_value
 
     def get_one(self):
-      """Iterates over self and returns first value
-      This method is idempotent
-      """
-      for value in self:
-          return value
+        """Iterates over self and returns first value
+        This method is idempotent
+        """
+        for value in self:
+            return value
 
     def get_many(self, n: int):
-      """Iterates over self and returns first n results
-      This method is idempotent
+        """Iterates over self and returns first n results
+        This method is idempotent
 
-      Args:
-          n (int): Number of elements to retrieve
-      """
-      results = []
-      i = 0
+        Args:
+            n (int): Number of elements to retrieve
+        """
+        results = []
+        i = 0
 
-      for value in self:
-          if i >= n:
-            break
+        for value in self:
+            if i >= n:
+              break
 
-          results.append(value)
-          i += 1
+            results.append(value)
+            i += 1
 
-      return results
+        return results
 
 
 class _Pagination(ABC):

--- a/labelbox/pagination.py
+++ b/labelbox/pagination.py
@@ -98,7 +98,7 @@ class PaginatedCollection:
 
         for value in self:
             if i >= n:
-              break
+                break
 
             results.append(value)
             i += 1

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -21,6 +21,14 @@ def test_dataset(client, rand_gen):
     assert len(after) == len(before) + 1
     assert dataset in after
 
+    # confirm get_one returns first dataset
+    get_one_dataset = client.get_datasets().get_one()
+    assert get_one_dataset.uid == after[0].uid
+
+    # confirm get_many(1) returns first dataset
+    get_many_datasets = client.get_datasets().get_many(1)
+    assert get_many_datasets[0].uid == after[0].uid
+
     dataset = client.get_dataset(dataset.uid)
     assert dataset.name == name
 


### PR DESCRIPTION
Adding more convenience to users when they want to get a predefined number of results from the paginated collection.

old way:
```
data_rows = dataset.data_rows()
data_row = next(data_rows)
```

new way:

```
data_row = dataset.data_rows().get_one()
```


old way:
```
data_rows = dataset.data_rows()
first_ten = []
for data_row in data_rows:
    first_ten.append(data_row)
    if len(first_ten) >= 10:
        break
```

new way: 
```
data_rows = dataset.data_rows().get_many(10)
```


important note. These methods are idempotent. That means: 
1. They can be called as many times as wanted and the result will be the same. E.x. get_one will **always** return first one result. It is not equivalent to calling next().
2. get_many will **not** call API in case it already has needed amount of data. This way to safe resources and time.
