### PR TITLE
[AL-5110] Fix video raster annotation import

### DIFF
--- a/labelbox/data/annotation_types/video.py
+++ b/labelbox/data/annotation_types/video.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 from pydantic import BaseModel, validator
-from labelbox.data.annotation_types.annotation import BaseAnnotation, ClassificationAnnotation, ObjectAnnotation
+from labelbox.data.annotation_types.annotation import FeatureSchema, ClassificationAnnotation, ObjectAnnotation
 
 from typing import List, Optional, Tuple
 from labelbox.data.mixins import ConfidenceNotSupportedMixin
@@ -96,15 +96,14 @@ class MaskFrame(_CamelCaseMixin, BaseModel):
         return v
 
 
-class MaskInstance(_CamelCaseMixin, BaseModel):
+class MaskInstance(_CamelCaseMixin, FeatureSchema):
     color_rgb: Tuple[int, int, int]
     name: str
 
 
-class VideoMaskAnnotation(BaseAnnotation):
+class VideoMaskAnnotation(BaseModel):
     """Video mask annotation
        >>> VideoMaskAnnotation(
-       >>>     name="video_mask",
        >>>     frames=[
        >>>         MaskFrame(index=1, instance_uri='https://storage.labelbox.com/cjhfn5y6s0pk507024nz1ocys%2F1d60856c-59b7-3060-2754-83f7e93e0d01-1?Expires=1666901963361&KeyName=labelbox-assets-key-3&Signature=t-2s2DB4YjFuWEFak0wxYqfBfZA'),
        >>>         MaskFrame(index=5, instance_uri='https://storage.labelbox.com/cjhfn5y6s0pk507024nz1ocys1%2F1d60856c-59b7-3060-2754-83f7e93e0d01-1?Expires=1666901963361&KeyName=labelbox-assets-key-3&Signature=t-2s2DB4YjFuWEFak0wxYqfBfZA'),

--- a/labelbox/data/serialization/ndjson/objects.py
+++ b/labelbox/data/serialization/ndjson/objects.py
@@ -21,7 +21,7 @@ from ...annotation_types.geometry import DocumentRectangle, Rectangle, Polygon, 
 from ...annotation_types.annotation import ClassificationAnnotation, ObjectAnnotation
 from ...annotation_types.video import VideoMaskAnnotation, DICOMMaskAnnotation, MaskFrame, MaskInstance
 from .classification import NDSubclassification, NDSubclassificationType
-from .base import DataRow, NDAnnotation
+from .base import DataRow, NDAnnotation, NDJsonBase
 
 
 class NDBaseObject(NDAnnotation):
@@ -456,15 +456,13 @@ class NDVideoMasksFramesInstances(BaseModel):
     instances: List[MaskInstance]
 
 
-class NDVideoMasks(ConfidenceMixin, NDAnnotation):
+class NDVideoMasks(NDJsonBase, ConfidenceMixin):
     masks: NDVideoMasksFramesInstances
 
     def to_common(self) -> VideoMaskAnnotation:
         return VideoMaskAnnotation(
             frames=self.masks.frames,
             instances=self.masks.instances,
-            name=self.name,
-            feature_schema_id=self.schema_id,
         )
 
     @classmethod
@@ -473,8 +471,6 @@ class NDVideoMasks(ConfidenceMixin, NDAnnotation):
             data_row=DataRow(id=data.uid, global_key=data.global_key),
             masks=NDVideoMasksFramesInstances(frames=annotation.frames,
                                               instances=annotation.instances),
-            name=annotation.name,
-            schema_id=annotation.feature_schema_id,
         )
 
 
@@ -484,8 +480,6 @@ class NDDicomMasks(NDVideoMasks, DicomSupported):
         return DICOMMaskAnnotation(
             frames=self.masks.frames,
             instances=self.masks.instances,
-            name=self.name,
-            feature_schema_id=self.schema_id,
             group_key=self.group_key,
         )
 
@@ -495,8 +489,6 @@ class NDDicomMasks(NDVideoMasks, DicomSupported):
             data_row=DataRow(id=data.uid, global_key=data.global_key),
             masks=NDVideoMasksFramesInstances(frames=annotation.frames,
                                               instances=annotation.instances),
-            name=annotation.name,
-            schema_id=annotation.feature_schema_id,
             group_key=annotation.group_key.value,
         )
 

--- a/tests/data/serialization/ndjson/test_dicom.py
+++ b/tests/data/serialization/ndjson/test_dicom.py
@@ -79,15 +79,13 @@ instances = [
     lb_types.MaskInstance(color_rgb=(255, 0, 0), name="mask3")
 ]
 
-video_mask_annotation = lb_types.VideoMaskAnnotation(name="video_mask",
-                                                     frames=frames,
+video_mask_annotation = lb_types.VideoMaskAnnotation(frames=frames,
                                                      instances=instances)
 
 video_mask_annotation_ndjson = {
     'dataRow': {
         'id': 'test-uid'
     },
-    'name': 'video_mask',
     'masks': {
         'frames': [{
             'index': 1,
@@ -144,7 +142,6 @@ dicom_mask_label_with_global_key = lb_types.Label(
 
 dicom_mask_annotation_ndjson = copy(video_mask_annotation_ndjson)
 dicom_mask_annotation_ndjson['groupKey'] = 'axial'
-dicom_mask_annotation_ndjson['name'] = 'dicom_mask'
 dicom_mask_annotation_ndjson_with_global_key = copy(
     dicom_mask_annotation_ndjson)
 dicom_mask_annotation_ndjson_with_global_key['dataRow'] = {
@@ -184,7 +181,8 @@ def test_serialize_label(label, ndjson):
 @pytest.mark.parametrize('label, ndjson', labels_ndjsons)
 def test_deserialize_label(label, ndjson):
     deserialized_label = next(NDJsonConverter().deserialize([ndjson]))
-    deserialized_label.annotations[0].extra = {}
+    if hasattr(deserialized_label.annotations[0], 'extra'):
+        deserialized_label.annotations[0].extra = {}
     assert deserialized_label.annotations == label.annotations
 
 
@@ -192,5 +190,6 @@ def test_deserialize_label(label, ndjson):
 def test_serialize_deserialize_label(label):
     serialized = list(NDJsonConverter.serialize([label]))
     deserialized = list(NDJsonConverter.deserialize(serialized))
-    deserialized[0].annotations[0].extra = {}
+    if hasattr(deserialized[0].annotations[0], 'extra'):
+        deserialized[0].annotations[0].extra = {}
     assert deserialized[0].annotations == label.annotations

--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -229,6 +229,13 @@ def ontology():
         'color': '#A30059',
         'classifications': []
     }
+    raster_segmentation_tool = {
+        'required': False,
+        'name': 'segmentation_mask',
+        'tool': 'raster-segmentation',
+        'color': '#ff0000',
+        'classifications': []
+    }
     checklist = {
         'required':
             False,
@@ -285,7 +292,7 @@ def ontology():
 
     tools = [
         bbox_tool, polygon_tool, polyline_tool, point_tool, entity_tool,
-        segmentation_tool, named_entity
+        segmentation_tool, raster_segmentation_tool, named_entity
     ]
     classifications = [checklist, free_form_text, radio]
     return {"tools": tools, "classifications": classifications}


### PR DESCRIPTION
* The name field at the root of VideoMaskAnnotation is not needed since this is part of `instances`, therefore it has been removed.
* Added an integration test to ensure VideoMaskAnnotation can be imported.