### PR TITLE
Add tests for export v2 timestamp exports

### DIFF
--- a/tests/integration/annotation_import/test_data_types.py
+++ b/tests/integration/annotation_import/test_data_types.py
@@ -7,6 +7,7 @@ import uuid
 import labelbox as lb
 from labelbox.data.annotation_types.data.video import VideoData
 from labelbox.schema.data_row import DataRow
+from labelbox.schema.media_type import MediaType
 import labelbox.types as lb_types
 from labelbox.data.annotation_types.data import AudioData, ConversationData, DicomData, DocumentData, HTMLData, ImageData, TextData
 from labelbox.data.serialization import NDJsonConverter
@@ -162,6 +163,10 @@ def validate_iso_format(date_string: str):
     assert parsed_t.second is not None
 
 
+def to_pascal_case(name: str) -> str:
+    return "".join([word.capitalize() for word in name.split("_")])
+
+
 @pytest.mark.parametrize('data_type_class', [
     AudioData, HTMLData, ImageData, TextData, VideoData, ConversationData,
     DocumentData, DicomData
@@ -175,6 +180,12 @@ def test_import_data_types_v2(client, configured_project,
     project_id = configured_project.uid
 
     data_type_string = data_type_class.__name__[:-4].lower()
+
+    media_type = to_pascal_case(data_type_string)
+    if media_type == 'Conversation':
+        media_type = 'Conversational'
+    configured_project.update(media_type=MediaType[media_type])
+
     data_row_ndjson = data_row_json_by_data_type[data_type_string]
     dataset = next(configured_project.datasets())
     data_row = dataset.create_data_row(data_row_ndjson)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -642,7 +642,9 @@ class ExportV2Helpers:
                                    params={}):
         task = None
         params = params if params else {
+            "project_details": True,
             "performance_details": False,
+            "data_row_details": True,
             "label_details": True
         }
         while (num_retries > 0):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -534,6 +534,8 @@ def configured_project_with_complex_ontology(client, rand_gen, image_url):
     project.delete()
 
 
+# NOTE this is nice heuristics, also there is this logic _wait_until_data_rows_are_processed in Project
+#    in case we still have flakiness in the future, we can use it
 @pytest.fixture
 def wait_for_data_row_processing():
     """


### PR DESCRIPTION
This PR will test changes from https://labelbox.atlassian.net/browse/AL-5592
Note:
- it will require labelbox-schemas version that supports automatic conversion to isoformat (prob 0.0.34 or higher)
- we do not support workflow history export in this test. I have tested it manually. but I did not want to take extra time/risk to convert our project to BATCH mode in order to make workflow history work easily; will do this in the future