### PR TITLE
Update colab links

### DIFF
--- a/examples/annotation_import/image.ipynb
+++ b/examples/annotation_import/image.ipynb
@@ -20,7 +20,7 @@
       },
       "source": [
         "<td>\n",
-        "<a href=\"https://colab.research.google.com/github/Labelbox/labelbox-python/blob/develop/examples/annotation_import/image_annotation_import.ipynb\" target=\"_blank\"><img\n",
+        "<a href=\"https://colab.research.google.com/github/Labelbox/labelbox-python/blob/develop/examples/annotation_import/image.ipynb\" target=\"_blank\"><img\n",
         "src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>\n",
         "</td>\n",
         "\n",
@@ -28,7 +28,7 @@
         "\n",
         "\n",
         "<td>\n",
-        "<a href=\"https://github.com/Labelbox/labelbox-python/tree/develop/examples/annotation_import/image_annotation_import.ipynb\" target=\"_blank\"><img\n",
+        "<a href=\"https://github.com/Labelbox/labelbox-python/tree/develop/examples/annotation_import/image.ipynb\" target=\"_blank\"><img\n",
         "src=\"https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white\" alt=\"GitHub\"></a>\n",
         "</td>"
       ]

--- a/examples/annotation_import/image.ipynb
+++ b/examples/annotation_import/image.ipynb
@@ -810,13 +810,6 @@
         "    ]\n",
         ")\n",
         "\n",
-        "# Create urls to mask data for upload\n",
-        "def signing_function(obj_bytes: bytes) -> str:\n",
-        "    url = client.upload_data(content=obj_bytes, sign=True)\n",
-        "    return url\n",
-        "\n",
-        "label.add_url_to_masks(signing_function)\n",
-        "\n",
         "# Convert our label from a Labelbox class object to the underlying NDJSON format required for upload \n",
         "label_ndjson = list(NDJsonConverter.serialize([label]))"
       ],


### PR DESCRIPTION
Old link was pointing to an image_annotation_import.ipynb instead of image.ipynb