### PR TITLE
Fix wording for assign_global_keys_to_data_rows error message

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -1116,7 +1116,9 @@ class Client:
                 errors.extend(
                     _format_failed_rows(
                         rows=res['invalidGlobalKeyAssignments'],
-                        error_msg="Invalid Data Row or invalid global key"))
+                        error_msg=
+                        "Invalid assignment. Either DataRow does not exist, or globalKey is invalid"
+                    ))
                 errors.extend(
                     _format_failed_rows(rows=res['accessDeniedAssignments'],
                                         error_msg="Access denied to Data Row"))

--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -1114,8 +1114,9 @@ class Client:
                                             sanitized=False))
                 # Failed assignments
                 errors.extend(
-                    _format_failed_rows(rows=res['invalidGlobalKeyAssignments'],
-                                        error_msg="Invalid global key"))
+                    _format_failed_rows(
+                        rows=res['invalidGlobalKeyAssignments'],
+                        error_msg="Invalid Data Row or invalid global key"))
                 errors.extend(
                     _format_failed_rows(rows=res['accessDeniedAssignments'],
                                         error_msg="Access denied to Data Row"))
@@ -1270,13 +1271,13 @@ class Client:
             'Errors' contains a list of global_keys correspond to the data rows that could not be
             modified, accessed by the user, or not found.
         Examples:
-            >>> job_result = client.get_data_row_ids_for_global_keys(["key1","key2"])
+            >>> job_result = client.clear_global_keys(["key1","key2","notfoundkey"])
             >>> print(job_result['status'])
             Partial Success
             >>> print(job_result['results'])
-            ['cl7tv9wry00hlka6gai588ozv', 'cl7tv9wxg00hpka6gf8sh81bj']
+            ['key1', 'key2']
             >>> print(job_result['errors'])
-            [{'global_key': 'asdf', 'error': 'Data Row not found'}]
+            [{'global_key': 'notfoundkey', 'error': 'Failed to find data row matching provided global key'}]
         """
 
         def _format_failed_rows(rows: List[str],

--- a/tests/integration/test_global_keys.py
+++ b/tests/integration/test_global_keys.py
@@ -112,7 +112,8 @@ def test_long_global_key_validation(client, dataset, image_url):
     assert res['results'][0]['global_key'] == gk_1
     assert res['errors'][0]['data_row_id'] == dr_2.uid
     assert res['errors'][0]['global_key'] == gk_2
-    assert res['errors'][0]['error'] == 'Invalid Data Row or invalid global key'
+    assert res['errors'][0][
+        'error'] == 'Invalid assignment. Either DataRow does not exist, or globalKey is invalid'
 
 
 def test_global_key_with_whitespaces_validation(client, dataset, image_url):

--- a/tests/integration/test_global_keys.py
+++ b/tests/integration/test_global_keys.py
@@ -75,7 +75,8 @@ def test_assign_same_global_keys_to_data_rows(client, dataset, image_url):
     assert len(res['errors']) == 1
     assert res['errors'][0]['data_row_id'] == dr_2.uid
     assert res['errors'][0]['global_key'] == gk_1
-    assert res['errors'][0]['error'] == "Invalid Data Row or invalid global key"
+    assert res['errors'][0][
+        'error'] == "Invalid assignment. Either DataRow does not exist, or globalKey is invalid"
 
 
 def test_global_key_sanitization(dataset, image_url):
@@ -144,9 +145,9 @@ def test_global_key_with_whitespaces_validation(client, dataset, image_url):
     assert assign_errors_ids == set([dr_1.uid, dr_2.uid, dr_3.uid])
     assert assign_errors_gks == set([gk_1, gk_2, gk_3])
     assert assign_errors_msgs == set([
-        'Invalid Data Row or invalid global key',
-        'Invalid Data Row or invalid global key',
-        'Invalid Data Row or invalid global key'
+        'Invalid assignment. Either DataRow does not exist, or globalKey is invalid',
+        'Invalid assignment. Either DataRow does not exist, or globalKey is invalid',
+        'Invalid assignment. Either DataRow does not exist, or globalKey is invalid'
     ])
 
 

--- a/tests/integration/test_global_keys.py
+++ b/tests/integration/test_global_keys.py
@@ -75,7 +75,7 @@ def test_assign_same_global_keys_to_data_rows(client, dataset, image_url):
     assert len(res['errors']) == 1
     assert res['errors'][0]['data_row_id'] == dr_2.uid
     assert res['errors'][0]['global_key'] == gk_1
-    assert res['errors'][0]['error'] == "Invalid global key"
+    assert res['errors'][0]['error'] == "Invalid Data Row or invalid global key"
 
 
 def test_global_key_sanitization(dataset, image_url):
@@ -111,7 +111,7 @@ def test_long_global_key_validation(client, dataset, image_url):
     assert res['results'][0]['global_key'] == gk_1
     assert res['errors'][0]['data_row_id'] == dr_2.uid
     assert res['errors'][0]['global_key'] == gk_2
-    assert res['errors'][0]['error'] == 'Invalid global key'
+    assert res['errors'][0]['error'] == 'Invalid Data Row or invalid global key'
 
 
 def test_global_key_with_whitespaces_validation(client, dataset, image_url):
@@ -143,8 +143,11 @@ def test_global_key_with_whitespaces_validation(client, dataset, image_url):
     assign_errors_msgs = set([e['error'] for e in res['errors']])
     assert assign_errors_ids == set([dr_1.uid, dr_2.uid, dr_3.uid])
     assert assign_errors_gks == set([gk_1, gk_2, gk_3])
-    assert assign_errors_msgs == set(
-        ['Invalid global key', 'Invalid global key', 'Invalid global key'])
+    assert assign_errors_msgs == set([
+        'Invalid Data Row or invalid global key',
+        'Invalid Data Row or invalid global key',
+        'Invalid Data Row or invalid global key'
+    ])
 
 
 @pytest.mark.skip(reason='get_data_rows_for_global_keys not included in '


### PR DESCRIPTION
As part of https://github.com/Labelbox/intelligence/pull/12986/files PR, for assign function, if incoming DataRow doesn't exist, or is not part of user's org, or is deleted, it gets returned in invalidDataRowsGlobalKeys bucket, so enhancing the error message for that