### PR TITLE
[X-0] Unify naming, add support to include modelRunIds projectIds

### DIFF
--- a/labelbox/schema/data_row.py
+++ b/labelbox/schema/data_row.py
@@ -187,8 +187,8 @@ class DataRow(DbObject, Updateable, BulkDeletable):
             "performance_details": False,
             "label_details": False,
             "media_type_override": None,
-            "model_runs_ids": None,
-            "projects_ids": None,
+            "model_run_ids": None,
+            "project_ids": None,
         })
 
         mutation_name = "exportDataRowsInCatalog"
@@ -233,7 +233,11 @@ class DataRow(DbObject, Updateable, BulkDeletable):
                     "includePerformanceDetails":
                         _params.get('performance_details', False),
                     "includeLabelDetails":
-                        _params.get('label_details', False)
+                        _params.get('label_details', False),
+                    "projectIds":
+                        _params.get('project_ids', None),
+                    "modelRunIds":
+                        _params.get('model_run_ids', None),
                 },
             }
         }

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -567,8 +567,8 @@ class Dataset(DbObject, Updateable, Deletable):
             "performance_details": False,
             "label_details": False,
             "media_type_override": None,
-            "model_runs_ids": None,
-            "projects_ids": None,
+            "model_run_ids": None,
+            "project_ids": None,
         })
 
         _filters = filters or DatasetExportFilters({
@@ -622,7 +622,11 @@ class Dataset(DbObject, Updateable, Deletable):
                     "includePerformanceDetails":
                         _params.get('performance_details', False),
                     "includeLabelDetails":
-                        _params.get('label_details', False)
+                        _params.get('label_details', False),
+                    "projectIds":
+                        _params.get('project_ids', None),
+                    "modelRunIds":
+                        _params.get('model_run_ids', None),
                 },
             }
         }

--- a/labelbox/schema/export_params.py
+++ b/labelbox/schema/export_params.py
@@ -26,8 +26,8 @@ class CatalogExportParams(DataRowParams):
     project_details: Optional[bool]
     label_details: Optional[bool]
     performance_details: Optional[bool]
-    model_runs_ids: Optional[List[str]]
-    projects_ids: Optional[List[str]]
+    model_run_ids: Optional[List[str]]
+    project_ids: Optional[List[str]]
     pass
 
 

--- a/labelbox/schema/slice.py
+++ b/labelbox/schema/slice.py
@@ -85,8 +85,8 @@ class CatalogSlice(Slice):
             "performance_details": False,
             "label_details": False,
             "media_type_override": None,
-            "model_runs_ids": None,
-            "projects_ids": None,
+            "model_run_ids": None,
+            "project_ids": None,
         })
 
         mutation_name = "exportDataRowsInSlice"
@@ -118,9 +118,9 @@ class CatalogSlice(Slice):
                     "includeLabelDetails":
                         _params.get('label_details', False),
                     "projectIds":
-                        _params.get('projects_ids', None),
+                        _params.get('project_ids', None),
                     "modelRunIds":
-                        _params.get('model_runs_ids', None),
+                        _params.get('model_run_ids', None),
                 },
             }
         }


### PR DESCRIPTION
- Adds support for project_ids, model_run_ids for the remaining methods (API already supports this)
- Unifies naming (projects_ids -> project_ids, model_runs_ids -> model_run_ids) 