### PR TITLE
Prep for sdk release 3.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+# Version 3.47.0 (2023-05-23)
+## Added
+* Support for interpolated frames to export v2
+
+## Changed
+* Removed ndjson library and replaced it with a custom ndjson parser
+
+## Notebooks
+* Removed confidence scores in annotations - video notebook
+* Removed raster seg masks from video prediction
+* Added export v2 example
+* Added SAM and Labelbox connector notebook
+
 # Version 3.46.0 (2023-05-03)
 ## Added
 * Global key support to DataRow Metadata `bulk_upsert()` function

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ project = 'Python SDK reference'
 copyright = '2021, Labelbox'
 author = 'Labelbox'
 
-release = '3.46.0'
+release = '3.47.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/labelbox/__init__.py
+++ b/labelbox/__init__.py
@@ -1,5 +1,5 @@
 name = "labelbox"
-__version__ = "3.46.0"
+__version__ = "3.47.0"
 
 from backports.datetime_fromisoformat import MonkeyPatch
 


### PR DESCRIPTION
# Version 3.47.0 (2023-05-23)
## Added
* Support for interpolated frames to export v2

## Changed
* Removed ndjson library and replaced it with a custom ndjson parser
## Notebooks
* Remove confidence scores in annotations - video notebook
* Remove raster seg masks from video prediction
* Added export v2 example
* Add SAM and Labelbox connector notebook
