### PR TITLE
[AL-4870] Split model run data rows using global keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 # Version 3.40.0 (YYYY-MM-DD)
 
-## Added 
-* Insert newest changelogs here
+## Added
+* Support Global keys to reference data rows in `Project.create_batch()`, `ModelRun.assign_data_rows_to_split()`.
+
 
 # Version 3.39.0 (2023-02-28)
 ## Added

--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -335,14 +335,15 @@ class ModelRun(DbObject):
 
     @experimental
     def assign_data_rows_to_split(self,
-                                  data_row_ids: List[str],
-                                  split: Union[DataSplit, str],
+                                  data_row_ids: List[str] = None,
+                                  split: Union[DataSplit, str] = None,
+                                  global_keys: List[str] = None,
                                   timeout_seconds=120):
 
         split_value = split.value if isinstance(split, DataSplit) else split
         valid_splits = DataSplit._member_names_
 
-        if split_value not in valid_splits:
+        if split_value is None or split_value not in valid_splits:
             raise ValueError(
                 f"`split` must be one of : `{valid_splits}`. Found : `{split}`")
 
@@ -354,7 +355,8 @@ class ModelRun(DbObject):
                 'data': {
                     'assignments': [{
                         'split': split_value,
-                        'dataRowIds': data_row_ids
+                        'dataRowIds': data_row_ids,
+                        'globalKeys': global_keys,
                     }]
                 }
             },


### PR DESCRIPTION
Depends on: https://github.com/Labelbox/intelligence/pull/13712