### PR TITLE
[AL-0] Fix model exports v2 flaky tests

### DIFF
--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -642,9 +642,8 @@ def model_run_with_training_metadata(rand_gen, model):
 
 
 @pytest.fixture
-def model_run_with_model_run_data_rows(client, configured_project,
-                                       model_run_predictions, model_run,
-                                       wait_for_label_processing):
+def model_run_with_data_rows(client, configured_project, model_run_predictions,
+                             model_run, wait_for_label_processing):
     configured_project.enable_model_assisted_labeling()
 
     upload_task = LabelImport.create_from_objects(

--- a/tests/integration/annotation_import/test_mea_prediction_import.py
+++ b/tests/integration/annotation_import/test_mea_prediction_import.py
@@ -11,27 +11,26 @@ from labelbox.data.serialization import NDJsonConverter
 """
 
 
-def test_create_from_url(model_run_with_model_run_data_rows,
+def test_create_from_url(model_run_with_data_rows,
                          annotation_import_test_helpers):
     name = str(uuid.uuid4())
     url = "https://storage.googleapis.com/labelbox-public-bucket/predictions_test_v2.ndjson"
-    annotation_import = model_run_with_model_run_data_rows.add_predictions(
+    annotation_import = model_run_with_data_rows.add_predictions(
         name=name, predictions=url)
-    assert annotation_import.model_run_id == model_run_with_model_run_data_rows.uid
+    assert annotation_import.model_run_id == model_run_with_data_rows.uid
     annotation_import_test_helpers.check_running_state(annotation_import, name,
                                                        url)
     annotation_import.wait_until_done()
 
 
-def test_create_from_objects(model_run_with_model_run_data_rows,
-                             object_predictions,
+def test_create_from_objects(model_run_with_data_rows, object_predictions,
                              annotation_import_test_helpers):
     name = str(uuid.uuid4())
 
-    annotation_import = model_run_with_model_run_data_rows.add_predictions(
+    annotation_import = model_run_with_data_rows.add_predictions(
         name=name, predictions=object_predictions)
 
-    assert annotation_import.model_run_id == model_run_with_model_run_data_rows.uid
+    assert annotation_import.model_run_id == model_run_with_data_rows.uid
     annotation_import_test_helpers.check_running_state(annotation_import, name)
     annotation_import_test_helpers.assert_file_content(
         annotation_import.input_file_url, object_predictions)
@@ -76,17 +75,16 @@ def test_model_run_project_labels(model_run_with_all_project_labels,
         assert actual_label['DataRow ID'] == expected_label['dataRow']['id']
 
 
-def test_create_from_label_objects(model_run_with_model_run_data_rows,
-                                   object_predictions,
+def test_create_from_label_objects(model_run_with_data_rows, object_predictions,
                                    annotation_import_test_helpers):
     name = str(uuid.uuid4())
 
     predictions = list(NDJsonConverter.deserialize(object_predictions))
 
-    annotation_import = model_run_with_model_run_data_rows.add_predictions(
+    annotation_import = model_run_with_data_rows.add_predictions(
         name=name, predictions=predictions)
 
-    assert annotation_import.model_run_id == model_run_with_model_run_data_rows.uid
+    assert annotation_import.model_run_id == model_run_with_data_rows.uid
     annotation_import_test_helpers.check_running_state(annotation_import, name)
     normalized_predictions = NDJsonConverter.serialize(predictions)
     annotation_import_test_helpers.assert_file_content(
@@ -94,7 +92,7 @@ def test_create_from_label_objects(model_run_with_model_run_data_rows,
     annotation_import.wait_until_done()
 
 
-def test_create_from_local_file(tmp_path, model_run_with_model_run_data_rows,
+def test_create_from_local_file(tmp_path, model_run_with_data_rows,
                                 object_predictions,
                                 annotation_import_test_helpers):
     name = str(uuid.uuid4())
@@ -103,37 +101,34 @@ def test_create_from_local_file(tmp_path, model_run_with_model_run_data_rows,
     with file_path.open("w") as f:
         ndjson.dump(object_predictions, f)
 
-    annotation_import = model_run_with_model_run_data_rows.add_predictions(
+    annotation_import = model_run_with_data_rows.add_predictions(
         name=name, predictions=str(file_path))
 
-    assert annotation_import.model_run_id == model_run_with_model_run_data_rows.uid
+    assert annotation_import.model_run_id == model_run_with_data_rows.uid
     annotation_import_test_helpers.check_running_state(annotation_import, name)
     annotation_import_test_helpers.assert_file_content(
         annotation_import.input_file_url, object_predictions)
     annotation_import.wait_until_done()
 
 
-def test_get(client, model_run_with_model_run_data_rows,
-             annotation_import_test_helpers):
+def test_get(client, model_run_with_data_rows, annotation_import_test_helpers):
     name = str(uuid.uuid4())
     url = "https://storage.googleapis.com/labelbox-public-bucket/predictions_test_v2.ndjson"
-    model_run_with_model_run_data_rows.add_predictions(name=name,
-                                                       predictions=url)
+    model_run_with_data_rows.add_predictions(name=name, predictions=url)
 
     annotation_import = MEAPredictionImport.from_name(
-        client, model_run_id=model_run_with_model_run_data_rows.uid, name=name)
+        client, model_run_id=model_run_with_data_rows.uid, name=name)
 
-    assert annotation_import.model_run_id == model_run_with_model_run_data_rows.uid
+    assert annotation_import.model_run_id == model_run_with_data_rows.uid
     annotation_import_test_helpers.check_running_state(annotation_import, name,
                                                        url)
     annotation_import.wait_until_done()
 
 
 @pytest.mark.slow
-def test_wait_till_done(model_run_predictions,
-                        model_run_with_model_run_data_rows):
+def test_wait_till_done(model_run_predictions, model_run_with_data_rows):
     name = str(uuid.uuid4())
-    annotation_import = model_run_with_model_run_data_rows.add_predictions(
+    annotation_import = model_run_with_data_rows.add_predictions(
         name=name, predictions=model_run_predictions)
 
     assert len(annotation_import.inputs) == len(model_run_predictions)

--- a/tests/integration/annotation_import/test_upsert_prediction_import.py
+++ b/tests/integration/annotation_import/test_upsert_prediction_import.py
@@ -12,7 +12,7 @@ from labelbox.schema.annotation_import import AnnotationImportState, MEAPredicti
 
 @pytest.mark.skip()
 def test_create_from_url(client, tmp_path, object_predictions,
-                         model_run_with_model_run_data_rows,
+                         model_run_with_data_rows,
                          configured_project_without_data_rows,
                          annotation_import_test_helpers):
     name = str(uuid.uuid4())
@@ -21,7 +21,7 @@ def test_create_from_url(client, tmp_path, object_predictions,
 
     model_run_data_rows = [
         mrdr.data_row().uid
-        for mrdr in model_run_with_model_run_data_rows.model_run_data_rows()
+        for mrdr in model_run_with_data_rows.model_run_data_rows()
     ]
     predictions = [
         p for p in object_predictions
@@ -38,13 +38,13 @@ def test_create_from_url(client, tmp_path, object_predictions,
                                  sign=True,
                                  content_type="application/json")
 
-    annotation_import, batch, mal_prediction_import = model_run_with_model_run_data_rows.upsert_predictions_and_send_to_project(
+    annotation_import, batch, mal_prediction_import = model_run_with_data_rows.upsert_predictions_and_send_to_project(
         name=name,
         predictions=url,
         project_id=configured_project_without_data_rows.uid,
         priority=5)
 
-    assert annotation_import.model_run_id == model_run_with_model_run_data_rows.uid
+    assert annotation_import.model_run_id == model_run_with_data_rows.uid
     annotation_import.wait_until_done()
     assert not annotation_import.errors
     assert annotation_import.statuses
@@ -60,26 +60,26 @@ def test_create_from_url(client, tmp_path, object_predictions,
 
 
 @pytest.mark.skip()
-def test_create_from_objects(model_run_with_model_run_data_rows,
+def test_create_from_objects(model_run_with_data_rows,
                              configured_project_without_data_rows,
                              object_predictions,
                              annotation_import_test_helpers):
     name = str(uuid.uuid4())
     model_run_data_rows = [
         mrdr.data_row().uid
-        for mrdr in model_run_with_model_run_data_rows.model_run_data_rows()
+        for mrdr in model_run_with_data_rows.model_run_data_rows()
     ]
     predictions = [
         p for p in object_predictions
         if p['dataRow']['id'] in model_run_data_rows
     ]
-    annotation_import, batch, mal_prediction_import = model_run_with_model_run_data_rows.upsert_predictions_and_send_to_project(
+    annotation_import, batch, mal_prediction_import = model_run_with_data_rows.upsert_predictions_and_send_to_project(
         name=name,
         predictions=predictions,
         project_id=configured_project_without_data_rows.uid,
         priority=5)
 
-    assert annotation_import.model_run_id == model_run_with_model_run_data_rows.uid
+    assert annotation_import.model_run_id == model_run_with_data_rows.uid
     annotation_import.wait_until_done()
     assert not annotation_import.errors
     assert annotation_import.statuses
@@ -95,7 +95,7 @@ def test_create_from_objects(model_run_with_model_run_data_rows,
 
 
 @pytest.mark.skip()
-def test_create_from_local_file(tmp_path, model_run_with_model_run_data_rows,
+def test_create_from_local_file(tmp_path, model_run_with_data_rows,
                                 configured_project_without_data_rows,
                                 object_predictions,
                                 annotation_import_test_helpers):
@@ -106,7 +106,7 @@ def test_create_from_local_file(tmp_path, model_run_with_model_run_data_rows,
 
     model_run_data_rows = [
         mrdr.data_row().uid
-        for mrdr in model_run_with_model_run_data_rows.model_run_data_rows()
+        for mrdr in model_run_with_data_rows.model_run_data_rows()
     ]
     predictions = [
         p for p in object_predictions
@@ -116,13 +116,13 @@ def test_create_from_local_file(tmp_path, model_run_with_model_run_data_rows,
     with file_path.open("w") as f:
         ndjson.dump(predictions, f)
 
-    annotation_import, batch, mal_prediction_import = model_run_with_model_run_data_rows.upsert_predictions_and_send_to_project(
+    annotation_import, batch, mal_prediction_import = model_run_with_data_rows.upsert_predictions_and_send_to_project(
         name=name,
         predictions=str(file_path),
         project_id=configured_project_without_data_rows.uid,
         priority=5)
 
-    assert annotation_import.model_run_id == model_run_with_model_run_data_rows.uid
+    assert annotation_import.model_run_id == model_run_with_data_rows.uid
     annotation_import.wait_until_done()
     assert not annotation_import.errors
     assert annotation_import.statuses


### PR DESCRIPTION
- Renamed `model_run_with_data_rows`
- Added retry logic to `model_run.exports_v2`