### PR TITLE
Potential fix for the COCO panoptic method

### DIFF
--- a/labelbox/data/serialization/coco/panoptic_dataset.py
+++ b/labelbox/data/serialization/coco/panoptic_dataset.py
@@ -98,7 +98,7 @@ def process_label(label: Label,
                     image=image,
                     category_id=categories[annotation.name])
 
-                if coco_segment_info is None:
+                if coco_vector_info is None:
                     # Filter out empty annotations
                     continue
 


### PR DESCRIPTION
Currently, this method fails since coco_segment_info is not defined in the scope of the "elif" clause for  (Polygon, Rectangle) annotations
