### PR TITLE
[QQC-2017]Return batch size of accepted data rows only

### DIFF
--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -794,7 +794,7 @@ class Project(DbObject, Updateable, Deletable):
                                   timeout=180.0,
                                   experimental=True)["project"][method]
         batch = res['batch']
-        batch['size'] = len(dr_ids)
+        batch['size'] = res['batch']['size']
         return Entity.Batch(self.client,
                             self.uid,
                             batch,


### PR DESCRIPTION
Previously batch size was set for all the data rows submitted instead of the ones accepted by the Labelbox backend. This PR is to set the backend response's batch size for the returned entity instead of the length of the inputted list.