### PR TITLE
[AL-5108] Add DICOM polyline annotation kind

### DIFF
--- a/labelbox/data/annotation_types/__init__.py
+++ b/labelbox/data/annotation_types/__init__.py
@@ -9,6 +9,8 @@ from .annotation import ClassificationAnnotation
 from .annotation import VideoClassificationAnnotation
 from .annotation import ObjectAnnotation
 from .annotation import VideoObjectAnnotation
+from .annotation import DICOMObjectAnnotation
+from .annotation import GroupKey
 
 from .ner import ConversationEntity
 from .ner import DocumentEntity

--- a/labelbox/data/annotation_types/annotation.py
+++ b/labelbox/data/annotation_types/annotation.py
@@ -1,4 +1,5 @@
 import abc
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 from labelbox.data.mixins import ConfidenceNotSupportedMixin, ConfidenceMixin
@@ -66,7 +67,7 @@ class VideoObjectAnnotation(ObjectAnnotation, ConfidenceNotSupportedMixin):
     >>>        end=Point(x=1, y=1)
     >>>     ),
     >>>     feature_schema_id="my-feature-schema-id"
-    >>>)
+    >>> )
 
     Args:
         name (Optional[str])
@@ -97,3 +98,41 @@ class VideoClassificationAnnotation(ClassificationAnnotation):
     """
     frame: int
     segment_index: Optional[int] = None
+
+
+class GroupKey(Enum):
+    """Group key for DICOM annotations
+    """
+    AXIAL = "axial"
+    SAGITTAL = "sagittal"
+    CORONAL = "coronal"
+
+
+class DICOMObjectAnnotation(VideoObjectAnnotation):
+    """DICOM object annotation
+
+    >>> DICOMObjectAnnotation(
+    >>>     name="dicom_polyline",
+    >>>     frame=2,
+    >>>     value=lb_types.Line(points = [
+    >>>         lb_types.Point(x=680, y=100),
+    >>>         lb_types.Point(x=100, y=190),
+    >>>         lb_types.Point(x=190, y=220)
+    >>>     ]),
+    >>>     segment_index=0,
+    >>>     keyframe=True,
+    >>>     group_key=GroupKey.AXIAL
+    >>> )
+
+    Args:
+        name (Optional[str])
+        feature_schema_id (Optional[Cuid])
+        value (Geometry)
+        group_key (GroupKey)
+        frame (Int): The frame index that this annotation corresponds to
+        keyframe (bool): Whether or not this annotation was a human generated or interpolated annotation
+        segment_id (Optional[Int]): Index of video segment this annotation belongs to
+        classifications (List[ClassificationAnnotation]) = []
+        extra (Dict[str, Any])        
+    """
+    group_key: GroupKey

--- a/labelbox/data/annotation_types/label.py
+++ b/labelbox/data/annotation_types/label.py
@@ -8,9 +8,10 @@ import labelbox
 from labelbox.data.annotation_types.data.tiled_image import TiledImageData
 from labelbox.schema import ontology
 from .annotation import (ClassificationAnnotation, ObjectAnnotation,
-                         VideoClassificationAnnotation, VideoObjectAnnotation)
+                         VideoClassificationAnnotation, VideoObjectAnnotation,
+                         DICOMObjectAnnotation)
 from .classification import ClassificationAnswer
-from .data import VideoData, TextData, ImageData
+from .data import DicomData, VideoData, TextData, ImageData
 from .geometry import Mask
 from .metrics import ScalarMetric, ConfusionMatrixMetric
 from .types import Cuid
@@ -39,9 +40,7 @@ class Label(BaseModel):
     uid: Optional[Cuid] = None
     data: Union[VideoData, ImageData, TextData, TiledImageData]
     annotations: List[Union[ClassificationAnnotation, ObjectAnnotation,
-                            VideoObjectAnnotation,
-                            VideoClassificationAnnotation, ScalarMetric,
-                            ConfusionMatrixMetric]] = []
+                            ScalarMetric, ConfusionMatrixMetric]] = []
     extra: Dict[str, Any] = {}
 
     def object_annotations(self) -> List[ObjectAnnotation]:

--- a/tests/data/serialization/coco/test_coco.py
+++ b/tests/data/serialization/coco/test_coco.py
@@ -6,28 +6,29 @@ from labelbox.data.serialization.coco import COCOConverter
 COCO_ASSETS_DIR = "tests/data/assets/coco"
 
 
-def run_instances():
+def run_instances(tmpdir):
     instance_json = json.load(open(Path(COCO_ASSETS_DIR, 'instances.json')))
     res = COCOConverter.deserialize_instances(instance_json,
                                               Path(COCO_ASSETS_DIR, 'images'))
     back = COCOConverter.serialize_instances(
         res,
-        Path('tmp/images_instances'),
+        Path(tmpdir),
     )
 
 
-def test_rle_objects():
+def test_rle_objects(tmpdir):
     rle_json = json.load(open(Path(COCO_ASSETS_DIR, 'rle.json')))
     res = COCOConverter.deserialize_instances(rle_json,
                                               Path(COCO_ASSETS_DIR, 'images'))
-    back = COCOConverter.serialize_instances(res, Path('/tmp/images_rle'))
+    back = COCOConverter.serialize_instances(res, tmpdir)
 
 
-def test_panoptic():
+def test_panoptic(tmpdir):
     panoptic_json = json.load(open(Path(COCO_ASSETS_DIR, 'panoptic.json')))
     image_dir, mask_dir = [
         Path(COCO_ASSETS_DIR, dir_name) for dir_name in ['images', 'masks']
     ]
     res = COCOConverter.deserialize_panoptic(panoptic_json, image_dir, mask_dir)
-    back = COCOConverter.serialize_panoptic(res, Path('/tmp/images_panoptic'),
-                                            Path('/tmp/masks_panoptic'))
+    back = COCOConverter.serialize_panoptic(res,
+                                            Path(f'/{tmpdir}/images_panoptic'),
+                                            Path(f'/{tmpdir}/masks_panoptic'))

--- a/tests/data/serialization/ndjson/test_dicom.py
+++ b/tests/data/serialization/ndjson/test_dicom.py
@@ -1,0 +1,78 @@
+from copy import copy
+import labelbox.types as lb_types
+from labelbox.data.serialization import NDJsonConverter
+from labelbox.data.serialization.ndjson.objects import NDDicomSegments, NDDicomSegment, NDDicomLine, NDSegments, NDSegment, NDFrameLine
+
+dicom_polyline_annotations = [
+    lb_types.DICOMObjectAnnotation(uuid="dicom-object-uid",
+                                   name="dicom_polyline",
+                                   frame=2,
+                                   value=lb_types.Line(points=[
+                                       lb_types.Point(x=680, y=100),
+                                       lb_types.Point(x=100, y=190),
+                                       lb_types.Point(x=190, y=220)
+                                   ]),
+                                   segment_index=0,
+                                   keyframe=True,
+                                   group_key=lb_types.GroupKey.AXIAL)
+]
+
+label = lb_types.Label(data=lb_types.DicomData(uid="test-uid"),
+                       annotations=dicom_polyline_annotations)
+
+label_ndjson = {
+    'classifications': [],
+    'dataRow': {
+        'id': 'test-uid'
+    },
+    'name':
+        'dicom_polyline',
+    'groupKey':
+        'axial',
+    'segments': [{
+        'keyframes': [{
+            'frame':
+                2,
+            'line': [
+                {
+                    'x': 680.0,
+                    'y': 100.0
+                },
+                {
+                    'x': 100.0,
+                    'y': 190.0
+                },
+                {
+                    'x': 190.0,
+                    'y': 220.0
+                },
+            ]
+        }]
+    }],
+}
+
+
+def test_serialize_dicom_polyline_annotation():
+    serialized_label = next(NDJsonConverter().serialize([label]))
+    serialized_label.pop('uuid')
+    assert serialized_label == label_ndjson
+
+
+def test_deserialize_dicom_polyline_annotation():
+    deserialized_label = next(NDJsonConverter().deserialize([label_ndjson]))
+    deserialized_label.annotations[0].extra.pop('uuid')
+    assert deserialized_label == label
+
+
+def test_serialize_deserialize_dicom_polyline_annotation():
+    labels = list(NDJsonConverter.deserialize([label_ndjson]))
+    res = list(NDJsonConverter.serialize(labels))
+    res[0].pop('uuid')
+    assert res == [label_ndjson]
+
+
+def test_deserialize_nd_dicom_segments():
+    nd_dicom_segments = NDDicomSegments(**label_ndjson)
+    assert isinstance(nd_dicom_segments, NDDicomSegments)
+    assert isinstance(nd_dicom_segments.segments[0], NDDicomSegment)
+    assert isinstance(nd_dicom_segments.segments[0].keyframes[0], NDDicomLine)


### PR DESCRIPTION
* Add `DICOMObjectAnnotation` and `GroupKey` enum to support annotation import using Python objects.
* Update `NDJsonConverter` to serialize/deserialize `DICOMObjectAnnotation` to/from the NDJson format.

Note: coco tests did not cleanup files written to directory which resulted in only the first execution of these tests working the and subsequent ones failing. These have been updated to cleanup temporary files.