### PR TITLE
[AL-5109][AL-5110] Add Video and Raster Segmentation Annotation Kinds

### DIFF
--- a/labelbox/data/annotation_types/__init__.py
+++ b/labelbox/data/annotation_types/__init__.py
@@ -6,11 +6,15 @@ from .geometry import Rectangle
 from .geometry import Geometry
 
 from .annotation import ClassificationAnnotation
-from .annotation import VideoClassificationAnnotation
 from .annotation import ObjectAnnotation
-from .annotation import VideoObjectAnnotation
-from .annotation import DICOMObjectAnnotation
-from .annotation import GroupKey
+from .video import VideoClassificationAnnotation
+from .video import VideoObjectAnnotation
+from .video import DICOMObjectAnnotation
+from .video import GroupKey
+from .video import MaskFrame
+from .video import MaskInstance
+from .video import VideoMaskAnnotation
+from .video import DICOMMaskAnnotation
 
 from .ner import ConversationEntity
 from .ner import DocumentEntity

--- a/labelbox/data/annotation_types/annotation.py
+++ b/labelbox/data/annotation_types/annotation.py
@@ -1,8 +1,7 @@
 import abc
-from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 
-from labelbox.data.mixins import ConfidenceNotSupportedMixin, ConfidenceMixin
+from labelbox.data.mixins import ConfidenceMixin
 
 from .classification import Checklist, Dropdown, Radio, Text
 from .feature import FeatureSchema
@@ -54,85 +53,3 @@ class ObjectAnnotation(BaseAnnotation, ConfidenceMixin):
     """
     value: Union[TextEntity, ConversationEntity, DocumentEntity, Geometry]
     classifications: List[ClassificationAnnotation] = []
-
-
-class VideoObjectAnnotation(ObjectAnnotation, ConfidenceNotSupportedMixin):
-    """Video object annotation
-
-    >>> VideoObjectAnnotation(
-    >>>     keyframe=True,
-    >>>     frame=10,
-    >>>     value=Rectangle(
-    >>>        start=Point(x=0, y=0),
-    >>>        end=Point(x=1, y=1)
-    >>>     ),
-    >>>     feature_schema_id="my-feature-schema-id"
-    >>> )
-
-    Args:
-        name (Optional[str])
-        feature_schema_id (Optional[Cuid])
-        value (Geometry)
-        frame (Int): The frame index that this annotation corresponds to
-        keyframe (bool): Whether or not this annotation was a human generated or interpolated annotation
-        segment_id (Optional[Int]): Index of video segment this annotation belongs to
-        classifications (List[ClassificationAnnotation]) = []
-        extra (Dict[str, Any])
-    """
-
-    frame: int
-    keyframe: bool
-    segment_index: Optional[int] = None
-
-
-class VideoClassificationAnnotation(ClassificationAnnotation):
-    """Video classification
-
-    Args:
-        name (Optional[str])
-        feature_schema_id (Optional[Cuid])
-        value (Union[Text, Checklist, Radio, Dropdown])
-        frame (int): The frame index that this annotation corresponds to
-        segment_id (Optional[Int]): Index of video segment this annotation belongs to
-        extra (Dict[str, Any])
-    """
-    frame: int
-    segment_index: Optional[int] = None
-
-
-class GroupKey(Enum):
-    """Group key for DICOM annotations
-    """
-    AXIAL = "axial"
-    SAGITTAL = "sagittal"
-    CORONAL = "coronal"
-
-
-class DICOMObjectAnnotation(VideoObjectAnnotation):
-    """DICOM object annotation
-
-    >>> DICOMObjectAnnotation(
-    >>>     name="dicom_polyline",
-    >>>     frame=2,
-    >>>     value=lb_types.Line(points = [
-    >>>         lb_types.Point(x=680, y=100),
-    >>>         lb_types.Point(x=100, y=190),
-    >>>         lb_types.Point(x=190, y=220)
-    >>>     ]),
-    >>>     segment_index=0,
-    >>>     keyframe=True,
-    >>>     group_key=GroupKey.AXIAL
-    >>> )
-
-    Args:
-        name (Optional[str])
-        feature_schema_id (Optional[Cuid])
-        value (Geometry)
-        group_key (GroupKey)
-        frame (Int): The frame index that this annotation corresponds to
-        keyframe (bool): Whether or not this annotation was a human generated or interpolated annotation
-        segment_id (Optional[Int]): Index of video segment this annotation belongs to
-        classifications (List[ClassificationAnnotation]) = []
-        extra (Dict[str, Any])        
-    """
-    group_key: GroupKey

--- a/labelbox/data/annotation_types/label.py
+++ b/labelbox/data/annotation_types/label.py
@@ -7,14 +7,14 @@ from pydantic import BaseModel, validator
 import labelbox
 from labelbox.data.annotation_types.data.tiled_image import TiledImageData
 from labelbox.schema import ontology
-from .annotation import (ClassificationAnnotation, ObjectAnnotation,
-                         VideoClassificationAnnotation, VideoObjectAnnotation,
-                         DICOMObjectAnnotation)
+from .annotation import (ClassificationAnnotation, ObjectAnnotation)
 from .classification import ClassificationAnswer
 from .data import AudioData, ConversationData, DicomData, DocumentData, HTMLData, ImageData, MaskData, TextData, VideoData
 from .geometry import Mask
 from .metrics import ScalarMetric, ConfusionMatrixMetric
 from .types import Cuid
+from .video import VideoClassificationAnnotation
+from .video import VideoObjectAnnotation, VideoMaskAnnotation
 from ..ontology import get_feature_schema_lookup
 
 DataType = Union[VideoData, ImageData, TextData, TiledImageData, AudioData,
@@ -43,7 +43,8 @@ class Label(BaseModel):
     uid: Optional[Cuid] = None
     data: DataType
     annotations: List[Union[ClassificationAnnotation, ObjectAnnotation,
-                            ScalarMetric, ConfusionMatrixMetric]] = []
+                            VideoMaskAnnotation, ScalarMetric,
+                            ConfusionMatrixMetric]] = []
     extra: Dict[str, Any] = {}
 
     def object_annotations(self) -> List[ObjectAnnotation]:

--- a/labelbox/data/annotation_types/video.py
+++ b/labelbox/data/annotation_types/video.py
@@ -1,0 +1,139 @@
+from enum import Enum
+
+from pydantic import BaseModel, validator
+from labelbox.data.annotation_types.annotation import BaseAnnotation, ClassificationAnnotation, ObjectAnnotation
+
+from typing import List, Optional, Tuple
+from labelbox.data.mixins import ConfidenceNotSupportedMixin
+
+from labelbox.utils import _CamelCaseMixin, is_valid_uri
+
+
+class VideoClassificationAnnotation(ClassificationAnnotation):
+    """Video classification
+    Args:
+        name (Optional[str])
+        feature_schema_id (Optional[Cuid])
+        value (Union[Text, Checklist, Radio, Dropdown])
+        frame (int): The frame index that this annotation corresponds to
+        segment_id (Optional[Int]): Index of video segment this annotation belongs to
+        extra (Dict[str, Any])
+    """
+    frame: int
+    segment_index: Optional[int] = None
+
+
+class VideoObjectAnnotation(ObjectAnnotation, ConfidenceNotSupportedMixin):
+    """Video object annotation
+    >>> VideoObjectAnnotation(
+    >>>     keyframe=True,
+    >>>     frame=10,
+    >>>     value=Rectangle(
+    >>>        start=Point(x=0, y=0),
+    >>>        end=Point(x=1, y=1)
+    >>>     ),
+    >>>     feature_schema_id="my-feature-schema-id"
+    >>> )
+    Args:
+        name (Optional[str])
+        feature_schema_id (Optional[Cuid])
+        value (Geometry)
+        frame (Int): The frame index that this annotation corresponds to
+        keyframe (bool): Whether or not this annotation was a human generated or interpolated annotation
+        segment_id (Optional[Int]): Index of video segment this annotation belongs to
+        classifications (List[ClassificationAnnotation]) = []
+        extra (Dict[str, Any])
+    """
+    frame: int
+    keyframe: bool
+    segment_index: Optional[int] = None
+
+
+class GroupKey(Enum):
+    """Group key for DICOM annotations
+    """
+    AXIAL = "axial"
+    SAGITTAL = "sagittal"
+    CORONAL = "coronal"
+
+
+class DICOMObjectAnnotation(VideoObjectAnnotation):
+    """DICOM object annotation
+    >>> DICOMObjectAnnotation(
+    >>>     name="dicom_polyline",
+    >>>     frame=2,
+    >>>     value=lb_types.Line(points = [
+    >>>         lb_types.Point(x=680, y=100),
+    >>>         lb_types.Point(x=100, y=190),
+    >>>         lb_types.Point(x=190, y=220)
+    >>>     ]),
+    >>>     segment_index=0,
+    >>>     keyframe=True,
+    >>>     Group_key=GroupKey.AXIAL
+    >>> )
+    Args:
+        name (Optional[str])
+        feature_schema_id (Optional[Cuid])
+        value (Geometry)
+        group_key (GroupKey)
+        frame (Int): The frame index that this annotation corresponds to
+        keyframe (bool): Whether or not this annotation was a human generated or interpolated annotation
+        segment_id (Optional[Int]): Index of video segment this annotation belongs to
+        classifications (List[ClassificationAnnotation]) = []
+        extra (Dict[str, Any])        
+    """
+    group_key: GroupKey
+
+
+class MaskFrame(_CamelCaseMixin, BaseModel):
+    index: int
+    instance_uri: str
+
+    @validator("instance_uri")
+    def validate_uri(cls, v):
+        if not is_valid_uri(v):
+            raise ValueError(f"{v} is not a valid uri")
+        return v
+
+
+class MaskInstance(_CamelCaseMixin, BaseModel):
+    color_rgb: Tuple[int, int, int]
+    name: str
+
+
+class VideoMaskAnnotation(BaseAnnotation):
+    """DICOM video annotation
+       >>> DICOMVideoAnnotation(
+       >>>     name="dicom_mask",
+       >>>     frames=[
+       >>>         MaskFrame(index=1, instance_uri='https://storage.labelbox.com/cjhfn5y6s0pk507024nz1ocys%2F1d60856c-59b7-3060-2754-83f7e93e0d01-1?Expires=1666901963361&KeyName=labelbox-assets-key-3&Signature=t-2s2DB4YjFuWEFak0wxYqfBfZA'),
+       >>>         MaskFrame(index=5, instance_uri='https://storage.labelbox.com/cjhfn5y6s0pk507024nz1ocys1%2F1d60856c-59b7-3060-2754-83f7e93e0d01-1?Expires=1666901963361&KeyName=labelbox-assets-key-3&Signature=t-2s2DB4YjFuWEFak0wxYqfBfZA'),
+       >>>     ],
+       >>>     instances=[
+       >>>         MaskInstance(color_rgb=(0, 0, 255), name="mask1"),
+       >>>         MaskInstance(color_rgb=(0, 255, 0), name="mask2"),
+       >>>         MaskInstance(color_rgb=(255, 0, 0), name="mask3")
+       >>>     ]
+       >>> )
+    """
+    frames: List[MaskFrame]
+    instances: List[MaskInstance]
+
+
+class DICOMMaskAnnotation(VideoMaskAnnotation):
+    """DICOM mask annotation
+       >>> DICOMMaskAnnotation(
+       >>>     name="dicom_mask",
+       >>>     group_key=GroupKey.AXIAL,
+       >>>     frames=[
+       >>>         MaskFrame(index=1, instance_uri='https://storage.labelbox.com/cjhfn5y6s0pk507024nz1ocys%2F1d60856c-59b7-3060-2754-83f7e93e0d01-1?Expires=1666901963361&KeyName=labelbox-assets-key-3&Signature=t-2s2DB4YjFuWEFak0wxYqfBfZA'),
+       >>>         MaskFrame(index=5, instance_uri='https://storage.labelbox.com/cjhfn5y6s0pk507024nz1ocys1%2F1d60856c-59b7-3060-2754-83f7e93e0d01-1?Expires=1666901963361&KeyName=labelbox-assets-key-3&Signature=t-2s2DB4YjFuWEFak0wxYqfBfZA'),
+       >>>     ],
+       >>>     instances=[
+       >>>         MaskInstance(color_rgb=(0, 0, 255), name="mask1"),
+       >>>         MaskInstance(color_rgb=(0, 255, 0), name="mask2"),
+       >>>         MaskInstance(color_rgb=(255, 0, 0), name="mask3")
+       >>>     ]
+       >>> )
+    """
+    group_key: GroupKey

--- a/labelbox/data/serialization/labelbox_v1/label.py
+++ b/labelbox/data/serialization/labelbox_v1/label.py
@@ -5,9 +5,8 @@ from typing import List, Optional, Union, Dict, Any
 from pydantic import BaseModel, Field
 
 from ...annotation_types.annotation import (ClassificationAnnotation,
-                                            ObjectAnnotation,
-                                            VideoClassificationAnnotation,
-                                            VideoObjectAnnotation)
+                                            ObjectAnnotation)
+from ...annotation_types.video import VideoClassificationAnnotation, VideoObjectAnnotation
 from ...annotation_types.data import ImageData, TextData, VideoData
 from ...annotation_types.label import Label
 from .classification import LBV1Classifications

--- a/labelbox/data/serialization/ndjson/classification.py
+++ b/labelbox/data/serialization/ndjson/classification.py
@@ -4,7 +4,8 @@ from pydantic import BaseModel, Field, root_validator
 from labelbox.data.mixins import ConfidenceMixin
 
 from labelbox.utils import camel_case
-from ...annotation_types.annotation import ClassificationAnnotation, VideoClassificationAnnotation
+from ...annotation_types.annotation import ClassificationAnnotation
+from ...annotation_types.video import VideoClassificationAnnotation
 from ...annotation_types.classification.classification import ClassificationAnswer, Dropdown, Text, Checklist, Radio
 from ...annotation_types.types import Cuid
 from ...annotation_types.data import TextData, VideoData, ImageData

--- a/labelbox/utils.py
+++ b/labelbox/utils.py
@@ -1,12 +1,17 @@
 import re
+from urllib.parse import urlparse
 from pydantic import BaseModel
+
+UPPERCASE_COMPONENTS = ['uri', 'rgb']
 
 
 def _convert(s, sep, title):
     components = re.findall(r"[A-Z][a-z0-9]*|[a-z][a-z0-9]*", s)
     components = list(map(str.lower, filter(None, components)))
     for i in range(len(components)):
-        if title(i):
+        if components[i] in UPPERCASE_COMPONENTS:
+            components[i] = components[i].upper()
+        elif title(i):
             components[i] = components[i][0].upper() + components[i][1:]
     return sep.join(components)
 
@@ -28,6 +33,14 @@ def snake_case(s):
 
 def is_exactly_one_set(x, y):
     return not (bool(x) == bool(y))
+
+
+def is_valid_uri(uri):
+    try:
+        result = urlparse(uri)
+        return all([result.scheme, result.netloc])
+    except:
+        return False
 
 
 class _CamelCaseMixin(BaseModel):

--- a/tests/data/annotation_types/test_annotation.py
+++ b/tests/data/annotation_types/test_annotation.py
@@ -3,10 +3,10 @@ from pydantic import ValidationError
 
 from labelbox.data.annotation_types import (Text, Point, Line,
                                             ClassificationAnnotation,
-                                            ObjectAnnotation,
-                                            VideoClassificationAnnotation,
-                                            VideoObjectAnnotation, TextEntity)
+                                            ObjectAnnotation, TextEntity)
+from labelbox.data.annotation_types.video import VideoObjectAnnotation
 from labelbox.data.annotation_types.geometry.rectangle import Rectangle
+from labelbox.data.annotation_types.video import VideoClassificationAnnotation
 from labelbox.exceptions import ConfidenceNotSupportedException
 
 

--- a/tests/data/annotation_types/test_video.py
+++ b/tests/data/annotation_types/test_video.py
@@ -1,0 +1,18 @@
+import labelbox.types as lb_types
+
+
+def test_mask_frame():
+    mask_frame = lb_types.MaskFrame(index=1,
+                                    instance_uri="http://path/to/frame.png")
+    assert mask_frame.dict(by_alias=True) == {
+        'index': 1,
+        'instanceURI': 'http://path/to/frame.png'
+    }
+
+
+def test_mask_instance():
+    mask_instance = lb_types.MaskInstance(color_rgb=(0, 0, 255), name="mask1")
+    assert mask_instance.dict(by_alias=True) == {
+        'colorRGB': (0, 0, 255),
+        'name': 'mask1'
+    }

--- a/tests/data/serialization/ndjson/test_dicom.py
+++ b/tests/data/serialization/ndjson/test_dicom.py
@@ -1,7 +1,11 @@
 from copy import copy
+import pytest
 import labelbox.types as lb_types
 from labelbox.data.serialization import NDJsonConverter
-from labelbox.data.serialization.ndjson.objects import NDDicomSegments, NDDicomSegment, NDDicomLine, NDSegments, NDSegment, NDFrameLine
+from labelbox.data.serialization.ndjson.objects import NDDicomSegments, NDDicomSegment, NDDicomLine
+"""
+Polyline test data
+"""
 
 dicom_polyline_annotations = [
     lb_types.DICOMObjectAnnotation(uuid="dicom-object-uid",
@@ -17,13 +21,10 @@ dicom_polyline_annotations = [
                                    group_key=lb_types.GroupKey.AXIAL)
 ]
 
-label = lb_types.Label(data=lb_types.DicomData(uid="test-uid"),
-                       annotations=dicom_polyline_annotations)
-label_with_global_key = lb_types.Label(
-    data=lb_types.DicomData(global_key="test-global-key"),
-    annotations=dicom_polyline_annotations)
+polyline_label = lb_types.Label(data=lb_types.DicomData(uid="test-uid"),
+                                annotations=dicom_polyline_annotations)
 
-label_ndjson = {
+polyline_annotation_ndjson = {
     'classifications': [],
     'dataRow': {
         'id': 'test-uid'
@@ -54,80 +55,142 @@ label_ndjson = {
     }],
 }
 
-label_ndjson_with_global_key = {
-    'classifications': [],
+polyline_with_global_key = lb_types.Label(
+    data=lb_types.DicomData(global_key="test-global-key"),
+    annotations=dicom_polyline_annotations)
+
+polyline_annotation_ndjson_with_global_key = copy(polyline_annotation_ndjson)
+polyline_annotation_ndjson_with_global_key['dataRow'] = {
+    'globalKey': 'test-global-key'
+}
+"""
+Video test data
+"""
+
+instance_uri_1 = 'https://storage.labelbox.com/cjhfn5y6s0pk507024nz1ocys%2F1d60856c-59b7-3060-2754-83f7e93e0d01-1?Expires=1666901963361&KeyName=labelbox-assets-key-3&Signature=t-2s2DB4YjFuWEFak0wxYqfBfZA'
+instance_uri_5 = 'https://storage.labelbox.com/cjhfn5y6s0pk507024nz1ocys1%2F1d60856c-59b7-3060-2754-83f7e93e0d01-1?Expires=1666901963361&KeyName=labelbox-assets-key-3&Signature=t-2s2DB4YjFuWEFak0wxYqfBfZA'
+frames = [
+    lb_types.MaskFrame(index=1, instance_uri=instance_uri_1),
+    lb_types.MaskFrame(index=5, instance_uri=instance_uri_5)
+]
+instances = [
+    lb_types.MaskInstance(color_rgb=(0, 0, 255), name="mask1"),
+    lb_types.MaskInstance(color_rgb=(0, 255, 0), name="mask2"),
+    lb_types.MaskInstance(color_rgb=(255, 0, 0), name="mask3")
+]
+
+video_mask_annotation = lb_types.VideoMaskAnnotation(name="video_mask",
+                                                     frames=frames,
+                                                     instances=instances)
+
+video_mask_annotation_ndjson = {
     'dataRow': {
-        'globalKey': 'test-global-key'
+        'id': 'test-uid'
     },
-    'name':
-        'dicom_polyline',
-    'groupKey':
-        'axial',
-    'segments': [{
-        'keyframes': [{
-            'frame':
-                2,
-            'line': [
-                {
-                    'x': 680.0,
-                    'y': 100.0
-                },
-                {
-                    'x': 100.0,
-                    'y': 190.0
-                },
-                {
-                    'x': 190.0,
-                    'y': 220.0
-                },
-            ]
-        }]
-    }],
+    'name': 'video_mask',
+    'masks': {
+        'frames': [{
+            'index': 1,
+            'instanceURI': instance_uri_1
+        }, {
+            'index': 5,
+            'instanceURI': instance_uri_5
+        }],
+        'instances': [
+            {
+                'colorRGB': (0, 0, 255),
+                'name': 'mask1'
+            },
+            {
+                'colorRGB': (0, 255, 0),
+                'name': 'mask2'
+            },
+            {
+                'colorRGB': (255, 0, 0),
+                'name': 'mask3'
+            },
+        ]
+    },
 }
 
+video_mask_annotation_ndjson_with_global_key = copy(
+    video_mask_annotation_ndjson)
+video_mask_annotation_ndjson_with_global_key['dataRow'] = {
+    'globalKey': 'test-global-key'
+}
 
-def test_serialize_dicom_polyline_annotation():
-    serialized_label = next(NDJsonConverter().serialize([label]))
-    serialized_label.pop('uuid')
-    assert serialized_label == label_ndjson
+video_mask_label = lb_types.Label(data=lb_types.VideoData(uid="test-uid"),
+                                  annotations=[video_mask_annotation])
 
+video_mask_label_with_global_key = lb_types.Label(
+    data=lb_types.VideoData(global_key="test-global-key"),
+    annotations=[video_mask_annotation])
+"""
+DICOM Mask test data
+"""
 
-def test_serialize_dicom_polyline_annotation_with_global_key():
-    serialized_label = next(NDJsonConverter().serialize([label_with_global_key
-                                                        ]))
-    serialized_label.pop('uuid')
-    assert serialized_label == label_ndjson_with_global_key
+dicom_mask_annotation = lb_types.DICOMMaskAnnotation(
+    name="dicom_mask",
+    group_key=lb_types.GroupKey.AXIAL,
+    frames=frames,
+    instances=instances)
 
+dicom_mask_label = lb_types.Label(data=lb_types.DicomData(uid="test-uid"),
+                                  annotations=[dicom_mask_annotation])
 
-def test_deserialize_dicom_polyline_annotation():
-    deserialized_label = next(NDJsonConverter().deserialize([label_ndjson]))
-    deserialized_label.annotations[0].extra.pop('uuid')
-    assert deserialized_label == label
+dicom_mask_label_with_global_key = lb_types.Label(
+    data=lb_types.DicomData(global_key="test-global-key"),
+    annotations=[dicom_mask_annotation])
 
+dicom_mask_annotation_ndjson = copy(video_mask_annotation_ndjson)
+dicom_mask_annotation_ndjson['groupKey'] = 'axial'
+dicom_mask_annotation_ndjson['name'] = 'dicom_mask'
+dicom_mask_annotation_ndjson_with_global_key = copy(
+    dicom_mask_annotation_ndjson)
+dicom_mask_annotation_ndjson_with_global_key['dataRow'] = {
+    'globalKey': 'test-global-key'
+}
+"""
+Tests
+"""
 
-def test_deserialize_dicom_polyline_annotation_with_global_key():
-    deserialized_label = next(NDJsonConverter().deserialize(
-        [label_ndjson_with_global_key]))
-    deserialized_label.annotations[0].extra.pop('uuid')
-    assert deserialized_label == label_with_global_key
-
-
-def test_serialize_deserialize_dicom_polyline_annotation():
-    labels = list(NDJsonConverter.deserialize([label_ndjson]))
-    res = list(NDJsonConverter.serialize(labels))
-    res[0].pop('uuid')
-    assert res == [label_ndjson]
-
-
-def test_serialize_deserialize_dicom_polyline_annotation_with_global_key():
-    labels = list(NDJsonConverter.deserialize([label_ndjson_with_global_key]))
-    res = list(NDJsonConverter.serialize(labels))
-    res[0].pop('uuid')
-    assert res == [label_ndjson_with_global_key]
+labels = [
+    polyline_label, polyline_with_global_key, dicom_mask_label,
+    dicom_mask_label_with_global_key, video_mask_label,
+    video_mask_label_with_global_key
+]
+ndjsons = [
+    polyline_annotation_ndjson, polyline_annotation_ndjson_with_global_key,
+    dicom_mask_annotation_ndjson, dicom_mask_annotation_ndjson_with_global_key,
+    video_mask_annotation_ndjson, video_mask_annotation_ndjson_with_global_key
+]
+labels_ndjsons = list(zip(labels, ndjsons))
 
 
 def test_deserialize_nd_dicom_segments():
-    nd_dicom_segments = NDDicomSegments(**label_ndjson)
+    nd_dicom_segments = NDDicomSegments(**polyline_annotation_ndjson)
     assert isinstance(nd_dicom_segments, NDDicomSegments)
     assert isinstance(nd_dicom_segments.segments[0], NDDicomSegment)
     assert isinstance(nd_dicom_segments.segments[0].keyframes[0], NDDicomLine)
+
+
+@pytest.mark.parametrize('label, ndjson', labels_ndjsons)
+def test_serialize_label(label, ndjson):
+    serialized_label = next(NDJsonConverter().serialize([label]))
+    serialized_label.pop('uuid')
+    assert serialized_label == ndjson
+
+
+@pytest.mark.parametrize('label, ndjson', labels_ndjsons)
+def test_deserialize_label(label, ndjson):
+    deserialized_label = next(NDJsonConverter().deserialize([ndjson]))
+    deserialized_label.annotations[0].extra = {}
+    assert deserialized_label.annotations == label.annotations
+
+
+@pytest.mark.parametrize('label', labels)
+def test_serialize_deserialize_label(label):
+    serialized = list(NDJsonConverter.serialize([label]))
+    deserialized = list(NDJsonConverter.deserialize(serialized))
+    deserialized[0].annotations[0].extra = {}
+    assert deserialized[0].annotations == label.annotations

--- a/tests/data/serialization/ndjson/test_export_video_objects.py
+++ b/tests/data/serialization/ndjson/test_export_video_objects.py
@@ -1,7 +1,7 @@
-from labelbox.data.annotation_types import Label
+from labelbox.data.annotation_types import Label, VideoObjectAnnotation
 from labelbox.data.serialization.ndjson.converter import NDJsonConverter
 from labelbox.data.annotation_types.geometry import Rectangle, Point
-from labelbox.data.annotation_types import VideoData, VideoObjectAnnotation
+from labelbox.data.annotation_types import VideoData
 
 
 def video_bbox_label():


### PR DESCRIPTION
* Create new module for Video and DICOM annotation kinds
* Add `VideoMaskAnnotation` and `DICOMMaskAnnotation`
* Update `NDJsonConverter` to support new annotation kinds
* Update case conversion util to produce acronyms in uppercase i.e `URI` instead of `Uri`.

Note: This PR includes changes from #999, please review #999 first.