### PR TITLE
[X-0] Remkve numpy version lockdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ shapely
 tqdm
 typeguard==2.13.3
 typing-extensions==4.5.0
+numpy

--- a/setup.py
+++ b/setup.py
@@ -20,15 +20,8 @@ setuptools.setup(
     url="https://labelbox.com",
     packages=setuptools.find_packages(),
     install_requires=[
-        "backoff==1.10.0",
-        "requests>=2.22.0",
-        "google-api-core>=1.22.1",
-        "pydantic>=1.8,<2.0",
-        "tqdm",
-        "python-dateutil>=2.8.2,<2.9.0",
-        'numpy==1.21.6; python_version<"3.8"',
-        'numpy~=1.23.5; python_version=="3.8"',
-        'numpy~=1.25.0; python_version>"3.8"',
+        "backoff==1.10.0", "requests>=2.22.0", "google-api-core>=1.22.1",
+        "pydantic>=1.8,<2.0", "tqdm", "python-dateutil>=2.8.2,<2.9.0"
     ],
     extras_require={
         'data': [


### PR DESCRIPTION
All numpy versions are supported now and Google Colab provides 1.22 by default for Python 3.10 by default, meaning that workspace has to be reloaded initially with current requirements(hence the requirement removal).