### PR TITLE
[AL-0] Better error handling for label creation during test

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -337,19 +337,13 @@ def configured_project_with_label(client, rand_gen, image_url, project, dataset,
         }
     }]
 
-    def create_label():
-        """ Ad-hoc function to create a LabelImport
+    upload_task = LabelImport.create_from_objects(
+        client, project.uid, f'label-import-{uuid.uuid4()}', predictions)
+    upload_task.wait_until_done(sleep_time_seconds=5)
+    assert upload_task.state == AnnotationImportState.FINISHED, "Label Import failed"
 
-        Creates a LabelImport task which will create a label
-        """
-        upload_task = LabelImport.create_from_objects(
-            client, project.uid, f'label-import-{uuid.uuid4()}', predictions)
-        upload_task.wait_until_done(sleep_time_seconds=5)
-        assert upload_task.state == AnnotationImportState.FINISHED
-
-    project.create_label = create_label
-    project.create_label()
-    label = next(project.labels())
+    label = project.labels().get_one()
+    assert label is not None, "Cannot fetch created label"
     yield [project, dataset, datarow, label]
 
     for label in project.labels():

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -337,11 +337,17 @@ def configured_project_with_label(client, rand_gen, image_url, project, dataset,
         }
     }]
 
-    upload_task = LabelImport.create_from_objects(
-        client, project.uid, f'label-import-{uuid.uuid4()}', predictions)
-    upload_task.wait_until_done(sleep_time_seconds=5)
-    assert upload_task.state == AnnotationImportState.FINISHED, "Label Import failed"
+    def create_label():
+        """ Ad-hoc function to create a LabelImport
+        Creates a LabelImport task which will create a label
+        """
+        upload_task = LabelImport.create_from_objects(
+            client, project.uid, f'label-import-{uuid.uuid4()}', predictions)
+        upload_task.wait_until_done(sleep_time_seconds=5)
+        assert upload_task.state == AnnotationImportState.FINISHED, "Label Import failed"
 
+    project.create_label = create_label
+    project.create_label()
     label = project.labels().get_one()
     assert label is not None, "Cannot fetch created label"
     yield [project, dataset, datarow, label]

--- a/tests/integration/test_data_row_media_attributes.py
+++ b/tests/integration/test_data_row_media_attributes.py
@@ -5,8 +5,8 @@ def test_export_empty_media_attributes(configured_project_with_label):
     project, _, _, _ = configured_project_with_label
     # Wait for exporter to retrieve latest labels
     sleep(10)
-    labels = project.label_generator().as_list()
+    labels = list(project.label_generator())
     assert len(
         labels
-    ) == 1, "Labels could not be fetched via `project.label_generator()`"
+    ) == 1, "Label export job unexpectedly returned an empty result set`"
     assert labels[0].data.media_attributes == {}

--- a/tests/integration/test_data_row_media_attributes.py
+++ b/tests/integration/test_data_row_media_attributes.py
@@ -5,6 +5,8 @@ def test_export_empty_media_attributes(configured_project_with_label):
     project, _, _, _ = configured_project_with_label
     # Wait for exporter to retrieve latest labels
     sleep(10)
-    labels = project.label_generator()
-    label = next(labels)
-    assert label.data.media_attributes == {}
+    labels = project.label_generator().as_list()
+    assert len(
+        labels
+    ) == 1, "Labels could not be fetched via `project.label_generator()`"
+    assert labels[0].data.media_attributes == {}


### PR DESCRIPTION
Fixed two places where we were using a Generator to verify existence of the label, which was resulting in an error message that was hard to decipher 