### PR TITLE
[CCV-1905][CCV-1906][CCV-1907] Pass media type when creating an ontology

### DIFF
--- a/labelbox/schema/media_type.py
+++ b/labelbox/schema/media_type.py
@@ -44,3 +44,9 @@ class MediaType(Enum):
             item for item in cls.__members__
             if item not in ["Unknown", "Unsupported"]
         ]
+
+
+def get_media_type_validation_error(media_type):
+    return TypeError(f"{media_type} is not a valid media type. Use"
+                     f" any of {MediaType.get_supported_members()}"
+                     " from MediaType. Example: MediaType.Image.")


### PR DESCRIPTION
[CVV-1905](https://labelbox.atlassian.net/browse/CCV-1905)
[CVV-1906](https://labelbox.atlassian.net/browse/CCV-1906)
[CVV-1907](https://labelbox.atlassian.net/browse/CCV-1907)
-----

<!-- Required sections -->

Description
-----

Added optional argument "media_type" to two functions:
- create_ontology_from_feature_schemas
- create_ontology

Risk Level: Medium
-------

How to test
-----

### With the [FF](https://app.launchdarkly.com/default/test/features/ontology-media-type/targeting) on

- [x] it's possible to use create_ontology without passing a media type

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

ontology_name = "sdk-ontology-2"
feature_schema_cat_normalized = {
    'tool': 'polygon',
    'name': 'cat',
    'color': 'black'
}

ontology_normalized_json = {
    "tools": [feature_schema_cat_normalized],
    "classifications": []
}
ontology = client.create_ontology(
    name=ontology_name,
    normalized=ontology_normalized_json,
)
```

- [x] it's possible to use create_ontology by passing None as a media type

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

ontology_name = "sdk-ontology-2"
feature_schema_cat_normalized = {
    'tool': 'polygon',
    'name': 'cat',
    'color': 'black'
}

ontology_normalized_json = {
    "tools": [feature_schema_cat_normalized],
    "classifications": []
}
ontology = client.create_ontology(
    name=ontology_name,
    normalized=ontology_normalized_json,
    media_type=None
)
```

- [x] it's possible to use create_ontology and pass a media type

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

ontology_name = "sdk-ontology-2"
feature_schema_cat_normalized = {
    'tool': 'polygon',
    'name': 'cat',
    'color': 'black'
}

ontology_normalized_json = {
    "tools": [feature_schema_cat_normalized],
    "classifications": []
}
ontology = client.create_ontology(
    name=ontology_name,
    normalized=ontology_normalized_json,
    media_type=MediaType.Image
)
```

- [x] returns an error when an ontology created using create_ontology does not support all provided tools 

(polygon tool is not supported in the pdf editor)
```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

ontology_name = "sdk-ontology-2"
feature_schema_cat_normalized = {
    'tool': 'polygon',
    'name': 'cat',
    'color': 'black'
}

ontology_normalized_json = {
    "tools": [feature_schema_cat_normalized],
    "classifications": []
}
ontology = client.create_ontology(
    name=ontology_name,
    normalized=ontology_normalized_json,
    media_type=MediaType.Pdf
)
```

![image](https://user-images.githubusercontent.com/15057234/206249872-719f6e22-952e-4b5a-9ec0-c104b65bb511.png)

- [x] it's possible to use create_ontology_from_feature_schemas without passing a media type

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

feature1 = client.get_feature_schema("clbcxwmo6000ig9vu2d256i22")
feature2 = client.get_feature_schema("clbca4xmk001v67vu7nq38xcy")

ontology = client.create_ontology_from_feature_schemas("Ontology from existing features 1", [feature1.uid, feature2.uid])
```

- [x] it's possible to use create_ontology_from_feature_schemas by passing None as a media type

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

feature1 = client.get_feature_schema("clbcxwmo6000ig9vu2d256i22")
feature2 = client.get_feature_schema("clbca4xmk001v67vu7nq38xcy")

ontology = client.create_ontology_from_feature_schemas("Ontology from existing features 1", [feature1.uid, feature2.uid], None)
```

- [x] it's possible to use create_ontology_from_feature_schemas and pass a media type

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

feature1 = client.get_feature_schema("clbcxwmo6000ig9vu2d256i22")
feature2 = client.get_feature_schema("clbca4xmk001v67vu7nq38xcy")

ontology = client.create_ontology_from_feature_schemas("Ontology from existing features 1", [feature1.uid, feature2.uid], MediaType.Image)
```

![image](https://user-images.githubusercontent.com/15057234/206251979-fe069c24-595d-4645-817c-e8cebb81d07b.png)

- [x] returns an error when an ontology created using create_ontology_from_feature_schemas does not support all provided tools 

(polygon tool is not supported in the pdf editor)
```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

feature1 = client.get_feature_schema("clbcxwmo6000ig9vu2d256i22")
feature2 = client.get_feature_schema("clbca4xmk001v67vu7nq38xcy")

ontology = client.create_ontology_from_feature_schemas("Ontology from existing features 1", [feature1.uid, feature2.uid], MediaType.Pdf)
```

![image](https://user-images.githubusercontent.com/15057234/206252242-9291a0d1-c5f5-4fc0-b18b-1c09f08bd539.png)

- [x] it's possible to assign an ontology with a `image` media type to a project with `image` allowed media type

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

project = client.create_project(
    name="my-test-project",
    description="a description",
    media_type=MediaType.Image
)
ontology = client.get_ontology("clbca3y6y001s67vu2lin3nws")
project.setup_editor(ontology)
```

- [x] it's possible to assign an ontology with a `null` media type to a project with `image` allowed media type

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

project = client.create_project(
    name="my-test-project",
    description="a description",
    media_type=MediaType.Image
)
ontology = client.get_ontology("clbcv20ed000aqvvualko6k2k")
project.setup_editor(ontology)
```

- [x] it's not possible to assign an ontology with a `video` media type to a project with `image` allowed media type

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

project = client.create_project(
    name="my-test-project",
    description="a description",
    media_type=MediaType.Image
)
ontology = client.get_ontology("clbcdx402000e07vu9d5pbggl")
project.setup_editor(ontology)
```

![image](https://user-images.githubusercontent.com/15057234/206253736-6c6a332f-3df3-4b07-8234-93d1b0e2dfcd.png)

### With the [FF](https://app.launchdarkly.com/default/test/features/ontology-media-type/targeting) off

- [x] it's possible to use create_ontology without passing a media type

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

ontology_name = "sdk-ontology-1"
feature_schema_cat_normalized = {
    'tool': 'polygon',
    'name': 'cat',
    'color': 'black'
}

ontology_normalized_json = {
    "tools": [feature_schema_cat_normalized],
    "classifications": []
}
ontology = client.create_ontology(
    name=ontology_name,
    normalized=ontology_normalized_json,
)
```

- [x] create_ontogy does not set passed media type in DB (default is null)

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

ontology_name = "sdk-ontology-2"
feature_schema_cat_normalized = {
    'tool': 'polygon',
    'name': 'cat',
    'color': 'black'
}

ontology_normalized_json = {
    "tools": [feature_schema_cat_normalized],
    "classifications": []
}
ontology = client.create_ontology(
    name=ontology_name,
    normalized=ontology_normalized_json,
    media_type=MediaType.Image
)
```

![image](https://user-images.githubusercontent.com/15057234/206246959-5ab353f7-8a68-482f-9cae-85796d4b2e0e.png)


- [x] it's possible to use create_ontology_from_feature_schemas without passing a media type

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

feature1 = client.get_feature_schema("clbcxwmo6000ig9vu2d256i22")
feature2 = client.get_feature_schema("clbca4xmk001v67vu7nq38xcy")

ontology = client.create_ontology_from_feature_schemas("Ontology from existing features", [feature1.uid, feature2.uid])
```

- [x] create_ontology_from_feature_schemas does not set passed media type in DB (default is null)

```python
from labelbox import OntologyBuilder, Tool, Classification, Option, Client, MediaType

client = Client(api_key="", endpoint="http://localhost:8080/graphql")

feature1 = client.get_feature_schema("clbcxwmo6000ig9vu2d256i22")
feature2 = client.get_feature_schema("clbca4xmk001v67vu7nq38xcy")

ontology = client.create_ontology_from_feature_schemas("Ontology from existing features 1", [feature1.uid, feature2.uid], MediaType.Image)
```

![image](https://user-images.githubusercontent.com/15057234/206248051-4f16de73-8aa6-4eef-a628-df0a1b940609.png)


Checklist
-----

#### PR owner

- [x] I have assigned an adequate number of reviewers to review this PR.
- [x] Every reviewer has a checklist.

#### Reviewer @Labelbox/active-learning-sdk 

- [ ] I have tested this PR, by following the "How to test" section.
- [ ] Changes made in this PR are satisfying the ticket's acceptance criteria.

#### Reviewer @Tim-Kerr 

- [x] I have tested this PR, by following the "How to test" section.
- [x] Changes made in this PR are satisfying the ticket's acceptance criteria.

<!-- Optional sections - uncomment what's needed -->

<!--
Visual change
-----

#### Before

<ADD_FILES>

#### After

<ADD_FILES>
-->

<!--
Heads Up
-----

<ADD_THINGS_TO_KEEP_IN_MIND_WHILE_REVIEWING>
-->

<!--
Authorization Considerations
-----

<DESCRIBE_AUTHORIZATION_CHANGES>
-->

<!--
Testing changes to the API service
-----

Test Result: <PASSED/FAILED>
-->

<!--
Automated tests
-----

<DESCRIBE_AUTOMATED_TESTS>
-->

<!--
SDK
-----

<DESCRIBE_CHANGES_TO_SDK>
-->

<!--
Guide

------------------------------------------------------------------------------------------------------------------------
Description
------------------------------------------------------------------------------------------------------------------------

Describe what changes have been implemented, and the reasoning behind them, to achieve
the acceptance criteria described in the ticket. Don't rewrite the ticket's description. 
Describe your motivation for the changes you've made. If there is anything you would like your reviewers to 
focus on, please remember to include it in this section.

For example, if you needed to add a new library, tell us why you made this decision. Why was it 
necessary to add it? Could we possibly create our implementation of this library? Is it well-tested? 
What license does it have? Is it actively maintained?

A good practice is to record a Loom video, in which you can describe your changes, show how to test your PR, and
explain the reasoning behind your decisions. Additionally, to provide more information, you can create diagrams using Mermaid
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams

------------------------------------------------------------------------------------------------------------------------
Risk Level
------------------------------------------------------------------------------------------------------------------------

Rubric:
- Low (aesthetic changes, gated novel features)
- Medium (everything else)
- High (impacts critical functionality, database migrations, potentially blocks system availability)

Generally speaking, higher-risk changes should have more reviewers.

------------------------------------------------------------------------------------------------------------------------
How to test
------------------------------------------------------------------------------------------------------------------------

When specifying test cases keep in mind the ticket's acceptance criteria.

When adding instructions on how to test your changes, please remember that your reviewer may have much less
context than you or may see this part of the application for the first time. Describe steps to follow in a form 
of a list. Add checkboxes that can be used by your reviewers to track the testing process. You may even add 
Loom/gifs/screenshots which may help. Here is an example of such a test case.

#### Title

1. Step_1
2. Step_2
3. Step_3
- [ ] Expected_result

<LOOM/GIF_SHOWING_THE_PROCESS>

If there are no instructions

- [ ] Test_case_1

If you have multiple reviewers, you can add a checkbox for all of them.

#### Title 1
1. Step_1
2. Step_2
3. Step_3
4. Expected_result

#### Title 2
1. Step_1
2. Expected_result

Lukasz:
- [ ] Title 1
- [ ] Title 2
- [ ] Title 3

Stan:
- [ ] Title 1
- [ ] Title 2
- [ ] Title 3

If you need some data for your testing scenarios, please use our Developer Testing Assets, which you can find 
here https://labelbox.atlassian.net/wiki/spaces/ENG/pages/1797324850/Developer+Testing+Assets

Ideally, you should be able to write automatic tests for test cases described in this section.

------------------------------------------------------------------------------------------------------------------------
Checklist
------------------------------------------------------------------------------------------------------------------------

"I have assigned an adequate number of reviewers to review this PR."

If it's a small change, one reviewer may be enough. If these changes have a high risk, are related to multiple editors, 
or are touching critical parts of the application, assign multiple reviewers. You should feel comfortable pressing 
the merge button, knowing that the PR has been well-tested.

"Every reviewer has a checklist." 

Copy the "Reviewer" checklist for every reviewer you want to test your changes.

------------------------------------------------------------------------------------------------------------------------
Visual changes
------------------------------------------------------------------------------------------------------------------------
 
Use gifs/Loom/screenshots to show changes. Feel free to modify this section, if you find a different, 
easier-to-understand way of presenting these changes. 

If this section is not applicable, let's say you are updating a library, there is no need to add 
the "Visual change" section.

------------------------------------------------------------------------------------------------------------------------
Heads Up
------------------------------------------------------------------------------------------------------------------------

Things to keep in mind while reviewing or steps necessary before deploying changes.

------------------------------------------------------------------------------------------------------------------------
Authorization Considerations
------------------------------------------------------------------------------------------------------------------------

Enumerate any changes in access. Explain any: 
- additions (e.g. new required permission for a resolver)
- omissions (e.g. new view that doesn't require any permissions)
- removals (e.g. making an action that used to be restricted available to additional users/groups)

------------------------------------------------------------------------------------------------------------------------
Testing changes to the API service
------------------------------------------------------------------------------------------------------------------------

Every change to the API service should be paired with a successful local run of the e2e test suite in the python SDK, 
to ensure no breaking changes were made. Automated builds for the API service currently do not include python SDK tests.

Please follow [How To: Test Local Changes using Python SDK](https://labelbox.atlassian.net/wiki/spaces/AIENG/pages/1946910734/How+To+Test+Local+Changes+using+Python+SDK) to run our Python SDK test suite 
against your local api service, and confirm a passing run below.

------------------------------------------------------------------------------------------------------------------------
Automated tests
------------------------------------------------------------------------------------------------------------------------

Were unit tests written for this code?

Briefly describe the automated tests you wrote to verify the correctness of your code
* Test 1
* Test 2

Additionally, describe the edge cases you tested manually
* Edge case 1
* Edge case 2

------------------------------------------------------------------------------------------------------------------------
SDK
------------------------------------------------------------------------------------------------------------------------

How will these changes impact the SDK? Were any private queries added? Is there a plan to eventually make 
these public? If not, why?
-->