### PR TITLE
fix test case by providing the missing media_type field

### DIFF
--- a/tests/integration/test_ontology.py
+++ b/tests/integration/test_ontology.py
@@ -1,6 +1,6 @@
 import pytest
 
-from labelbox import OntologyBuilder
+from labelbox import OntologyBuilder, MediaType
 from labelbox.orm.model import Entity
 import json
 import time
@@ -62,7 +62,10 @@ def test_ontology_create_read(client, rand_gen):
     }
     feature_schema = client.create_feature_schema(feature_schema_cat_normalized)
     created_ontology = client.create_ontology_from_feature_schemas(
-        name=ontology_name, feature_schema_ids=[feature_schema.uid])
+        name=ontology_name,
+        feature_schema_ids=[feature_schema.uid],
+        media_type=MediaType.Image
+    )
     tool_normalized = created_ontology.normalized['tools'][0]
     for k, v in feature_schema_cat_normalized.items():
         assert tool_normalized[k] == v

--- a/tests/integration/test_ontology.py
+++ b/tests/integration/test_ontology.py
@@ -41,8 +41,8 @@ def test_feature_schema_create_read(client, rand_gen):
 
     time.sleep(3)  # Slight delay for searching
     queried_feature_schemas = list(client.get_feature_schemas(name))
-    assert [feature_schema.name for feature_schema in queried_feature_schemas
-           ] == [name]
+    assert [feature_schema.name
+            for feature_schema in queried_feature_schemas] == [name]
     queried_feature_schema = queried_feature_schemas[0]
 
     for attr in Entity.FeatureSchema.fields():
@@ -60,12 +60,12 @@ def test_ontology_create_read(client, rand_gen):
         'color': 'black',
         'classifications': [],
     }
-    feature_schema = client.create_feature_schema(feature_schema_cat_normalized)
+    feature_schema = client.create_feature_schema(
+        feature_schema_cat_normalized)
     created_ontology = client.create_ontology_from_feature_schemas(
         name=ontology_name,
         feature_schema_ids=[feature_schema.uid],
-        media_type=MediaType.Image
-    )
+        media_type=MediaType.Image)
     tool_normalized = created_ontology.normalized['tools'][0]
     for k, v in feature_schema_cat_normalized.items():
         assert tool_normalized[k] == v
@@ -81,7 +81,8 @@ def test_ontology_create_read(client, rand_gen):
 
     time.sleep(3)  # Slight delay for searching
     queried_ontologies = list(client.get_ontologies(ontology_name))
-    assert [ontology.name for ontology in queried_ontologies] == [ontology_name]
+    assert [ontology.name
+            for ontology in queried_ontologies] == [ontology_name]
     queried_ontology = queried_ontologies[0]
     for attr in Entity.Ontology.fields():
         assert _get_attr_stringify_json(created_ontology,

--- a/tests/integration/test_ontology.py
+++ b/tests/integration/test_ontology.py
@@ -41,8 +41,8 @@ def test_feature_schema_create_read(client, rand_gen):
 
     time.sleep(3)  # Slight delay for searching
     queried_feature_schemas = list(client.get_feature_schemas(name))
-    assert [feature_schema.name
-            for feature_schema in queried_feature_schemas] == [name]
+    assert [feature_schema.name for feature_schema in queried_feature_schemas
+           ] == [name]
     queried_feature_schema = queried_feature_schemas[0]
 
     for attr in Entity.FeatureSchema.fields():
@@ -60,8 +60,7 @@ def test_ontology_create_read(client, rand_gen):
         'color': 'black',
         'classifications': [],
     }
-    feature_schema = client.create_feature_schema(
-        feature_schema_cat_normalized)
+    feature_schema = client.create_feature_schema(feature_schema_cat_normalized)
     created_ontology = client.create_ontology_from_feature_schemas(
         name=ontology_name,
         feature_schema_ids=[feature_schema.uid],
@@ -81,8 +80,7 @@ def test_ontology_create_read(client, rand_gen):
 
     time.sleep(3)  # Slight delay for searching
     queried_ontologies = list(client.get_ontologies(ontology_name))
-    assert [ontology.name
-            for ontology in queried_ontologies] == [ontology_name]
+    assert [ontology.name for ontology in queried_ontologies] == [ontology_name]
     queried_ontology = queried_ontologies[0]
     for attr in Entity.Ontology.fields():
         assert _get_attr_stringify_json(created_ontology,

--- a/tests/integration/test_project_setup.py
+++ b/tests/integration/test_project_setup.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from labelbox import LabelingFrontend
+from labelbox import LabelingFrontend, MediaType
 from labelbox.exceptions import InvalidQueryError, ResourceConflict
 
 
@@ -53,7 +53,9 @@ def test_project_setup(project) -> None:
 
 def test_project_editor_setup(client, project, rand_gen):
     ontology_name = f"test_project_editor_setup_ontology_name-{rand_gen(str)}"
-    ontology = client.create_ontology(ontology_name, simple_ontology())
+    ontology = client.create_ontology(ontology_name,
+                                      simple_ontology(),
+                                      media_type=MediaType.Image)
     now = datetime.now().astimezone(timezone.utc)
     project.setup_editor(ontology)
     assert now - project.setup_complete <= timedelta(seconds=3)
@@ -71,7 +73,9 @@ def test_project_editor_setup(client, project, rand_gen):
 def test_project_editor_setup_cant_call_multiple_times(client, project,
                                                        rand_gen):
     ontology_name = f"test_project_editor_setup_ontology_name-{rand_gen(str)}"
-    ontology = client.create_ontology(ontology_name, simple_ontology())
+    ontology = client.create_ontology(ontology_name,
+                                      simple_ontology(),
+                                      media_type=MediaType.Image)
     project.setup_editor(ontology)
     with pytest.raises(ResourceConflict):
         project.setup_editor(ontology)


### PR DESCRIPTION
https://labelbox.slack.com/archives/C040H094D4Y/p1673291524133319?thread_ts=1673288175.540119&cid=C040H094D4Y

the flag `ontology-media-type` was turned on on 6th January for `internalenterprise` and since then one SDK test case `test_ontology_create_read` had been failing because the `media_type` field was not provided when creating an ontology and the by enabling the flag it became a required field

By providing the missing field, the test case passes. Proof:

![image](https://user-images.githubusercontent.com/97034214/211390217-57eab55b-91aa-49af-bf6d-3c53ae3c6485.png)
