### PR TITLE
Update labelbox import and coco_utils.py URL

### DIFF
--- a/examples/integrations/detectron2/coco_object.ipynb
+++ b/examples/integrations/detectron2/coco_object.ipynb
@@ -97,7 +97,7 @@
     "                torchvision \\\n",
     "                git+https://github.com/cocodataset/panopticapi.git \\\n",
     "                'git+https://github.com/facebookresearch/detectron2.git'           \n",
-    "!pip install -q \"git+https://github.com/Labelbox/labelbox-python@ms/coco#egg=labelbox[data]\""
+    "!pip install -q \"labelbox[data]\""
    ]
   },
   {
@@ -156,7 +156,7 @@
     ")\n",
     "\n",
     "with open('./coco_utils.py', 'w' ) as file:\n",
-    "    helper = requests.get(\"https://raw.githubusercontent.com/Labelbox/labelbox-python/ms/coco/examples/integrations/detectron2/coco_utils.py\").text\n",
+    "    helper = requests.get(\"https://raw.githubusercontent.com/Labelbox/labelbox-python/develop/examples/integrations/detectron2/coco_utils.py\").text\n",
     "    file.write(helper)\n",
     "from coco_utils import visualize_coco_examples, visualize_object_inferences, partition_coco    \n"
    ]


### PR DESCRIPTION
### Changes:

1. Change how the labelbox module is imported
2. 
From:
```!pip install -q "git+https://github.com/Labelbox/labelbox-python@ms/coco#egg=labelbox[data]"```
To:
```!pip install -q "labelbox[data]"```

3. Update the URL for `coco_utils.py`
4. 
From:
```https://raw.githubusercontent.com/Labelbox/labelbox-python/ms/coco/examples/integrations/detectron2/coco_utils.py```
To:
```https://raw.githubusercontent.com/Labelbox/labelbox-python/develop/examples/integrations/detectron2/coco_utils.py"```