### PR TITLE
[AL-0] Pin typing-extensions library to 4.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ opencv-python
 imagesize
 pyproj
 pygeotile
-typing-extensions
+typing-extensions==4.5.0
 pytest-xdist
 nbformat~=5.7.0
 nbconvert~=7.2.6


### PR DESCRIPTION
`typing-extensions` got a new minor version which is not compatible with our SDK
```
File "/usr/local/lib/python3.9/site-packages/labelbox-3.46.0-py3.9.egg/labelbox/data/annotation_types/data/audio.py", line 6, in <module>             
    class AudioData(BaseData, _NoCoercionMixin):                                                                                                        
  File "pydantic/main.py", line 197, in pydantic.main.ModelMetaclass.__new__                                                                            
  File "pydantic/fields.py", line 506, in pydantic.fields.ModelField.infer                                                                              
  File "pydantic/fields.py", line 436, in pydantic.fields.ModelField.__init__                                                                           
  File "pydantic/fields.py", line 552, in pydantic.fields.ModelField.prepare                                                                            
  File "pydantic/fields.py", line 668, in pydantic.fields.ModelField._type_analysis                                                                     
  File "/usr/local/lib/python3.9/typing.py", line 852, in __subclasscheck__                                                                             
    return issubclass(cls, self.__origin__)                                                                                                             
TypeError: issubclass() arg 1 must be a class
```