### PR TITLE
[PTDT-1105] Increase timeout to support creating huge ontologies

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -937,7 +937,10 @@ class Client:
                 'mediaType': media_type
             }
         }
-        res = self.execute(query_str, params)
+        # Timeout is set to 10 minutes, because an ontology can accept up to 25k root feature schemas, and it takes
+        # a while to create all of them. The code in api needs to be optimized, but for now we are setting a high
+        # timeout.
+        res = self.execute(query_str, params, timeout=600)
         return Entity.Ontology(self, res['upsertOntology'])
 
     def create_feature_schema(self, normalized):


### PR DESCRIPTION
API PR which allows to create ontologies with up to 25k root schema nodes https://github.com/Labelbox/intelligence/pull/13665.

How to test:

Run the code below. It should create an ontology with 24999 root schema nodes, after a few minutes

```python
ontology_name = "new 25k"
feature_schema_cat_normalized = {
    'tool': 'polygon',
    'name': 'something',
    'color': 'blue'
}

all_tools = [feature_schema_cat_normalized.copy() for _ in range(24999)]
for i, tool in enumerate(all_tools):
    tool['name'] = f'something_{i}'

ontology_normalized_json = {
    "tools": all_tools,
    "classifications": []
}
ontology = client.create_ontology(name=ontology_name,
                                  normalized=ontology_normalized_json,
                                  media_type=MediaType.Image)

```