### PR TITLE
[AL-5269] Lift up string metadata limitation to 4096 chars

### DIFF
--- a/labelbox/schema/data_row_metadata.py
+++ b/labelbox/schema/data_row_metadata.py
@@ -33,7 +33,7 @@ class DataRowMetadataSchema(BaseModel):
 DataRowMetadataSchema.update_forward_refs()
 
 Embedding: Type[List[float]] = conlist(float, min_items=128, max_items=128)
-String: Type[str] = constr(max_length=1024)
+String: Type[str] = constr(max_length=4096)
 
 
 # Metadata base class


### PR DESCRIPTION
**Description**
Lifting up string metadata limitation to 4096 characters.