### PR TITLE
[AL-5276] Fix ISO timestamp parsing

### DIFF
--- a/labelbox/__init__.py
+++ b/labelbox/__init__.py
@@ -1,6 +1,10 @@
 name = "labelbox"
 __version__ = "3.43.0"
 
+from backports.datetime_fromisoformat import MonkeyPatch
+
+MonkeyPatch.patch_fromisoformat()
+
 from labelbox.client import Client
 from labelbox.schema.project import Project
 from labelbox.schema.model import Model

--- a/labelbox/schema/data_row_metadata.py
+++ b/labelbox/schema/data_row_metadata.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Dict, Union, Callable, Type, Any, Generator
 from pydantic import BaseModel, conlist, constr
 
 from labelbox.schema.ontology import SchemaId
-from labelbox.utils import _CamelCaseMixin
+from labelbox.utils import _CamelCaseMixin, format_iso_datetime
 
 
 class DataRowMetadataKind(Enum):
@@ -462,9 +462,9 @@ class DataRowMetadataOntology:
                 field = DataRowMetadataField(schema_id=schema.parent,
                                              value=schema.uid)
             elif schema.kind == DataRowMetadataKind.datetime:
-                field = DataRowMetadataField(
-                    schema_id=schema.uid,
-                    value=datetime.fromisoformat(f["value"][:-1] + "+00:00"))
+                field = DataRowMetadataField(schema_id=schema.uid,
+                                             value=datetime.fromisoformat(
+                                                 f["value"]))
             else:
                 field = DataRowMetadataField(schema_id=schema.uid,
                                              value=f["value"])
@@ -831,8 +831,6 @@ def _validate_parse_number(
 def _validate_parse_datetime(
         field: DataRowMetadataField) -> List[Dict[str, Union[SchemaId, str]]]:
     if isinstance(field.value, str):
-        if field.value.endswith("Z"):
-            field.value = field.value[:-1]
         field.value = datetime.fromisoformat(field.value)
     elif not isinstance(field.value, datetime):
         raise TypeError(
@@ -841,7 +839,7 @@ def _validate_parse_datetime(
 
     return [{
         "schemaId": field.schema_id,
-        "value": field.value.isoformat() + "Z",  # needs to be UTC
+        "value": format_iso_datetime(field.value)
     }]
 
 

--- a/labelbox/utils.py
+++ b/labelbox/utils.py
@@ -1,8 +1,10 @@
+import datetime
 import re
 from urllib.parse import urlparse
 from pydantic import BaseModel
 
 UPPERCASE_COMPONENTS = ['uri', 'rgb']
+ISO_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 
 def _convert(s, sep, title):
@@ -71,3 +73,11 @@ class _NoCoercionMixin:
         res = super().dict(*args, **kwargs)
         res.pop('class_name')
         return res
+
+
+def format_iso_datetime(dt: datetime.datetime) -> str:
+    """
+    Formats a datetime object into the format: 2011-11-04T00:05:23Z
+    Note that datetime.isoformat() outputs 2011-11-04T00:05:23+00:00
+    """
+    return dt.strftime(ISO_DATETIME_FORMAT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pytest-xdist
 nbformat~=5.7.0
 nbconvert~=7.2.6
 typeguard==2.13.3
+backports-datetime-fromisoformat~=2.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "backoff==1.10.0", "requests>=2.22.0", "google-api-core>=1.22.1",
-        "pydantic>=1.8,<2.0", "tqdm", "ndjson"
+        "pydantic>=1.8,<2.0", "tqdm", "ndjson",
+        "backports-datetime-fromisoformat~=2.0"
     ],
     extras_require={
         'data': [


### PR DESCRIPTION
When creating a data row, datetime metadata in the following iso format was not supported: `2011-05-07T14:34:14+00:00`. Since Python 3.7-3.10 did not have full parsing support for ISO timestamps we were doing datetime manipulation in our parsing code, which resulted in this problem. Python 3.11 has more general support for parsing ISO datetime strings, I have installed a backport to bring Python 3.11 datetime parsing to earlier versions. Tests have been adding for adding / updating datetime metadata.