### PR TITLE
[AL-4858][AL-4860] Reduce imports and hide NDJsonConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+# Version 3.38.0 (2023-xx-xx)
+
+### Added
+* All imports are available via `import labelbox as lb` and `import labelbox.types as lb_types`.
+
+## Changed
+* `LabelImport.create_from_objects()`, `MALPredictionImport.create_from_objects()`, `MEAPredictionImport.create_from_objects()`, `Project.upload_annotations()`, `ModelRun.add_predictions()` now support Python Types for annotations.
 
 # Version 3.37.0 (2023-02-08)
 ## Added

--- a/labelbox/__init__.py
+++ b/labelbox/__init__.py
@@ -20,7 +20,7 @@ from labelbox.schema.webhook import Webhook
 from labelbox.schema.ontology import Ontology, OntologyBuilder, Classification, Option, Tool, FeatureSchema
 from labelbox.schema.role import Role, ProjectRole
 from labelbox.schema.invite import Invite, InviteLimit
-from labelbox.schema.data_row_metadata import DataRowMetadataOntology
+from labelbox.schema.data_row_metadata import DataRowMetadataOntology, DataRowMetadataField, DataRowMetadata, DeleteDataRowMetadata
 from labelbox.schema.model_run import ModelRun, DataSplit
 from labelbox.schema.benchmark import Benchmark
 from labelbox.schema.iam_integration import IAMIntegration
@@ -28,3 +28,4 @@ from labelbox.schema.resource_tag import ResourceTag
 from labelbox.schema.project_resource_tag import ProjectResourceTag
 from labelbox.schema.media_type import MediaType
 from labelbox.schema.slice import Slice, CatalogSlice
+from labelbox.schema.queue_mode import QueueMode

--- a/labelbox/data/annotation_types/__init__.py
+++ b/labelbox/data/annotation_types/__init__.py
@@ -34,3 +34,9 @@ from .metrics import ConfusionMatrixMetric
 from .metrics import ConfusionMatrixAggregation
 from .metrics import ScalarMetricValue
 from .metrics import ConfusionMatrixMetricValue
+
+from .data.tiled_image import EPSG
+from .data.tiled_image import EPSGTransformer
+from .data.tiled_image import TiledBounds
+from .data.tiled_image import TiledImageData
+from .data.tiled_image import TileLayer

--- a/labelbox/data/annotation_types/collection.py
+++ b/labelbox/data/annotation_types/collection.py
@@ -298,4 +298,4 @@ class LabelGenerator(PrefetchGenerator):
         return self._process(value)
 
 
-LabelCollection = Union[LabelList, LabelGenerator]
+LabelCollection = Union[LabelList, LabelGenerator, Iterable[Label]]

--- a/labelbox/data/annotation_types/geometry/geometry.py
+++ b/labelbox/data/annotation_types/geometry/geometry.py
@@ -3,8 +3,9 @@ from abc import ABC, abstractmethod
 
 import geojson
 import numpy as np
-from shapely import geometry as geom
 from pydantic import BaseModel
+
+from shapely import geometry as geom
 
 
 class Geometry(BaseModel, ABC):

--- a/labelbox/data/annotation_types/geometry/line.py
+++ b/labelbox/data/annotation_types/geometry/line.py
@@ -4,6 +4,7 @@ import geojson
 import numpy as np
 import cv2
 from pydantic import validator
+
 from shapely.geometry import LineString as SLineString
 
 from .point import Point

--- a/labelbox/data/annotation_types/geometry/mask.py
+++ b/labelbox/data/annotation_types/geometry/mask.py
@@ -2,8 +2,9 @@ from typing import Callable, Optional, Tuple, Union, Dict, List
 
 import numpy as np
 from pydantic.class_validators import validator
-from shapely.geometry import MultiPolygon, Polygon
 import cv2
+
+from shapely.geometry import MultiPolygon, Polygon
 
 from ..data import MaskData
 from .geometry import Geometry

--- a/labelbox/data/annotation_types/geometry/polygon.py
+++ b/labelbox/data/annotation_types/geometry/polygon.py
@@ -4,6 +4,7 @@ import cv2
 import geojson
 import numpy as np
 from pydantic import validator
+
 from shapely.geometry import Polygon as SPolygon
 
 from .geometry import Geometry

--- a/labelbox/data/annotation_types/geometry/rectangle.py
+++ b/labelbox/data/annotation_types/geometry/rectangle.py
@@ -3,6 +3,7 @@ from typing import Optional, Union, Tuple
 import cv2
 import geojson
 import numpy as np
+
 from shapely.geometry import Polygon as SPolygon
 
 from .geometry import Geometry

--- a/labelbox/data/metrics/iou/calculation.py
+++ b/labelbox/data/metrics/iou/calculation.py
@@ -1,8 +1,8 @@
 from typing import List, Optional, Tuple, Union
 from itertools import product
 
-from shapely.geometry import Polygon
 import numpy as np
+from shapely.geometry import Polygon
 
 from ..group import get_feature_pairs, get_identifying_key, has_no_annotations, has_no_matching_annotations
 from ...annotation_types import (ObjectAnnotation, ClassificationAnnotation,

--- a/labelbox/schema/bulk_import_request.py
+++ b/labelbox/schema/bulk_import_request.py
@@ -21,9 +21,11 @@ from labelbox.orm import query
 from labelbox.orm.db_object import DbObject
 from labelbox.orm.model import Field, Relationship
 from labelbox.schema.enums import BulkImportRequestState
+from labelbox.schema.serialization import serialize_labels
 
 if TYPE_CHECKING:
     from labelbox import Project
+    from labelbox.types import Label
 
 NDJSON_MIME_TYPE = "application/x-ndjson"
 logger = logging.getLogger(__name__)
@@ -280,7 +282,8 @@ class BulkImportRequest(DbObject):
                             client,
                             project_id: str,
                             name: str,
-                            predictions: Iterable[Dict],
+                            predictions: Union[Iterable[Dict],
+                                               Iterable["Label"]],
                             validate=True) -> 'BulkImportRequest':
         """
         Creates a `BulkImportRequest` from an iterable of dictionaries.
@@ -314,11 +317,12 @@ class BulkImportRequest(DbObject):
             raise TypeError(
                 f"annotations must be in a form of Iterable. Found {type(predictions)}"
             )
+        ndjson_predictions = serialize_labels(predictions)
 
         if validate:
-            _validate_ndjson(predictions, client.get_project(project_id))
+            _validate_ndjson(ndjson_predictions, client.get_project(project_id))
 
-        data_str = ndjson.dumps(predictions)
+        data_str = ndjson.dumps(ndjson_predictions)
         if not data_str:
             raise ValueError('annotations cannot be empty')
 

--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -18,6 +18,7 @@ from labelbox.schema.user import User
 
 if TYPE_CHECKING:
     from labelbox import MEAPredictionImport
+    from labelbox.types import Label
 
 logger = logging.getLogger(__name__)
 
@@ -215,7 +216,7 @@ class ModelRun(DbObject):
     def add_predictions(
         self,
         name: str,
-        predictions: Union[str, Path, Iterable[Dict]],
+        predictions: Union[str, Path, Iterable[Dict], Iterable["Label"]],
     ) -> 'MEAPredictionImport':  # type: ignore
         """ Uploads predictions to a new Editor project.
         Args:

--- a/labelbox/schema/serialization.py
+++ b/labelbox/schema/serialization.py
@@ -1,0 +1,23 @@
+from typing import cast, Any, Dict, Generator, List, TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from labelbox.types import Label
+
+
+def serialize_labels(
+    objects: Union[List[Dict[str, Any]],
+                   List["Label"]]) -> List[Dict[str, Any]]:
+    """
+    Checks if objects are of type Labels and serializes labels for annotation import. Serialization depends the labelbox[data] package, therefore NDJsonConverter is only loaded if using `Label` objects instead of `dict` objects.
+    """
+    if len(objects) == 0:
+        return []
+
+    is_label_type = not isinstance(objects[0], Dict)
+    if is_label_type:
+        # If a Label object exists, labelbox[data] is already installed, so no error checking is needed.
+        from labelbox.data.serialization import NDJsonConverter
+        labels = cast(List["Label"], objects)
+        return list(NDJsonConverter.serialize(labels))
+
+    return cast(List[Dict[str, Any]], objects)

--- a/labelbox/types.py
+++ b/labelbox/types.py
@@ -1,0 +1,6 @@
+try:
+    from labelbox.data.annotation_types import *
+except ImportError:
+    raise ImportError(
+        "There are missing dependencies for `labelbox.types`, use `pip install labelbox[data] --upgrade` to install missing dependencies."
+    )

--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -442,10 +442,11 @@ def model_run_with_model_run_data_rows(client, configured_project,
 
 class AnnotationImportTestHelpers:
 
-    @staticmethod
-    def assert_file_content(url: str, predictions):
+    @classmethod
+    def assert_file_content(cls, url: str, predictions):
         response = requests.get(url)
-        assert response.text == ndjson.dumps(predictions)
+        predictions = cls._convert_to_plain_object(predictions)
+        assert ndjson.loads(response.text) == predictions
 
     @staticmethod
     def check_running_state(req, name, url=None):
@@ -455,6 +456,12 @@ class AnnotationImportTestHelpers:
         assert req.error_file_url is None
         assert req.status_file_url is None
         assert req.state == AnnotationImportState.RUNNING
+
+    @staticmethod
+    def _convert_to_plain_object(obj):
+        """Some Python objects e.g. tuples can't be compared with JSON serialized data, serialize to JSON and deserialize to get plain objects"""
+        json_str = ndjson.dumps(obj)
+        return ndjson.loads(json_str)
 
 
 @pytest.fixture

--- a/tests/integration/annotation_import/test_label_import.py
+++ b/tests/integration/annotation_import/test_label_import.py
@@ -2,6 +2,7 @@ import uuid
 import pytest
 
 from labelbox.schema.annotation_import import AnnotationImportState, LabelImport
+from labelbox.data.serialization import NDJsonConverter
 """
 - Here we only want to check that the uploads are calling the validation
 - Then with unit tests we can check the types of errors raised
@@ -35,6 +36,27 @@ def test_create_from_objects(client, configured_project, object_predictions,
     annotation_import_test_helpers.check_running_state(label_import, name)
     annotation_import_test_helpers.assert_file_content(
         label_import.input_file_url, object_predictions)
+
+
+def test_create_from_label_objects(client, configured_project,
+                                   object_predictions,
+                                   annotation_import_test_helpers):
+    """this test should check running state only to validate running, not completed"""
+    name = str(uuid.uuid4())
+
+    labels = list(NDJsonConverter.deserialize(object_predictions))
+
+    label_import = LabelImport.create_from_objects(
+        client=client,
+        project_id=configured_project.uid,
+        name=name,
+        labels=labels)
+
+    assert label_import.parent_id == configured_project.uid
+    annotation_import_test_helpers.check_running_state(label_import, name)
+    normalized_predictions = NDJsonConverter.serialize(labels)
+    annotation_import_test_helpers.assert_file_content(
+        label_import.input_file_url, normalized_predictions)
 
 
 #   TODO: add me when we add this ability


### PR DESCRIPTION
SDK objects can now be imported with:
```
import labelbox as lb
import labelbox.types as lb_types
```

* Update `__init__.py` file include imports used by notebooks but not in the root namespace.
* Create a types module that imports annotation types
* Update AnnotationImport and BulkImportRequest to serialize Python annotations.

Tested the dependency on labelbox[data] by uninstalling shapely and running a notebook that uses NDJson-based annotation import.

Notebooks will be updated in a subsequent PR, there have been a number of updates in `develop` since this PR was opened and a large number of conflicts. I'll redo the renaming instead of resolving conflicts.
