### PR TITLE
Skip notebook tests and add test dependencies to docker image

### DIFF
--- a/examples/test_notebooks.py
+++ b/examples/test_notebooks.py
@@ -64,7 +64,11 @@ run_notebook_paths = [
 ]
 
 
-@pytest.mark.notebooks
+@pytest.mark.skip(
+    'Need some more work to run reliably, e.g. figuring out how to deal with '
+    'max number of models per org, therefore skipping from CI. However, this '
+    'test can be run locally after updating notebooks to ensure notebooks '
+    'are working.')
 @pytest.mark.parametrize("notebook_path", run_notebook_paths)
 def test_notebooks_run_without_errors(notebook_path):
     run_notebook(examples_path / notebook_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ pyproj
 pygeotile
 typing-extensions
 pytest-xdist
+nbformat~=5.7.0
+nbconvert~=7.2.6

--- a/tox.ini
+++ b/tox.ini
@@ -21,4 +21,4 @@ passenv =
     LABELBOX_TEST_GRAPHQL_API_ENDPOINT     
     DA_GCP_LABELBOX_API_KEY
 
-commands = pytest -k "not notebooks" {posargs}
+commands = pytest {posargs}


### PR DESCRIPTION
This is a new test added that was only meant to be run locally, but it is breaking the SDK tests. Adding dependencies for this test and skipping it.