### PR TITLE
Fix annotation data type coersion by Pydantic

### DIFF
--- a/labelbox/data/annotation_types/data/audio.py
+++ b/labelbox/data/annotation_types/data/audio.py
@@ -1,5 +1,7 @@
+from labelbox.typing_imports import Literal
+from labelbox.utils import _NoCoercionMixin
 from .base_data import BaseData
 
 
-class AudioData(BaseData):
-    ...
+class AudioData(BaseData, _NoCoercionMixin):
+    class_name: Literal["AudioData"] = "AudioData"

--- a/labelbox/data/annotation_types/data/conversation.py
+++ b/labelbox/data/annotation_types/data/conversation.py
@@ -1,5 +1,7 @@
+from labelbox.typing_imports import Literal
+from labelbox.utils import _NoCoercionMixin
 from .base_data import BaseData
 
 
 class ConversationData(BaseData):
-    ...
+    class_name: Literal["ConversationData"] = "ConversationData"

--- a/labelbox/data/annotation_types/data/dicom.py
+++ b/labelbox/data/annotation_types/data/dicom.py
@@ -1,5 +1,7 @@
+from labelbox.typing_imports import Literal
+from labelbox.utils import _NoCoercionMixin
 from .base_data import BaseData
 
 
-class DicomData(BaseData):
-    ...
+class DicomData(BaseData, _NoCoercionMixin):
+    class_name: Literal["DicomData"] = "DicomData"

--- a/labelbox/data/annotation_types/data/document.py
+++ b/labelbox/data/annotation_types/data/document.py
@@ -1,5 +1,7 @@
+from labelbox.typing_imports import Literal
+from labelbox.utils import _NoCoercionMixin
 from .base_data import BaseData
 
 
-class DocumentData(BaseData):
-    ...
+class DocumentData(BaseData, _NoCoercionMixin):
+    class_name: Literal["DocumentData"] = "DocumentData"

--- a/labelbox/data/annotation_types/data/html.py
+++ b/labelbox/data/annotation_types/data/html.py
@@ -1,5 +1,7 @@
+from labelbox.typing_imports import Literal
+from labelbox.utils import _NoCoercionMixin
 from .base_data import BaseData
 
 
-class HTMLData(BaseData):
-    ...
+class HTMLData(BaseData, _NoCoercionMixin):
+    class_name: Literal["HTMLData"] = "HTMLData"

--- a/labelbox/data/annotation_types/data/text.py
+++ b/labelbox/data/annotation_types/data/text.py
@@ -6,10 +6,12 @@ from google.api_core import retry
 from pydantic import root_validator
 
 from labelbox.exceptions import InternalServerError
+from labelbox.typing_imports import Literal
+from labelbox.utils import _NoCoercionMixin
 from .base_data import BaseData
 
 
-class TextData(BaseData):
+class TextData(BaseData, _NoCoercionMixin):
     """
     Represents text data. Requires arg file_path, text, or url
 
@@ -20,6 +22,7 @@ class TextData(BaseData):
         text (str)
         url (str)
     """
+    class_name: Literal["TextData"] = "TextData"
     file_path: Optional[str] = None
     text: Optional[str] = None
     url: Optional[str] = None

--- a/labelbox/data/annotation_types/label.py
+++ b/labelbox/data/annotation_types/label.py
@@ -11,11 +11,14 @@ from .annotation import (ClassificationAnnotation, ObjectAnnotation,
                          VideoClassificationAnnotation, VideoObjectAnnotation,
                          DICOMObjectAnnotation)
 from .classification import ClassificationAnswer
-from .data import DicomData, VideoData, TextData, ImageData
+from .data import AudioData, ConversationData, DicomData, DocumentData, HTMLData, ImageData, MaskData, TextData, VideoData
 from .geometry import Mask
 from .metrics import ScalarMetric, ConfusionMatrixMetric
 from .types import Cuid
 from ..ontology import get_feature_schema_lookup
+
+DataType = Union[VideoData, ImageData, TextData, TiledImageData, AudioData,
+                 ConversationData, DicomData, DocumentData, HTMLData]
 
 
 class Label(BaseModel):
@@ -38,7 +41,7 @@ class Label(BaseModel):
         extra: additional context
     """
     uid: Optional[Cuid] = None
-    data: Union[VideoData, ImageData, TextData, TiledImageData]
+    data: DataType
     annotations: List[Union[ClassificationAnnotation, ObjectAnnotation,
                             ScalarMetric, ConfusionMatrixMetric]] = []
     extra: Dict[str, Any] = {}

--- a/labelbox/typing_imports.py
+++ b/labelbox/typing_imports.py
@@ -1,0 +1,10 @@
+"""
+This module imports types that differ across python versions, so other modules 
+don't have to worry about where they should be imported from.
+"""
+
+import sys
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal

--- a/labelbox/utils.py
+++ b/labelbox/utils.py
@@ -35,3 +35,26 @@ class _CamelCaseMixin(BaseModel):
     class Config:
         allow_population_by_field_name = True
         alias_generator = camel_case
+
+
+class _NoCoercionMixin:
+    """
+    When using Unions in type annotations, pydantic will try to coerce the type
+    of the object to the type of the first Union member. Which results in
+    uninteded behavior.
+
+    This mixin uses a class_name discriminator field to prevent pydantic from
+    corecing the type of the object. Add a class_name field to the class you 
+    want to discrimniate and use this mixin class to remove the discriminator
+    when serializing the object.
+
+    Example:
+        class ConversationData(BaseData, _NoCoercionMixin):
+            class_name: Literal["ConversationData"] = "ConversationData"
+
+    """
+
+    def dict(self, *args, **kwargs):
+        res = super().dict(*args, **kwargs)
+        res.pop('class_name')
+        return res

--- a/tests/data/annotation_types/test_label.py
+++ b/tests/data/annotation_types/test_label.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import labelbox.types as lb_types
 from labelbox import OntologyBuilder, Tool, Classification as OClassification, Option
 from labelbox.data.annotation_types import (ClassificationAnswer, Radio, Text,
                                             ClassificationAnnotation,
@@ -181,3 +182,14 @@ def test_schema_assignment_confidence():
                   ])
 
     assert label.annotations[0].confidence == 0.914
+
+
+def test_initialize_label_no_coercion():
+    global_key = 'global-key'
+    ner_annotation = lb_types.ObjectAnnotation(
+        name="ner",
+        value=lb_types.ConversationEntity(start=0, end=8, message_id="4"))
+    label = Label(data=lb_types.ConversationData(global_key=global_key),
+                  annotations=[ner_annotation])
+    assert isinstance(label.data, lb_types.ConversationData)
+    assert label.data.global_key == global_key


### PR DESCRIPTION
When creating a `Label`, the annotation data type class was being changed and the global_key field was disappearing. Example:

```
label = []
label.append(
  lb_types.Label(
    data=lb_types.ConversationData(
      global_key=global_key
    ),
    annotations=[
      ner_annotation
    ]
  )
)
```
Output
```
[Label(uid=None, data=VideoData(file_path=None,frames=None,url=None), annotations=[ObjectAnnotation(confidence=None, name='ner', feature_schema_id=None, extra={}, value=ConversationEntity(start=0, end=8, extra={}, message_id='4'), classifications=[])], extra={})]
```
The problem was that Pydantic tries to coerce objects to the first class listed in a Union. See [Pydantic docs](https://docs.pydantic.dev/usage/types/#unions) for more details.

This is fixed by adding a discriminator field (`class_name`) which is ignored during serialization.
