### PR TITLE
Vb/freetext confidence al 6008

### DIFF
--- a/labelbox/data/serialization/ndjson/classification.py
+++ b/labelbox/data/serialization/ndjson/classification.py
@@ -64,12 +64,15 @@ class NDTextSubclass(NDAnswer):
     answer: str
 
     def to_common(self) -> Text:
-        return Text(answer=self.answer)
+        return Text(answer=self.answer, confidence=self.confidence)
 
     @classmethod
     def from_common(cls, text: Text, name: str,
                     feature_schema_id: Cuid) -> "NDTextSubclass":
-        return cls(answer=text.answer, name=name, schema_id=feature_schema_id)
+        return cls(answer=text.answer,
+                   name=name,
+                   schema_id=feature_schema_id,
+                   confidence=text.confidence)
 
 
 class NDChecklistSubclass(NDAnswer):
@@ -161,7 +164,7 @@ class NDText(NDAnnotation, NDTextSubclass):
             schema_id=feature_schema_id,
             uuid=uuid,
             message_id=message_id,
-            confidence=confidence,
+            confidence=text.confidence,
         )
 
 
@@ -273,7 +276,6 @@ class NDClassification:
             feature_schema_id=annotation.schema_id,
             extra={'uuid': annotation.uuid},
             message_id=annotation.message_id,
-            confidence=annotation.confidence,
         )
 
         if getattr(annotation, 'frames', None) is None:

--- a/labelbox/data/serialization/ndjson/classification.py
+++ b/labelbox/data/serialization/ndjson/classification.py
@@ -276,6 +276,7 @@ class NDClassification:
             feature_schema_id=annotation.schema_id,
             extra={'uuid': annotation.uuid},
             message_id=annotation.message_id,
+            confidence=annotation.confidence,
         )
 
         if getattr(annotation, 'frames', None) is None:

--- a/tests/data/serialization/ndjson/test_free_text.py
+++ b/tests/data/serialization/ndjson/test_free_text.py
@@ -1,0 +1,103 @@
+from labelbox.data.annotation_types.annotation import ClassificationAnnotation
+from labelbox.data.annotation_types.classification.classification import Checklist, ClassificationAnswer, Radio, Text
+from labelbox.data.annotation_types.data.text import TextData
+from labelbox.data.annotation_types.label import Label
+
+from labelbox.data.serialization.ndjson.converter import NDJsonConverter
+
+
+def test_serialization():
+    label = Label(uid="ckj7z2q0b0000jx6x0q2q7q0d",
+                  data=TextData(
+                      uid="bkj7z2q0b0000jx6x0q2q7q0d",
+                      text="This is a test",
+                  ),
+                  annotations=[
+                      ClassificationAnnotation(name="free_text_annotation",
+                                               value=Text(confidence=0.5,
+                                                          answer="text_answer"))
+                  ])
+
+    serialized = NDJsonConverter.serialize([label])
+    res = next(serialized)
+
+    assert res['confidence'] == 0.5
+    assert res['name'] == "free_text_annotation"
+    assert res['answer'] == "text_answer"
+    assert res['dataRow']['id'] == "bkj7z2q0b0000jx6x0q2q7q0d"
+
+    deserialized = NDJsonConverter.deserialize([res])
+    res = next(deserialized)
+
+    annotation = res.annotations[0]
+
+    annotation_value = annotation.value
+    assert type(annotation_value) is Text
+    assert annotation_value.answer == "text_answer"
+    assert annotation_value.confidence == 0.5
+
+
+def test_nested_serialization():
+    label = Label(
+        uid="ckj7z2q0b0000jx6x0q2q7q0d",
+        data=TextData(
+            uid="bkj7z2q0b0000jx6x0q2q7q0d",
+            text="This is a test",
+        ),
+        annotations=[
+            ClassificationAnnotation(
+                name="nested test",
+                value=Checklist(answer=[
+                    ClassificationAnswer(
+                        name="first_answer",
+                        confidence=0.9,
+                        classifications=[
+                            ClassificationAnnotation(
+                                name="sub_radio_question",
+                                value=Radio(answer=ClassificationAnswer(
+                                    name="first_sub_radio_answer",
+                                    confidence=0.8,
+                                    classifications=[
+                                        ClassificationAnnotation(
+                                            name="nested answer",
+                                            value=Text(
+                                                answer="nested answer",
+                                                confidence=0.7,
+                                            ))
+                                    ])))
+                        ])
+                ]),
+            )
+        ])
+
+    serialized = NDJsonConverter.serialize([label])
+    res = next(serialized)
+
+    assert res['dataRow']['id'] == "bkj7z2q0b0000jx6x0q2q7q0d"
+    answer = res['answer'][0]
+    assert answer['confidence'] == 0.9
+    assert answer['name'] == "first_answer"
+    classification = answer['classifications'][0]
+    nested_classification_answer = classification['answer']
+    assert nested_classification_answer['confidence'] == 0.8
+    assert nested_classification_answer['name'] == "first_sub_radio_answer"
+    sub_classification = nested_classification_answer['classifications'][0]
+    assert sub_classification['name'] == "nested answer"
+    assert sub_classification['answer'] == "nested answer"
+    assert sub_classification['confidence'] == 0.7
+
+    deserialized = NDJsonConverter.deserialize([res])
+    res = next(deserialized)
+    annotation = res.annotations[0]
+    answer = annotation.value.answer[0]
+    assert answer.confidence == 0.9
+    assert answer.name == "first_answer"
+
+    classification_answer = answer.classifications[0].value.answer
+    assert classification_answer.confidence == 0.8
+    assert classification_answer.name == "first_sub_radio_answer"
+
+    sub_classification_answer = classification_answer.classifications[0].value
+    assert type(sub_classification_answer) is Text
+    assert sub_classification_answer.answer == "nested answer"
+    assert sub_classification_answer.confidence == 0.7

--- a/tests/data/serialization/ndjson/test_text.py
+++ b/tests/data/serialization/ndjson/test_text.py
@@ -1,5 +1,5 @@
 from labelbox.data.annotation_types.annotation import ClassificationAnnotation
-from labelbox.data.annotation_types.classification.classification import Checklist, ClassificationAnswer, Radio, Text
+from labelbox.data.annotation_types.classification.classification import ClassificationAnswer, Radio, Text
 from labelbox.data.annotation_types.data.text import TextData
 from labelbox.data.annotation_types.label import Label
 
@@ -13,92 +13,23 @@ def test_serialization():
                       text="This is a test",
                   ),
                   annotations=[
-                      ClassificationAnnotation(name="free_text_annotation",
-                                               value=Text(confidence=0.5,
-                                                          answer="text_answer"))
+                      ClassificationAnnotation(
+                          name="radio_question_geo",
+                          confidence=0.5,
+                          value=Text(answer="first_radio_answer"))
                   ])
 
     serialized = NDJsonConverter.serialize([label])
     res = next(serialized)
-
-    assert res['confidence'] == 0.5
-    assert res['name'] == "free_text_annotation"
-    assert res['answer'] == "text_answer"
+    assert 'confidence' not in res  # because confidence needs to be set on the annotation itself
+    assert res['name'] == "radio_question_geo"
+    assert res['answer'] == "first_radio_answer"
     assert res['dataRow']['id'] == "bkj7z2q0b0000jx6x0q2q7q0d"
 
     deserialized = NDJsonConverter.deserialize([res])
     res = next(deserialized)
-
     annotation = res.annotations[0]
-    answer = annotation.value.answer
 
     annotation_value = annotation.value
     assert type(annotation_value) is Text
-    assert annotation_value.answer == "text_answer"
-    assert annotation_value.confidence == 0.5
-
-
-def test_nested_serialization():
-    label = Label(
-        uid="ckj7z2q0b0000jx6x0q2q7q0d",
-        data=TextData(
-            uid="bkj7z2q0b0000jx6x0q2q7q0d",
-            text="This is a test",
-        ),
-        annotations=[
-            ClassificationAnnotation(
-                name="nested test",
-                value=Checklist(answer=[
-                    ClassificationAnswer(
-                        name="first_answer",
-                        confidence=0.9,
-                        classifications=[
-                            ClassificationAnnotation(
-                                name="sub_radio_question",
-                                value=Radio(answer=ClassificationAnswer(
-                                    name="first_sub_radio_answer",
-                                    confidence=0.8,
-                                    classifications=[
-                                        ClassificationAnnotation(
-                                            name="nested answer",
-                                            value=Text(
-                                                answer="nested answer",
-                                                confidence=0.7,
-                                            ))
-                                    ])))
-                        ])
-                ]),
-            )
-        ])
-
-    serialized = NDJsonConverter.serialize([label])
-    res = next(serialized)
-
-    assert res['dataRow']['id'] == "bkj7z2q0b0000jx6x0q2q7q0d"
-    answer = res['answer'][0]
-    assert answer['confidence'] == 0.9
-    assert answer['name'] == "first_answer"
-    classification = answer['classifications'][0]
-    nested_classification_answer = classification['answer']
-    assert nested_classification_answer['confidence'] == 0.8
-    assert nested_classification_answer['name'] == "first_sub_radio_answer"
-    sub_classification = nested_classification_answer['classifications'][0]
-    assert sub_classification['name'] == "nested answer"
-    assert sub_classification['answer'] == "nested answer"
-    assert sub_classification['confidence'] == 0.7
-
-    deserialized = NDJsonConverter.deserialize([res])
-    res = next(deserialized)
-    annotation = res.annotations[0]
-    answer = annotation.value.answer[0]
-    assert answer.confidence == 0.9
-    assert answer.name == "first_answer"
-
-    classification_answer = answer.classifications[0].value.answer
-    assert classification_answer.confidence == 0.8
-    assert classification_answer.name == "first_sub_radio_answer"
-
-    sub_classification_answer = classification_answer.classifications[0].value
-    assert type(sub_classification_answer) is Text
-    assert sub_classification_answer.answer == "nested answer"
-    assert sub_classification_answer.confidence == 0.7
+    assert annotation_value.answer == "first_radio_answer"

--- a/tests/data/serialization/ndjson/test_text.py
+++ b/tests/data/serialization/ndjson/test_text.py
@@ -1,5 +1,5 @@
 from labelbox.data.annotation_types.annotation import ClassificationAnnotation
-from labelbox.data.annotation_types.classification.classification import ClassificationAnswer, Radio, Text
+from labelbox.data.annotation_types.classification.classification import Checklist, ClassificationAnswer, Radio, Text
 from labelbox.data.annotation_types.data.text import TextData
 from labelbox.data.annotation_types.label import Label
 
@@ -13,40 +13,92 @@ def test_serialization():
                       text="This is a test",
                   ),
                   annotations=[
-                      ClassificationAnnotation(
-                          name="radio_question_geo",
-                          confidence=0.5,
-                          value=Text(answer="first_radio_answer"))
+                      ClassificationAnnotation(name="free_text_annotation",
+                                               value=Text(confidence=0.5,
+                                                          answer="text_answer"))
                   ])
 
     serialized = NDJsonConverter.serialize([label])
     res = next(serialized)
+
     assert res['confidence'] == 0.5
-    assert res['name'] == "radio_question_geo"
-    assert res['answer'] == "first_radio_answer"
+    assert res['name'] == "free_text_annotation"
+    assert res['answer'] == "text_answer"
     assert res['dataRow']['id'] == "bkj7z2q0b0000jx6x0q2q7q0d"
 
     deserialized = NDJsonConverter.deserialize([res])
     res = next(deserialized)
+
     annotation = res.annotations[0]
-    assert annotation.confidence == 0.5
+    answer = annotation.value.answer
 
     annotation_value = annotation.value
     assert type(annotation_value) is Text
-    assert annotation_value.answer == "first_radio_answer"
+    assert annotation_value.answer == "text_answer"
+    assert annotation_value.confidence == 0.5
+
+
+def test_nested_serialization():
+    label = Label(
+        uid="ckj7z2q0b0000jx6x0q2q7q0d",
+        data=TextData(
+            uid="bkj7z2q0b0000jx6x0q2q7q0d",
+            text="This is a test",
+        ),
+        annotations=[
+            ClassificationAnnotation(
+                name="nested test",
+                value=Checklist(answer=[
+                    ClassificationAnswer(
+                        name="first_answer",
+                        confidence=0.9,
+                        classifications=[
+                            ClassificationAnnotation(
+                                name="sub_radio_question",
+                                value=Radio(answer=ClassificationAnswer(
+                                    name="first_sub_radio_answer",
+                                    confidence=0.8,
+                                    classifications=[
+                                        ClassificationAnnotation(
+                                            name="nested answer",
+                                            value=Text(
+                                                answer="nested answer",
+                                                confidence=0.7,
+                                            ))
+                                    ])))
+                        ])
+                ]),
+            )
+        ])
 
     serialized = NDJsonConverter.serialize([label])
     res = next(serialized)
-    assert res['confidence'] == 0.5
-    assert res['name'] == "radio_question_geo"
-    assert res['answer'] == "first_radio_answer"
+
     assert res['dataRow']['id'] == "bkj7z2q0b0000jx6x0q2q7q0d"
+    answer = res['answer'][0]
+    assert answer['confidence'] == 0.9
+    assert answer['name'] == "first_answer"
+    classification = answer['classifications'][0]
+    nested_classification_answer = classification['answer']
+    assert nested_classification_answer['confidence'] == 0.8
+    assert nested_classification_answer['name'] == "first_sub_radio_answer"
+    sub_classification = nested_classification_answer['classifications'][0]
+    assert sub_classification['name'] == "nested answer"
+    assert sub_classification['answer'] == "nested answer"
+    assert sub_classification['confidence'] == 0.7
 
     deserialized = NDJsonConverter.deserialize([res])
     res = next(deserialized)
     annotation = res.annotations[0]
-    assert annotation.confidence == 0.5
+    answer = annotation.value.answer[0]
+    assert answer.confidence == 0.9
+    assert answer.name == "first_answer"
 
-    annotation_value = annotation.value
-    assert type(annotation_value) is Text
-    assert annotation_value.answer == "first_radio_answer"
+    classification_answer = answer.classifications[0].value.answer
+    assert classification_answer.confidence == 0.8
+    assert classification_answer.name == "first_sub_radio_answer"
+
+    sub_classification_answer = classification_answer.classifications[0].value
+    assert type(sub_classification_answer) is Text
+    assert sub_classification_answer.answer == "nested answer"
+    assert sub_classification_answer.confidence == 0.7

--- a/tests/integration/annotation_import/test_mea_prediction_import.py
+++ b/tests/integration/annotation_import/test_mea_prediction_import.py
@@ -37,6 +37,31 @@ def test_create_from_objects(model_run_with_data_rows, object_predictions,
     annotation_import.wait_until_done()
 
 
+def test_create_from_objects_with_confidence(predictions_with_confidence,
+                                             model_run_with_data_rows,
+                                             annotation_import_test_helpers):
+    name = str(uuid.uuid4())
+
+    object_prediction_data_rows = [
+        object_prediction["dataRow"]["id"]
+        for object_prediction in predictions_with_confidence
+    ]
+    # MUST have all data rows in the model run
+    model_run_with_data_rows.upsert_data_rows(
+        data_row_ids=object_prediction_data_rows)
+
+    annotation_import = model_run_with_data_rows.add_predictions(
+        name=name, predictions=predictions_with_confidence)
+
+    assert annotation_import.model_run_id == model_run_with_data_rows.uid
+    annotation_import_test_helpers.check_running_state(annotation_import, name)
+    annotation_import_test_helpers.assert_file_content(
+        annotation_import.input_file_url, predictions_with_confidence)
+    annotation_import.wait_until_done()
+    annotation_import_test_helpers.download_and_assert_status(
+        annotation_import.status_file_url)
+
+
 def test_create_from_objects_all_project_labels(
         model_run_with_all_project_labels, object_predictions,
         annotation_import_test_helpers):


### PR DESCRIPTION
Story: https://labelbox.atlassian.net/browse/AL-6008

We are able to support confidence on both free text and nested free text by just moving the `confidence` attribute to `Text` when we convert date to_ from_common. The attribute itself has already been defined via pydantic

Also added unit tests, integration test and test via a notebook