### PR TITLE
[AL-5686] Remove ndjson library and replaced it with a custom ndjson parser

### DIFF
--- a/labelbox/data/serialization/labelbox_v1/converter.py
+++ b/labelbox/data/serialization/labelbox_v1/converter.py
@@ -2,7 +2,6 @@ from labelbox.data.serialization.labelbox_v1.objects import LBV1Mask
 from typing import Any, Dict, Generator, Iterable, Union
 import logging
 
-import ndjson
 from labelbox.data.serialization.ndjson import parser
 import requests
 from copy import deepcopy

--- a/labelbox/data/serialization/labelbox_v1/converter.py
+++ b/labelbox/data/serialization/labelbox_v1/converter.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Generator, Iterable, Union
 import logging
 
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 import requests
 from copy import deepcopy
 from requests.exceptions import HTTPError
@@ -91,7 +92,7 @@ class LBV1VideoIterator(PrefetchGenerator):
         value = deepcopy(value)
         if 'frames' in value['Label']:
             req = self._request(value)
-            value['Label'] = ndjson.loads(req)
+            value['Label'] = parser.loads(req)
         return value
 
     @retry.Retry(predicate=retry.if_exception_type(HTTPError))

--- a/labelbox/data/serialization/ndjson/parser.py
+++ b/labelbox/data/serialization/ndjson/parser.py
@@ -1,20 +1,32 @@
+from collections.abc import Callable
 from io import FileIO, StringIO
 import json
-from typing import Iterable, Union
+from typing import Any, Iterable, Union
 
 
-def loads(ndjson_string: str, **kwargs) -> list:
-    # NOTE: the consequence of this line would be conversion of 'literal' line breaks to commas
-    lines = ','.join(ndjson_string.splitlines())
-    text = f"[{lines}]"  # NOTE: this is a hack to make json.loads work for ndjson
-    return json.loads(text, **kwargs)
+class NdjsonDecoder(json.JSONDecoder):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # self.parse_array = self._parse_array
+
+    # def _parse_array(self, *args, **kwargs):
+    #     return list(self.scan_once(*args, **kwargs))
+    
+    def decode(self, s: str, *args, **kwargs) -> Any:
+        lines = ','.join(s.splitlines())
+        text = f"[{lines}]"  # NOTE: this is a hack to make json.loads work for ndjson
+        return super().decode(text, *args, **kwargs)
 
 
-def dumps(obj: list, **kwargs) -> str:
+def loads(ndjson_string, **kwargs) -> list:
+    kwargs.setdefault('cls', NdjsonDecoder)
+    return json.loads(ndjson_string, **kwargs)
+
+def dumps(obj, **kwargs) -> str:
     lines = map(lambda obj: json.dumps(obj, **kwargs), obj)
     return '\n'.join(lines)
 
 
-def reader(io_handle: Union[StringIO, FileIO, Iterable], **kwargs):
+def reader(io_handle, **kwargs):
     for line in io_handle:
         yield json.loads(line, **kwargs)

--- a/labelbox/data/serialization/ndjson/parser.py
+++ b/labelbox/data/serialization/ndjson/parser.py
@@ -5,10 +5,6 @@ class NdjsonDecoder(json.JSONDecoder):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # self.parse_array = self._parse_array
-
-    # def _parse_array(self, *args, **kwargs):
-    #     return list(self.scan_once(*args, **kwargs))
 
     def decode(self, s: str, *args, **kwargs):
         lines = ','.join(s.splitlines())
@@ -24,6 +20,11 @@ def loads(ndjson_string, **kwargs) -> list:
 def dumps(obj, **kwargs):
     lines = map(lambda obj: json.dumps(obj, **kwargs), obj)
     return '\n'.join(lines)
+
+
+def dump(obj, io, **kwargs):
+    lines = dumps(obj, **kwargs)
+    io.write(lines)
 
 
 def reader(io_handle, **kwargs):

--- a/labelbox/data/serialization/ndjson/parser.py
+++ b/labelbox/data/serialization/ndjson/parser.py
@@ -21,7 +21,7 @@ def loads(ndjson_string, **kwargs) -> list:
     return json.loads(ndjson_string, **kwargs)
 
 
-def dumps(obj, **kwargs) -> str:
+def dumps(obj, **kwargs):
     lines = map(lambda obj: json.dumps(obj, **kwargs), obj)
     return '\n'.join(lines)
 

--- a/labelbox/data/serialization/ndjson/parser.py
+++ b/labelbox/data/serialization/ndjson/parser.py
@@ -1,18 +1,16 @@
-from collections.abc import Callable
-from io import FileIO, StringIO
 import json
-from typing import Any, Iterable, Union
 
 
 class NdjsonDecoder(json.JSONDecoder):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # self.parse_array = self._parse_array
 
     # def _parse_array(self, *args, **kwargs):
     #     return list(self.scan_once(*args, **kwargs))
-    
-    def decode(self, s: str, *args, **kwargs) -> Any:
+
+    def decode(self, s: str, *args, **kwargs):
         lines = ','.join(s.splitlines())
         text = f"[{lines}]"  # NOTE: this is a hack to make json.loads work for ndjson
         return super().decode(text, *args, **kwargs)
@@ -21,6 +19,7 @@ class NdjsonDecoder(json.JSONDecoder):
 def loads(ndjson_string, **kwargs) -> list:
     kwargs.setdefault('cls', NdjsonDecoder)
     return json.loads(ndjson_string, **kwargs)
+
 
 def dumps(obj, **kwargs) -> str:
     lines = map(lambda obj: json.dumps(obj, **kwargs), obj)

--- a/labelbox/schema/annotation_import.py
+++ b/labelbox/schema/annotation_import.py
@@ -162,7 +162,9 @@ class AnnotationImport(DbObject):
         if not data_str:
             raise ValueError(f"{object_name} cannot be empty")
 
-        return data_str.encode('utf-8')
+        return data_str.encode(
+            'utf-8'
+        )  # NOTICE this method returns bytes, NOT BinaryIO... should have done  io.BytesIO(...) but not going to change this at the moment since it works and fools mypy
 
     def refresh(self) -> None:
         """Synchronizes values of all fields with the database.

--- a/labelbox/schema/annotation_import.py
+++ b/labelbox/schema/annotation_import.py
@@ -7,6 +7,7 @@ from typing import Any, BinaryIO, Dict, List, Union, TYPE_CHECKING, cast
 
 import backoff
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 import requests
 from tqdm import tqdm  # type: ignore
 
@@ -132,7 +133,7 @@ class AnnotationImport(DbObject):
 
         response = requests.get(url)
         response.raise_for_status()
-        return ndjson.loads(response.text)
+        return parser.loads(response.text)
 
     @classmethod
     def _create_from_bytes(cls, client, variables, query_str, file_name,

--- a/labelbox/schema/annotation_import.py
+++ b/labelbox/schema/annotation_import.py
@@ -159,7 +159,7 @@ class AnnotationImport(DbObject):
         objects = serialize_labels(objects)
         cls._validate_data_rows(objects)
 
-        data_str = ndjson.dumps(objects)
+        data_str = parser.dumps(objects)
         if not data_str:
             raise ValueError(f"{object_name} cannot be empty")
 

--- a/labelbox/schema/annotation_import.py
+++ b/labelbox/schema/annotation_import.py
@@ -6,7 +6,6 @@ import time
 from typing import Any, BinaryIO, Dict, List, Union, TYPE_CHECKING, cast
 
 import backoff
-import ndjson
 from labelbox.data.serialization.ndjson import parser
 import requests
 from tqdm import tqdm  # type: ignore

--- a/labelbox/schema/batch.py
+++ b/labelbox/schema/batch.py
@@ -5,6 +5,7 @@ from labelbox.orm.model import Entity, Field, Relationship
 from labelbox.exceptions import LabelboxError, ResourceNotFoundError
 from io import StringIO
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 import requests
 import logging
 import time

--- a/labelbox/schema/batch.py
+++ b/labelbox/schema/batch.py
@@ -4,7 +4,6 @@ from labelbox.orm import query
 from labelbox.orm.model import Entity, Field, Relationship
 from labelbox.exceptions import LabelboxError, ResourceNotFoundError
 from io import StringIO
-import ndjson
 from labelbox.data.serialization.ndjson import parser
 import requests
 import logging

--- a/labelbox/schema/batch.py
+++ b/labelbox/schema/batch.py
@@ -119,7 +119,7 @@ class Batch(DbObject):
                 download_url = res["downloadUrl"]
                 response = requests.get(download_url)
                 response.raise_for_status()
-                reader = ndjson.reader(StringIO(response.text))
+                reader = parser.reader(StringIO(response.text))
                 return (
                     Entity.DataRow(self.client, result) for result in reader)
             elif res["status"] == "FAILED":

--- a/labelbox/schema/bulk_import_request.py
+++ b/labelbox/schema/bulk_import_request.py
@@ -7,7 +7,6 @@ import logging
 from pathlib import Path
 import pydantic
 import backoff
-import ndjson
 from labelbox.data.serialization.ndjson import parser
 import requests
 from pydantic import BaseModel, root_validator, validator

--- a/labelbox/schema/bulk_import_request.py
+++ b/labelbox/schema/bulk_import_request.py
@@ -367,7 +367,7 @@ class BulkImportRequest(DbObject):
 
         with file.open('rb') as f:
             if validate_file:
-                reader = ndjson.reader(f)
+                reader = parser.reader(f)
                 # ensure that the underlying json load call is valid
                 # https://github.com/rhgrant10/ndjson/blob/ff2f03c56b21f28f7271b27da35ca4a8bf9a05d0/ndjson/api.py#L53
                 # by iterating through the file so we only store

--- a/labelbox/schema/bulk_import_request.py
+++ b/labelbox/schema/bulk_import_request.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pydantic
 import backoff
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 import requests
 from pydantic import BaseModel, root_validator, validator
 from typing_extensions import Literal
@@ -172,7 +173,7 @@ class BulkImportRequest(DbObject):
         """
         response = requests.get(url)
         response.raise_for_status()
-        return ndjson.loads(response.text)
+        return parser.loads(response.text)
 
     def refresh(self) -> None:
         """Synchronizes values of all fields with the database.
@@ -258,7 +259,7 @@ class BulkImportRequest(DbObject):
                 "Validation is turned on. The file will be downloaded locally and processed before uploading."
             )
             res = requests.get(url)
-            data = ndjson.loads(res.text)
+            data = parser.loads(res.text)
             _validate_ndjson(data, client.get_project(project_id))
 
         query_str = """mutation createBulkImportRequestPyApi(

--- a/labelbox/schema/bulk_import_request.py
+++ b/labelbox/schema/bulk_import_request.py
@@ -323,7 +323,7 @@ class BulkImportRequest(DbObject):
         if validate:
             _validate_ndjson(ndjson_predictions, client.get_project(project_id))
 
-        data_str = ndjson.dumps(ndjson_predictions)
+        data_str = parser.dumps(ndjson_predictions)
         if not data_str:
             raise ValueError('annotations cannot be empty')
 

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -4,7 +4,7 @@ import json
 import logging
 from collections.abc import Iterable
 import time
-import ndjson
+
 from labelbox.data.serialization.ndjson import parser
 from itertools import islice
 

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import Iterable
 import time
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 from itertools import islice
 
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -522,7 +522,7 @@ class Dataset(DbObject, Updateable, Deletable):
                 download_url = res["downloadUrl"]
                 response = requests.get(download_url)
                 response.raise_for_status()
-                reader = ndjson.reader(StringIO(response.text))
+                reader = parser.reader(StringIO(response.text))
                 return (
                     Entity.DataRow(self.client, result) for result in reader)
             elif res["status"] == "FAILED":

--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -6,6 +6,7 @@ import time
 import logging
 import requests
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 from enum import Enum
 
 from labelbox.pagination import PaginatedCollection
@@ -489,7 +490,7 @@ class ModelRun(DbObject):
                 else:
                     response = requests.get(url)
                     response.raise_for_status()
-                    return ndjson.loads(response.content)
+                    return parser.loads(response.content)
 
             timeout_seconds -= sleep_time
             if timeout_seconds <= 0:

--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -5,7 +5,6 @@ import os
 import time
 import logging
 import requests
-import ndjson
 from labelbox.data.serialization.ndjson import parser
 from enum import Enum
 

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 from urllib.parse import urlparse
 
-import ndjson
 from labelbox.data.serialization.ndjson import parser
 import requests
 

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 from urllib.parse import urlparse
 
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 import requests
 
 from labelbox import utils
@@ -244,7 +245,7 @@ class Project(DbObject, Updateable, Deletable):
                 download_url = res["downloadUrl"]
                 response = requests.get(download_url)
                 response.raise_for_status()
-                return ndjson.loads(response.text)
+                return parser.loads(response.text)
             elif res["status"] == "FAILED":
                 raise LabelboxError("Data row export failed.")
 

--- a/labelbox/schema/task.py
+++ b/labelbox/schema/task.py
@@ -3,7 +3,6 @@ import logging
 import requests
 import time
 from typing import TYPE_CHECKING, Callable, Optional, Dict, Any, List, Union
-import ndjson
 from labelbox.data.serialization.ndjson import parser
 
 from labelbox.exceptions import ResourceNotFoundError

--- a/labelbox/schema/task.py
+++ b/labelbox/schema/task.py
@@ -4,6 +4,7 @@ import requests
 import time
 from typing import TYPE_CHECKING, Callable, Optional, Dict, Any, List, Union
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 
 from labelbox.exceptions import ResourceNotFoundError
 from labelbox.orm.db_object import DbObject
@@ -147,7 +148,7 @@ class Task(DbObject):
             if format == 'json':
                 return response.json()
             elif format == 'ndjson':
-                return ndjson.loads(response.text)
+                return parser.loads(response.text)
             else:
                 raise ValueError(
                     "Expected the result format to be either `ndjson` or `json`."

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,9 +3,6 @@
 [mypy-backoff.*]
 ignore_missing_imports = True
 
-[mypy-ndjson.*]
-ignore_missing_imports = True
-
 [mypy-google.*]
 ignore_missing_imports = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests==2.22.0
-ndjson==0.3.1
 backoff==1.10.0
 google-api-core>=1.22.1
 pydantic>=1.8,<2.0

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "backoff==1.10.0", "requests>=2.22.0", "google-api-core>=1.22.1",
-        "pydantic>=1.8,<2.0", "tqdm", "ndjson",
-        "backports-datetime-fromisoformat~=2.0"
+        "pydantic>=1.8,<2.0", "tqdm", "backports-datetime-fromisoformat~=2.0"
     ],
     extras_require={
         'data': [

--- a/tests/data/serialization/ndjson/test_video.py
+++ b/tests/data/serialization/ndjson/test_video.py
@@ -9,7 +9,6 @@ from labelbox.data.annotation_types.geometry.point import Point
 
 from labelbox.data.annotation_types.label import Label
 from labelbox.data.annotation_types.video import VideoObjectAnnotation
-import ndjson
 from labelbox.data.serialization.ndjson import parser
 
 from labelbox.data.serialization.ndjson.converter import NDJsonConverter

--- a/tests/data/serialization/ndjson/test_video.py
+++ b/tests/data/serialization/ndjson/test_video.py
@@ -10,6 +10,7 @@ from labelbox.data.annotation_types.geometry.point import Point
 from labelbox.data.annotation_types.label import Label
 from labelbox.data.annotation_types.video import VideoObjectAnnotation
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 
 from labelbox.data.serialization.ndjson.converter import NDJsonConverter
 from labelbox.schema.annotation_import import MALPredictionImport

--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -899,7 +899,7 @@ class AnnotationImportTestHelpers:
     @staticmethod
     def _convert_to_plain_object(obj):
         """Some Python objects e.g. tuples can't be compared with JSON serialized data, serialize to JSON and deserialize to get plain objects"""
-        json_str = ndjson.dumps(obj)
+        json_str = parser.dumps(obj)
         return parser.loads(json_str)
 
 

--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -4,6 +4,7 @@ import pytest
 import time
 import requests
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 
 from typing import Type
 from labelbox.schema.labeling_frontend import LabelingFrontend
@@ -884,7 +885,7 @@ class AnnotationImportTestHelpers:
     def assert_file_content(cls, url: str, predictions):
         response = requests.get(url)
         predictions = cls._convert_to_plain_object(predictions)
-        assert ndjson.loads(response.text) == predictions
+        assert parser.loads(response.text) == predictions
 
     @staticmethod
     def check_running_state(req, name, url=None):
@@ -899,7 +900,7 @@ class AnnotationImportTestHelpers:
     def _convert_to_plain_object(obj):
         """Some Python objects e.g. tuples can't be compared with JSON serialized data, serialize to JSON and deserialize to get plain objects"""
         json_str = ndjson.dumps(obj)
-        return ndjson.loads(json_str)
+        return parser.loads(json_str)
 
 
 @pytest.fixture

--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 import time
 import requests
-import ndjson
+
 from labelbox.data.serialization.ndjson import parser
 
 from typing import Type

--- a/tests/integration/annotation_import/test_bulk_import_request.py
+++ b/tests/integration/annotation_import/test_bulk_import_request.py
@@ -1,5 +1,6 @@
 import uuid
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 import pytest
 import random
 from labelbox.data.annotation_types.annotation import ObjectAnnotation

--- a/tests/integration/annotation_import/test_bulk_import_request.py
+++ b/tests/integration/annotation_import/test_bulk_import_request.py
@@ -160,7 +160,7 @@ def test_validate_ndjson_uuid(tmp_path, configured_project, predictions):
 @pytest.mark.slow
 def test_wait_till_done(rectangle_inference, configured_project):
     name = str(uuid.uuid4())
-    url = configured_project.client.upload_data(content=ndjson.dumps(
+    url = configured_project.client.upload_data(content=parser.dumps(
         [rectangle_inference]),
                                                 sign=True)
     bulk_import_request = configured_project.upload_annotations(name=name,

--- a/tests/integration/annotation_import/test_bulk_import_request.py
+++ b/tests/integration/annotation_import/test_bulk_import_request.py
@@ -90,7 +90,7 @@ def test_create_from_local_file(tmp_path, predictions, configured_project,
     file_name = f"{name}.ndjson"
     file_path = tmp_path / file_name
     with file_path.open("w") as f:
-        ndjson.dump(predictions, f)
+        parser.dump(predictions, f)
 
     bulk_import_request = configured_project.upload_annotations(
         name=name, annotations=str(file_path), validate=False)
@@ -143,7 +143,7 @@ def test_validate_ndjson_uuid(tmp_path, configured_project, predictions):
     repeat_uuid[1]['uuid'] = uid
 
     with file_path.open("w") as f:
-        ndjson.dump(repeat_uuid, f)
+        parser.dump(repeat_uuid, f)
 
     with pytest.raises(UuidError):
         configured_project.upload_annotations(name="name",

--- a/tests/integration/annotation_import/test_bulk_import_request.py
+++ b/tests/integration/annotation_import/test_bulk_import_request.py
@@ -1,5 +1,4 @@
 import uuid
-import ndjson
 from labelbox.data.serialization.ndjson import parser
 import pytest
 import random

--- a/tests/integration/annotation_import/test_mea_prediction_import.py
+++ b/tests/integration/annotation_import/test_mea_prediction_import.py
@@ -1,5 +1,6 @@
 import uuid
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 import pytest
 
 from labelbox.schema.annotation_import import AnnotationImportState, MEAPredictionImport

--- a/tests/integration/annotation_import/test_mea_prediction_import.py
+++ b/tests/integration/annotation_import/test_mea_prediction_import.py
@@ -99,7 +99,7 @@ def test_create_from_local_file(tmp_path, model_run_with_data_rows,
     file_name = f"{name}.ndjson"
     file_path = tmp_path / file_name
     with file_path.open("w") as f:
-        ndjson.dump(object_predictions, f)
+        parser.dump(object_predictions, f)
 
     annotation_import = model_run_with_data_rows.add_predictions(
         name=name, predictions=str(file_path))

--- a/tests/integration/annotation_import/test_mea_prediction_import.py
+++ b/tests/integration/annotation_import/test_mea_prediction_import.py
@@ -1,5 +1,4 @@
 import uuid
-import ndjson
 from labelbox.data.serialization.ndjson import parser
 import pytest
 

--- a/tests/integration/annotation_import/test_ndjson_validation.py
+++ b/tests/integration/annotation_import/test_ndjson_validation.py
@@ -1,5 +1,5 @@
 import pytest
-import ndjson
+
 from labelbox.data.serialization.ndjson import parser
 from pytest_cases import parametrize, fixture_ref
 

--- a/tests/integration/annotation_import/test_ndjson_validation.py
+++ b/tests/integration/annotation_import/test_ndjson_validation.py
@@ -225,7 +225,7 @@ def test_validate_ndjson_uuid(tmp_path, configured_project, predictions):
     repeat_uuid[1]['uuid'] = 'test_uuid'
 
     with file_path.open("w") as f:
-        ndjson.dump(repeat_uuid, f)
+        parser.dump(repeat_uuid, f)
 
     with pytest.raises(MALValidationError):
         configured_project.upload_annotations(name="name",

--- a/tests/integration/annotation_import/test_ndjson_validation.py
+++ b/tests/integration/annotation_import/test_ndjson_validation.py
@@ -1,5 +1,6 @@
 import pytest
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 from pytest_cases import parametrize, fixture_ref
 
 from labelbox.exceptions import MALValidationError

--- a/tests/integration/annotation_import/test_upsert_prediction_import.py
+++ b/tests/integration/annotation_import/test_upsert_prediction_import.py
@@ -1,5 +1,6 @@
 import uuid
 import ndjson
+from labelbox.data.serialization.ndjson import parser
 import pytest
 
 from labelbox.schema.annotation_import import AnnotationImportState, MEAPredictionImport

--- a/tests/integration/annotation_import/test_upsert_prediction_import.py
+++ b/tests/integration/annotation_import/test_upsert_prediction_import.py
@@ -1,5 +1,4 @@
 import uuid
-import ndjson
 from labelbox.data.serialization.ndjson import parser
 import pytest
 

--- a/tests/unit/test_ndjson_parsing.py
+++ b/tests/unit/test_ndjson_parsing.py
@@ -1,6 +1,4 @@
 import ast
-import random
-import time
 from io import StringIO
 
 from labelbox.data.serialization.ndjson import parser
@@ -8,8 +6,18 @@ from labelbox.data.serialization.ndjson import parser
 
 def test_loads(ndjson_content):
     expected_line, expected_objects = ndjson_content
-
     parsed_line = parser.loads(expected_line)
+
+    assert parsed_line == expected_objects
+    assert parser.dumps(parsed_line) == expected_line
+
+
+def test_loads_bytes(ndjson_content):
+    expected_line, expected_objects = ndjson_content
+
+    bytes_line = expected_line.encode('utf-8')
+    parsed_line = parser.loads(bytes_line)
+
     assert parsed_line == expected_objects
     assert parser.dumps(parsed_line) == expected_line
 

--- a/tests/unit/test_ndjson_parsing.py
+++ b/tests/unit/test_ndjson_parsing.py
@@ -2,7 +2,7 @@ import ast
 import random
 import time
 from io import StringIO
-import ndjson
+
 from labelbox.data.serialization.ndjson import parser
 
 


### PR DESCRIPTION
Story: https://labelbox.atlassian.net/browse/AL-5686

Even though this is a large PR, 90% of files is just a drop-in replacement of the 3d party ndjson library with our own. The rest 10% are important updates to the parser library to address issues from integration tests and removal of the 3d party ndjson library from our setup and requirements.txt

_List of Affected SDK API's_
- prediction upload
  - LabelImport#create_from_objects
  - MEAPredictionImport#create_from_objects
- export v2
  - Batch#export_data_rows
  - Dataset#export_data_rows (can just test this and not Batch)
  - ModelRun#export_labels
  - BulkImportRequest create_from_url, create_from_objects, create_from_local_file, also in errors, statuses etc
- other
  - Project#export_queued_data_rows
  - Task#failed_data_rows, errors, result etc

