### PR TITLE
[AL-4860] Remove lb_serializers imports and fix invalid notebook

### DIFF
--- a/examples/annotation_import/image.ipynb
+++ b/examples/annotation_import/image.ipynb
@@ -84,8 +84,7 @@
       "metadata": {},
       "source": [
         "import labelbox as lb\n",
-        "import labelbox.data.annotation_types as lb_types\n",
-        "import labelbox.data.serialization as lb_serializers\n",
+        "import labelbox.types as lb_types\n",
         "import uuid\n",
         "import numpy as np\n"
       ],

--- a/examples/prediction_upload/image_predictions.ipynb
+++ b/examples/prediction_upload/image_predictions.ipynb
@@ -91,8 +91,7 @@
       "metadata": {},
       "source": [
         "import labelbox as lb\n",
-        "import labelbox.data.annotation_types as lb_types\n",
-        "import labelbox.data.serialization as lb_serializers\n",
+        "import labelbox.types as lb_types\n",
         "import uuid\n",
         "import numpy as np"
       ],

--- a/examples/prediction_upload/text_predictions.ipynb
+++ b/examples/prediction_upload/text_predictions.ipynb
@@ -84,8 +84,7 @@
       "metadata": {},
       "source": [
         "import labelbox as lb\n",
-        "import labelbox.data.annotation_types as lb_types\n",
-        "import labelbox.data.serialization as lb_serializers\n",
+        "import labelbox.types as lb_types\n",
         "import uuid"
       ],
       "cell_type": "code",


### PR DESCRIPTION
* lb_serialzers imports were unused, removing them
* examples/label_export/images.ipynb was invalid, it was missing some required metadata and not in the format the pre-commit hook expects. Fixing that.