### PR TITLE
[X-0] batch_id -> batch_ids

### DIFF
--- a/labelbox/schema/export_filters.py
+++ b/labelbox/schema/export_filters.py
@@ -37,10 +37,10 @@ class SharedExportFilters(TypedDict):
 
 
 class ProjectExportFilters(SharedExportFilters):
-    batch_id: Optional[str]
-    """ Batch id to export
+    batch_ids: Optional[List[str]]
+    """ Batch ids to export
     Example:
-    >>> "clgo3lyax0000veeezdbu3ws4"
+    >>> ["clgo3lyax0000veeezdbu3ws4"]
     """
 
 
@@ -183,11 +183,18 @@ def build_filters(client, filters):
             "type": "data_row_id"
         })
 
-    batch_id = filters.get("batch_id")
-    if batch_id:
+    batch_ids = filters.get("batch_ids")
+    if batch_ids:
+        if not isinstance(batch_ids, list):
+            raise ValueError("`batch_ids` filter expects a list.")
+        if len(batch_ids) > MAX_DATA_ROW_IDS_PER_EXPORT_V2:
+            raise ValueError(
+                f"`batch_ids` filter only supports a max of {MAX_DATA_ROW_IDS_PER_EXPORT_V2} items."
+            )
         search_query.append({
-            "ids": [batch_id],
+            "ids": batch_ids,
             "operator": "is",
             "type": "batch"
         })
+
     return search_query

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -442,7 +442,7 @@ class Project(DbObject, Updateable, Deletable):
             "last_activity_at": None,
             "label_created_at": None,
             "data_row_ids": None,
-            "batch_id": None,
+            "batch_ids": None,
         })
 
         mutation_name = "exportDataRowsInProject"

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -55,7 +55,7 @@ def test_batch_project_export_v2(
     filters = {
         "last_activity_at": ["2000-01-01 00:00:00", "2050-01-01 00:00:00"],
         "label_created_at": ["2000-01-01 00:00:00", "2050-01-01 00:00:00"],
-        "batch_id": batch.uid,
+        "batch_ids": [batch.uid],
     }
     params = {
         "include_performance_details": True,


### PR DESCRIPTION
It's more robust, the limits are the same as for the drws due to ElasticSearch