### PR TITLE
[AL-5407] use UUID from annotation object for ConversationEntity

### DIFF
--- a/labelbox/data/serialization/ndjson/objects.py
+++ b/labelbox/data/serialization/ndjson/objects.py
@@ -583,7 +583,7 @@ class NDConversationEntity(NDTextEntity):
                    dataRow=DataRow(id=data.uid, global_key=data.global_key),
                    name=name,
                    schema_id=feature_schema_id,
-                   uuid=extra.get('uuid'),
+                   uuid=uuid,
                    classifications=classifications,
                    confidence=confidence)
 


### PR DESCRIPTION
Relationships in conversations were failing because `NDConversationEntity` objects were not using the UUIDs generated by the annotation object.