### PR TITLE
[PG-61] Don't retry on 426 error code

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -216,7 +216,7 @@ class Client:
             return None
 
         def get_error_status_code(error):
-            return error["extensions"].get("code")
+            return error["extensions"].get("exception").get("status")
 
         if check_errors(["AUTHENTICATION_ERROR"], "extensions",
                         "code") is not None:
@@ -279,6 +279,8 @@ class Client:
 
             if get_error_status_code(internal_server_error) == 400:
                 raise labelbox.exceptions.InvalidQueryError(message)
+            elif get_error_status_code(internal_server_error) == 426:
+                raise labelbox.exceptions.OperationNotAllowedException(message)
             else:
                 raise labelbox.exceptions.InternalServerError(message)
 


### PR DESCRIPTION
If a user is over their LBU limit and tries to do an operation that increases LBUs, the server responds with an error.
That error is returned as an "Internal Server Error", but has the correct 426 status and proper message nested in the error.
This code prevents the SDK from retrying if the user is over their LBU limit, and shows them a OperationNotAllowedException with the message instead. 

This also fixes a bug where the `get_error_status_code` method was looking in the wrong place for the http status code.

Example response from production:
```
{
   "message":"LBU limit exceeded, upgrade to continue",
   "locations":[
      {
         "line":1,
         "column":45
      }
   ],
   "extensions":{
      "code":"INTERNAL_SERVER_ERROR",
      "exception":{
         "response":"LBU limit exceeded, upgrade to continue",
         "status":426,
         "message":"LBU limit exceeded, upgrade to continue"
      }
   },
   "path":[
      "createDataset"
   ]
}
```