### PR TITLE
Fix label import test

### DIFF
--- a/tests/integration/annotation_import/test_label_import.py
+++ b/tests/integration/annotation_import/test_label_import.py
@@ -9,14 +9,13 @@ from labelbox.schema.annotation_import import AnnotationImportState, LabelImport
 """
 
 
-def test_create_from_url(client, project, annotation_import_test_helpers):
+def test_create_from_url(client, configured_project,
+                         annotation_import_test_helpers):
     name = str(uuid.uuid4())
     url = "https://storage.googleapis.com/labelbox-public-bucket/predictions_test_v2.ndjson"
-    label_import = LabelImport.create_from_url(client=client,
-                                               project_id=project.uid,
-                                               name=name,
-                                               url=url)
-    assert label_import.parent_id == project.uid
+    label_import = LabelImport.create_from_url(
+        client=client, project_id=configured_project.uid, name=name, url=url)
+    assert label_import.parent_id == configured_project.uid
     annotation_import_test_helpers.check_running_state(label_import, name, url)
 
 
@@ -53,16 +52,13 @@ def test_create_from_objects(client, configured_project, object_predictions,
 #     annotation_import_test_helpers.assert_file_content(label_import.input_file_url, object_predictions)
 
 
-def test_get(client, project, annotation_import_test_helpers):
+def test_get(client, configured_project, annotation_import_test_helpers):
     name = str(uuid.uuid4())
     url = "https://storage.googleapis.com/labelbox-public-bucket/predictions_test_v2.ndjson"
+    label_import = LabelImport.create_from_url(
+        client=client, project_id=configured_project.uid, name=name, url=url)
 
-    label_import = LabelImport.create_from_url(client=client,
-                                               project_id=project.uid,
-                                               name=name,
-                                               url=url)
-
-    assert label_import.parent_id == project.uid
+    assert label_import.parent_id == configured_project.uid
     annotation_import_test_helpers.check_running_state(label_import, name, url)
 
 


### PR DESCRIPTION
The API now validates that an ontology is linked to a project before LabelImport can be done. The two tests were using a project without ontology for label import, updating to use project with ontology.