### PR TITLE
[X-0] Fix SDK default task name

### DIFF
--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -467,8 +467,6 @@ class ModelRun(DbObject):
         create_task_query_str = """mutation exportDataRowsInModelRunPyApi($input: ExportDataRowsInModelRunInput!){
           %s(input: $input) {taskId} }
           """ % (mutation_name)
-        if (task_name is None):
-            task_name = f'Export Data Rows in Model Run - {self.name}'
 
         _params = params or ModelRunExportParams()
 

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -411,9 +411,6 @@ class Project(DbObject, Updateable, Deletable):
                   task_name: Optional[str] = None,
                   params: Optional[ProjectExportParams] = None) -> Task:
 
-        if (task_name is None):
-            task_name = f'Export Data Rows in Project - {self.name}'
-
         _params = params or ProjectExportParams({
             "attachments": False,
             "metadata_fields": False,


### PR DESCRIPTION
We do have backend default taskName implemented at this moment, there's no need for the SDK to have it too.