### PR TITLE
[AL-4046] [AL-4048] Bulk DataRow update and delete

### DIFF
--- a/labelbox_dev/data_row.py
+++ b/labelbox_dev/data_row.py
@@ -11,35 +11,29 @@ from labelbox_dev.pagination import IdentifierPaginator
 DATA_ROW_RESOURCE = "data-rows"
 
 
-class AttachmentsType(TypedDict):
+class AttachmentsInput(TypedDict):
     type: str
     value: str
     name: str
 
 
-class MetadataType(TypedDict):
+class MetadataInput(TypedDict):
     schema_id: str
     value: Any
 
 
-class CreateDataRowType(TypedDict):
+class CreateDataRowInput(TypedDict):
     id: Optional[str]
     global_key: Optional[str]
     external_id: Optional[str]
     row_data: str
-    attachments: List[AttachmentsType]
-    metadata: List[MetadataType]
+    attachments: List[AttachmentsInput]
+    metadata: List[MetadataInput]
     media_type: Optional[str]
 
 
-class UpdateDataRowsWithIdType(TypedDict):
-    id: str
-    global_key: Optional[str]
-    external_id: Optional[str]
-    row_data: Optional[str]
-
-
-class UpdateDataRowType(TypedDict):
+class UpdateDataRowInput(TypedDict):
+    id: Optional[str]
     global_key: Optional[str]
     external_id: Optional[str]
     row_data: Optional[str]
@@ -67,7 +61,7 @@ class DataRow(Entity):
 
         return self
 
-    def update(self, data_row_update: UpdateDataRowType) -> "DataRow":
+    def update(self, data_row_update: UpdateDataRowInput) -> "DataRow":
         data_row_json = Session.patch_request(f"{DATA_ROW_RESOURCE}/{self.id}",
                                               json=data_row_update)
         return self.from_json(data_row_json)
@@ -97,7 +91,7 @@ class DataRow(Entity):
         return data_rows
 
     @staticmethod
-    def create_one(dataset_id, data_row: CreateDataRowType):
+    def create_one(dataset_id, data_row: CreateDataRowInput):
         data_row = DataRow._format_data_rows([data_row])[0]
         body = {'dataset_id': dataset_id, 'data_row': data_row}
         data_row_json = Session.post_request(f"{DATA_ROW_RESOURCE}", json=body)
@@ -105,7 +99,7 @@ class DataRow(Entity):
 
     @staticmethod
     def create(dataset_id,
-               data_rows: List[CreateDataRowType],
+               data_rows: List[CreateDataRowInput],
                run_async: bool = False):
         data_rows = DataRow._format_data_rows(data_rows)
 
@@ -192,8 +186,8 @@ class DataRow(Entity):
                                    identifiers_key='global_keys')
 
     @staticmethod
-    def update_many(data_rows: List[UpdateDataRowsWithIdType],
-                    run_async: bool = False):
+    def update_many(data_rows: List[UpdateDataRowInput],
+                    run_async: bool = False) -> UpdateDataRowsTask:
         for data_row in data_rows:
             if 'row_data' in data_row:
                 data_row = DataRow._format_data_rows([data_row])[0]
@@ -218,7 +212,7 @@ class DataRow(Entity):
     @staticmethod
     def delete_many(ids: Optional[List[str]] = None,
                     global_keys: Optional[List[str]] = None,
-                    run_async: bool = False):
+                    run_async: bool = False) -> DeleteDataRowsTask:
         body = {'run_async': run_async}
         if ids:
             body.update({'ids': ids})

--- a/labelbox_dev/data_row.py
+++ b/labelbox_dev/data_row.py
@@ -84,11 +84,21 @@ class DataRow(Entity):
         return data_rows
 
     @staticmethod
-    def _check_sync_request_limits(request_name: str, request_count):
+    def _check_sync_request_limits(request_name, request_count):
         if request_count > MAX_SYNCHRONOUS_DATA_ROW_REQUEST:
             raise LabelboxError(
                 f"Request exceeds {MAX_SYNCHRONOUS_DATA_ROW_REQUEST} DataRows. Please use `DataRow.{request_name}_async()` instead"
             )
+
+    @staticmethod
+    def _parse_task(request_name, task_json):
+        task_id = task_json.get(
+            'taskId')  # TODO: change to snake_case from backend
+        if task_id is None:
+            raise LabelboxError(
+                f"Failed to retrieve task information for `{request_name}` async operation"
+            )
+        return task_id
 
     @staticmethod
     def create_async(dataset_id,
@@ -101,12 +111,8 @@ class DataRow(Entity):
 
         task_json = Session.post_request(f"{DATA_ROW_RESOURCE}/create-async",
                                          json=body)
-        task_id = task_json.get(
-            'taskId')  # TODO: change to snake_case from backend
-        if task_id is None:
-            raise LabelboxError(
-                f"Failed to retrieve task information for `data_row.create()` async operation"
-            )
+        task_id = DataRow._parse_task('DataRow.create_async()', task_json)
+
         return CreateDataRowsTask.get_by_id(task_id)
 
     @staticmethod
@@ -143,12 +149,7 @@ class DataRow(Entity):
 
         task_json = Session.post_request(f"{DATA_ROW_RESOURCE}/update-async",
                                          json=body)
-        task_id = task_json.get(
-            'taskId')  # TODO: change to snake_case from backend
-        if task_id is None:
-            raise LabelboxError(
-                f"Failed to retrieve task information for `data_row.update_many()` async operation"
-            )
+        task_id = DataRow._parse_task('DataRow.update_async()', task_json)
         return UpdateDataRowsTask.get_by_id(task_id)
 
     @staticmethod
@@ -173,12 +174,7 @@ class DataRow(Entity):
 
         task_json = Session.post_request(f"{DATA_ROW_RESOURCE}/delete-async",
                                          json=body)
-        task_id = task_json.get(
-            'taskId')  # TODO: change to snake_case from backend
-        if task_id is None:
-            raise LabelboxError(
-                f"Failed to retrieve task information for `data_row.delete_many()` async operation"
-            )
+        task_id = DataRow._parse_task('DataRow.delete_async()', task_json)
         return DeleteDataRowsTask.get_by_id(task_id)
 
     @staticmethod

--- a/labelbox_dev/data_row.py
+++ b/labelbox_dev/data_row.py
@@ -1,14 +1,15 @@
 import os
-from typing import Any, Iterator, List, Optional, Union
+from typing import Any, Iterator, List, Optional
 
 from labelbox_dev.entity import Entity
 from labelbox_dev.exceptions import LabelboxError
 from labelbox_dev.session import Session
-from labelbox_dev.task import GetDataRowsTask, CreateDataRowsTask, DeleteDataRowsTask, UpdateDataRowsTask
+from labelbox_dev.task import CreateDataRowsTask, DeleteDataRowsTask, UpdateDataRowsTask
 from labelbox_dev.types import TypedDict
 from labelbox_dev.pagination import IdentifierPaginator
 
 DATA_ROW_RESOURCE = "data-rows"
+MAX_SYNCHRONOUS_DATA_ROW_REQUEST = 100  # Tentatively set to 100
 
 
 class AttachmentsInput(TypedDict):
@@ -61,14 +62,6 @@ class DataRow(Entity):
 
         return self
 
-    def update(self, data_row_update: UpdateDataRowInput) -> "DataRow":
-        data_row_json = Session.patch_request(f"{DATA_ROW_RESOURCE}/{self.id}",
-                                              json=data_row_update)
-        return self.from_json(data_row_json)
-
-    def delete(self) -> None:
-        Session.delete_request(f"{DATA_ROW_RESOURCE}/{self.id}")
-
     @staticmethod
     def _validate_keys(item):
         if 'row_data' not in item:
@@ -91,146 +84,112 @@ class DataRow(Entity):
         return data_rows
 
     @staticmethod
-    def create_one(dataset_id, data_row: CreateDataRowInput):
-        data_row = DataRow._format_data_rows([data_row])[0]
-        body = {'dataset_id': dataset_id, 'data_row': data_row}
-        data_row_json = Session.post_request(f"{DATA_ROW_RESOURCE}", json=body)
-        return DataRow(data_row_json)
+    def _check_sync_request_limits(request_name: str, request_count):
+        if request_count > MAX_SYNCHRONOUS_DATA_ROW_REQUEST:
+            raise LabelboxError(
+                f"Request exceeds {MAX_SYNCHRONOUS_DATA_ROW_REQUEST} DataRows. Please use `DataRow.{request_name}_async()` instead"
+            )
 
     @staticmethod
-    def create(dataset_id,
-               data_rows: List[CreateDataRowInput],
-               run_async: bool = False):
+    def create_async(dataset_id,
+                     data_rows: List[CreateDataRowInput]) -> CreateDataRowsTask:
         data_rows = DataRow._format_data_rows(data_rows)
-
         body = {
             'dataset_id': dataset_id,
             'data_rows': data_rows,
-            'run_async': run_async
         }
-        if run_async:
-            task_json = Session.post_request(f"{DATA_ROW_RESOURCE}/bulkcreate",
-                                             json=body)
-            task_id = task_json.get(
-                'taskId')  # TODO: change to snake_case from backend
 
-            if task_id is None:
-                raise LabelboxError(
-                    f"Failed to retrieve task information for `data_row.create()` async operation"
-                )
-            return CreateDataRowsTask.get_by_id(task_id)
+        task_json = Session.post_request(f"{DATA_ROW_RESOURCE}/create-async",
+                                         json=body)
+        task_id = task_json.get(
+            'taskId')  # TODO: change to snake_case from backend
+        if task_id is None:
+            raise LabelboxError(
+                f"Failed to retrieve task information for `data_row.create()` async operation"
+            )
+        return CreateDataRowsTask.get_by_id(task_id)
+
+    @staticmethod
+    def create(dataset_id,
+               data_rows: List[CreateDataRowInput]) -> List["DataRow"]:
+        DataRow._check_sync_request_limits('create', len(data_rows))
+        data_rows = DataRow._format_data_rows(data_rows)
+        body = {
+            'dataset_id': dataset_id,
+            'data_rows': data_rows,
+        }
 
         # TODO: Need to paginate sync call. Currently, 100 data rows is the limit
-        data_rows = Session.post_request(f"{DATA_ROW_RESOURCE}/bulkcreate",
-                                         json=body)
+        data_rows = Session.post_request(f"{DATA_ROW_RESOURCE}", json=body)
         return [DataRow(data_row_json) for data_row_json in data_rows]
 
     @staticmethod
-    def get_by_id(id: str):
-        data_row_json = Session.get_request(f"{DATA_ROW_RESOURCE}/{id}")
-        return DataRow(data_row_json)
-
-    @staticmethod
-    def get_by_global_key(global_key: str):
-        params = {'is_global_key': True}
-        data_row_json = Session.get_request(f"{DATA_ROW_RESOURCE}/{global_key}",
-                                            params=params)
-        return DataRow(data_row_json)
-
-    @staticmethod
-    def get_by_ids(
-            ids: List[str],
-            run_async: bool = False
-    ) -> Union[Iterator["DataRow"], GetDataRowsTask]:
-        body = {'keys': ids, 'run_async': run_async}
-
-        if run_async:
-            task_json = Session.post_request(f"{DATA_ROW_RESOURCE}/bulkget",
-                                             json=body)
-            # TODO: change to snake_case from backend
-            task_id = task_json.get('taskId')
-
-            if task_id is None:
-                raise LabelboxError(
-                    f"Failed to retrieve task information for `data_row.get_by_ids()` async operation"
-                )
-            return GetDataRowsTask.get_by_id(task_id)
-
+    def get_by_ids(ids: List[str],) -> Iterator["DataRow"]:
         return IdentifierPaginator(f"{DATA_ROW_RESOURCE}", DataRow, ids)
 
     @staticmethod
-    def get_by_global_keys(
-            global_keys: List[str],
-            run_async: bool = False
-    ) -> Union[Iterator["DataRow"], GetDataRowsTask]:
-        body = {
-            'keys': global_keys,
-            'is_global_key': True,
-            'run_async': run_async
-        }
-        if run_async:
-            task_json = Session.post_request(f"{DATA_ROW_RESOURCE}/bulkget",
-                                             json=body)
-            # TODO: change to snake_case from backend
-            task_id = task_json.get('taskId')
-
-            if task_id is None:
-                raise LabelboxError(
-                    f"Failed to retrieve task information for `data_row.get_by_global_keys()` async operation"
-                )
-            return GetDataRowsTask.get_by_id(task_id)
-
+    def get_by_global_keys(global_keys: List[str],) -> Iterator["DataRow"]:
         return IdentifierPaginator(f"{DATA_ROW_RESOURCE}",
                                    DataRow,
                                    global_keys,
                                    identifiers_key='global_keys')
 
     @staticmethod
-    def update_many(data_rows: List[UpdateDataRowInput],
-                    run_async: bool = False) -> UpdateDataRowsTask:
+    def update_async(data_rows: List[UpdateDataRowInput]) -> UpdateDataRowsTask:
         for data_row in data_rows:
             if 'row_data' in data_row:
                 data_row = DataRow._format_data_rows([data_row])[0]
+        body = {'data_rows': data_rows}
 
-        body = {'data_rows': data_rows, 'run_async': run_async}
-        if run_async:
-            task_json = Session.post_request(f"{DATA_ROW_RESOURCE}/bulkupdate",
-                                             json=body)
-            task_id = task_json.get(
-                'taskId')  # TODO: change to snake_case from backend
-
-            if task_id is None:
-                raise LabelboxError(
-                    f"Failed to retrieve task information for `data_row.update_many()` async operation"
-                )
-            return UpdateDataRowsTask.get_by_id(task_id)
-
-        data_rows = Session.post_request(f"{DATA_ROW_RESOURCE}/bulkupdate",
+        task_json = Session.post_request(f"{DATA_ROW_RESOURCE}/update-async",
                                          json=body)
+        task_id = task_json.get(
+            'taskId')  # TODO: change to snake_case from backend
+        if task_id is None:
+            raise LabelboxError(
+                f"Failed to retrieve task information for `data_row.update_many()` async operation"
+            )
+        return UpdateDataRowsTask.get_by_id(task_id)
+
+    @staticmethod
+    def update(data_rows: List[UpdateDataRowInput]) -> List["DataRow"]:
+        DataRow._check_sync_request_limits('update', len(data_rows))
+
+        for data_row in data_rows:
+            if 'row_data' in data_row:
+                data_row = DataRow._format_data_rows([data_row])[0]
+        body = {'data_rows': data_rows}
+        data_rows = Session.patch_request(f"{DATA_ROW_RESOURCE}", json=body)
         return [DataRow(data_row_json) for data_row_json in data_rows]
 
     @staticmethod
-    def delete_many(ids: Optional[List[str]] = None,
-                    global_keys: Optional[List[str]] = None,
-                    run_async: bool = False) -> DeleteDataRowsTask:
-        body = {'run_async': run_async}
+    def delete_async(
+            ids: Optional[List[str]] = None,
+            global_keys: Optional[List[str]] = None) -> DeleteDataRowsTask:
         if ids:
-            body.update({'ids': ids})
-        if global_keys:
-            body.update({'global_keys': global_keys})
+            body = {'ids': ids}
+        elif global_keys:
+            body = {'global_keys': global_keys}
 
-        if run_async:
-            task_json = Session.post_request(f"{DATA_ROW_RESOURCE}/bulkdelete",
-                                             json=body)
-            task_id = task_json.get(
-                'taskId')  # TODO: change to snake_case from backend
-
-            if task_id is None:
-                raise LabelboxError(
-                    f"Failed to retrieve task information for `data_row.delete_many()` async operation"
-                )
-            return DeleteDataRowsTask.get_by_id(task_id)
-
-        data_rows = Session.post_request(f"{DATA_ROW_RESOURCE}/bulkdelete",
+        task_json = Session.post_request(f"{DATA_ROW_RESOURCE}/delete-async",
                                          json=body)
+        task_id = task_json.get(
+            'taskId')  # TODO: change to snake_case from backend
+        if task_id is None:
+            raise LabelboxError(
+                f"Failed to retrieve task information for `data_row.delete_many()` async operation"
+            )
+        return DeleteDataRowsTask.get_by_id(task_id)
+
+    @staticmethod
+    def delete(ids: Optional[List[str]] = None,
+               global_keys: Optional[List[str]] = None) -> List[str]:
+        if ids:
+            DataRow._check_sync_request_limits('delete', len(ids))
+            body = {'ids': ids}
+        elif global_keys:
+            DataRow._check_sync_request_limits('delete', len(global_keys))
+            body = {'global_keys': global_keys}
+
+        data_rows = Session.delete_request(f"{DATA_ROW_RESOURCE}", json=body)
         return data_rows

--- a/labelbox_dev/session.py
+++ b/labelbox_dev/session.py
@@ -72,8 +72,12 @@ class Session:
                                  timeout=timeout)
 
     @classmethod
-    def delete_request(cls, uri, params=None, timeout=DEFAULT_TIMEOUT):
-        return cls._http_request("DELETE", uri, params=params, timeout=timeout)
+    def delete_request(cls, uri, data=None, json=None, timeout=DEFAULT_TIMEOUT):
+        return cls._http_request("DELETE",
+                                 uri,
+                                 data=data,
+                                 json=json,
+                                 timeout=timeout)
 
     @classmethod
     def _http_request(cls,
@@ -97,6 +101,7 @@ class Session:
                 'params': params,
                 'timeout': timeout
             }
+            print(f"Request: {request}")
             response = requests.request(**request)
 
         except requests.exceptions.Timeout as e:

--- a/labelbox_dev/task.py
+++ b/labelbox_dev/task.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 import requests
 
 from labelbox_dev.entity import Entity
-from labelbox_dev.exceptions import LabelboxError, ResourceNotFoundError
+from labelbox_dev.exceptions import LabelboxError
 from labelbox_dev.session import Session
 from labelbox_dev.utils import format_json_to_snake_case
 
@@ -25,7 +25,6 @@ class TaskStatus(Enum):
 
 class TaskType(Enum):
     CREATE_DATA_ROWS = "CREATE_DATA_ROWS"
-    GET_DATA_ROWS = "GET_DATA_ROWS"
     UPDATE_DATA_ROWS = "UPDATE_DATA_ROWS"
     DELETE_DATA_ROWS = "DELETE_DATA_ROWS"
 
@@ -137,38 +136,6 @@ class BulkTask(BaseTask, ABC):
             timeout_seconds -= check_frequency
             time.sleep(sleep_time_seconds)
             self.refresh()
-
-
-class GetDataRowsTask(BulkTask):
-    task_type = TaskType.GET_DATA_ROWS
-
-    def __init__(self, json):
-        super().__init__(json)
-
-    @property
-    def results(self) -> Optional[Dict[str, Any]]:
-        task_result = self.fetch_result()
-        if self.status == TaskStatus.FAILED.name or 'results' not in task_result:
-            logger.warning(
-                "Task has failed. Please look at `task.errors` for more details"
-            )
-            return None
-
-        result = {}
-        # TODO: Format results as DataRow objects
-        result['data_rows'] = [
-            format_json_to_snake_case(dr) for dr in task_result['results']
-        ]
-        return result
-
-    @property
-    def errors(self) -> Optional[Dict[str, Any]]:
-        task_result = self.fetch_result()
-        errors = {}
-        if 'errors' in task_result and len(task_result['errors']) != 0:
-            errors['errors'] = task_result['errors']
-
-        return errors if errors else None
 
 
 class CreateDataRowsTask(BulkTask):


### PR DESCRIPTION
- Renamed occurrences of `data_row_ids` to `ids
- Introduced `DataRow.update_many()` and `DataRow.delete_many()`
- Async task classes for update and delete async jobs
- Disclaimer: Task.errors doesn't return anything b/c we're not properly storing errors using bulk ops