### PR TITLE
Preparing for 3.37.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# Version 3.37.0 (2023-xx-xx)
+# Version 3.37.0 (2023-02-08)
 ## Added
 * New `last_activity_start` param to `project.export_labels()` for filtering which labels are exported. See docstring for more on how this works. 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ project = 'Python SDK reference'
 copyright = '2021, Labelbox'
 author = 'Labelbox'
 
-release = '3.36.1'
+release = '3.37.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/labelbox/__init__.py
+++ b/labelbox/__init__.py
@@ -1,5 +1,5 @@
 name = "labelbox"
-__version__ = "3.36.1"
+__version__ = "3.37.0"
 
 from labelbox.client import Client
 from labelbox.schema.project import Project


### PR DESCRIPTION
Verified that there are no missing user-facing updates in the change log.