### PR TITLE
fix export tests

### DIFF
--- a/tests/integration/annotation_import/test_model_run.py
+++ b/tests/integration/annotation_import/test_model_run.py
@@ -187,7 +187,6 @@ def test_model_run_export_v2(model_run_with_model_run_data_rows,
 
     assert len(task_results) == len(label_ids)
     for task_result in task_results:
-        assert len(task_result['errors']) == 0
         # Check export param handling
         if media_attributes:
             assert 'media_attributes' in task_result and task_result[

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -70,7 +70,6 @@ def test_project_export_v2(configured_project_with_label):
     task_results = download_result(task.result_url)
 
     for task_result in task_results:
-        assert len(task_result['errors']) == 0
         task_project = task_result['projects'][project.uid]
         task_project_label_ids_set = set(
             map(lambda prediction: prediction['id'], task_project['labels']))


### PR DESCRIPTION
Errors has been removed from the payload and put in a separate field. 

I have another pr for adding this back to the tests using the appropriate field.