### PR TITLE
[X-0] Further numpy fixes

### DIFF
--- a/labelbox/data/annotation_types/types.py
+++ b/labelbox/data/annotation_types/types.py
@@ -36,7 +36,10 @@ class _TypedArray(np.ndarray, Generic[DType, DShape]):
         return val
 
 
-if version.parse(np.__version__) >= version.parse('1.23.0'):
+if version.parse(np.__version__) >= version.parse('1.25.0'):
+    from typing import GenericAlias
+    TypedArray = GenericAlias(_TypedArray, (Any, DType))
+elif version.parse(np.__version__) >= version.parse('1.23.0'):
     from numpy._typing import _GenericAlias
     TypedArray = _GenericAlias(_TypedArray, (Any, DType))
 elif version.parse('1.22.0') <= version.parse(

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setuptools.setup(
         "tqdm",
         "python-dateutil>=2.8.2,<2.9.0",
         'numpy==1.21.6; python_version<"3.8"',
-        'numpy~=1.23.5; python_version>="3.8"',
+        'numpy~=1.23.5; python_version=="3.8"',
+        'numpy~=1.25.0; python_version>"3.8"',
     ],
     extras_require={
         'data': [


### PR DESCRIPTION
Numpy 1.25.0 removes _ GenericAlias in favour of py39 native GenericAlias
