### PR TITLE
[AL-6294] Support cursor-based pagination for dataset.data_rows()

### DIFF
--- a/labelbox/orm/model.py
+++ b/labelbox/orm/model.py
@@ -244,6 +244,7 @@ class Relationship:
         self.filter_deleted = filter_deleted
         self.cache = cache
         self.deprecation_warning = deprecation_warning
+        self.graphql_name = graphql_name
 
         if name is None:
             name = utils.snake_case(destination_type_name) + (

--- a/labelbox/orm/model.py
+++ b/labelbox/orm/model.py
@@ -244,7 +244,6 @@ class Relationship:
         self.filter_deleted = filter_deleted
         self.cache = cache
         self.deprecation_warning = deprecation_warning
-        self.graphql_name = graphql_name
 
         if name is None:
             name = utils.snake_case(destination_type_name) + (

--- a/labelbox/orm/query.py
+++ b/labelbox/orm/query.py
@@ -1,4 +1,5 @@
 from itertools import chain
+from typing import Any, Dict
 
 from labelbox import utils
 from labelbox.exceptions import InvalidQueryError, InvalidAttributeError, MalformedQueryException
@@ -448,3 +449,24 @@ def bulk_delete(db_objects, use_where_clause):
         utils.camel_case(type_name), ", ".join(
             '"%s"' % db_object.uid for db_object in db_objects))
     return query_str, {}
+
+
+def where_as_dict(entity, node: Comparison) -> Dict[str, Any]:
+    check_where_clause(entity, node)
+    """ Helper that constructs a where clause from a Comparison node. """
+    COMPARISON_TO_SUFFIX = {
+        Comparison.Op.EQ: "",
+        Comparison.Op.NE: "_not",
+        Comparison.Op.LT: "_lt",
+        Comparison.Op.GT: "_gt",
+        Comparison.Op.LE: "_lte",
+        Comparison.Op.GE: "_gte",
+    }
+
+    key = f"{node.field.graphql_name}{COMPARISON_TO_SUFFIX[node.op]}"
+    return {key: node.value}
+
+
+def order_by_as_string(entity, node: tuple) -> str:
+    check_order_by_clause(entity, node)
+    return f"{node[0].graphql_name}_{node[1].name.upper()}"

--- a/labelbox/pagination.py
+++ b/labelbox/pagination.py
@@ -22,7 +22,7 @@ class PaginatedCollection:
     def __init__(self,
                  client: "Client",
                  query: str,
-                 params: Dict[str, str],
+                 params: Dict[str, Union[str, int]],
                  dereferencing: Union[List[str], Dict[str, Any]],
                  obj_class: Union[Type["DbObject"], Callable[[Any, Any], Any]],
                  cursor_path: Optional[List[str]] = None,

--- a/labelbox/pagination.py
+++ b/labelbox/pagination.py
@@ -145,7 +145,8 @@ class _CursorPagination(_Pagination):
         return not self.next_cursor
 
     def fetch_results(self) -> Dict[str, Any]:
-        self.params.update({'from': self.next_cursor, 'first': _PAGE_SIZE})
+        page_size = self.params.get('first', _PAGE_SIZE)
+        self.params.update({'from': self.next_cursor, 'first': page_size})
         return self.client.execute(self.query,
                                    self.params,
                                    experimental=self.experimental)

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -79,7 +79,7 @@ class Dataset(DbObject, Updateable, Deletable):
         NOTE: 
         """
 
-        query_str = """query DatasetDataRowsPyApi($id: ID!, $from: ID, $first: PageSize)  {
+        query_str = """query DatasetDataRowsPyApi($id: ID!, $from: ID, $first: Int)  {
                         datasetDataRows(id: $id, from: $from, first: $first) 
                             { 
                                 nodes { %s } 

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -534,7 +534,7 @@ class Dataset(DbObject, Updateable, Deletable):
                 multiple `DataRows` for it.
         """
         DataRow = Entity.DataRow
-        where = dict([(DataRow.external_id, external_id)])
+        where = DataRow.external_id == external_id
 
         data_rows = self.data_rows(where=where)
         # Get at most `limit` data_rows.

--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -576,12 +576,6 @@ def test_data_row_filtering_sorting(dataset, image_url):
     row2 = row2[0]
     assert row2.external_id == "row2"
 
-    # Test sorting
-    assert list(
-        dataset.data_rows(order_by=DataRow.external_id.asc)) == [row1, row2]
-    assert list(
-        dataset.data_rows(order_by=DataRow.external_id.desc)) == [row2, row1]
-
 
 def test_data_row_deletion(dataset, image_url):
     task = dataset.create_data_rows([{


### PR DESCRIPTION
Story: https://labelbox.atlassian.net/browse/AL-6294

Replaces dataset.data_rows() Relation with a method and implement cursor-based pagination


- Why did I not update the existing data_rows() Relationship but created a new method instead?
  - There are specific requirements for how graphql needs to be composed for consumption in Relationship, so I would have to create a Dataset#data_rows_2() node resolver, which I think would be confusing
  - The Relationship framework does not support cursor-based pagination and would have to be extended
    - BUT we are talking of getting rid of this home-grown framework for sdk 4
  - All our queries for cursor-based access use custom methods instead of Relation

And this the work I needed to do:
- make sure my method supports `where` parameter the way Relationship does. I have extracted `where` and order by method into simple helpers in the query module
- extended cursor pagination to allow customize page size

Some of perf test results (I will publish complete results in the story once I finish my tests):

Running on my laptop dataset.data_rows()  against stage / mysql org

Offset pagination (legacy)
page size 100
dataset size: 1 mln
time per query p50/p99 in DataDog: 521/ 1000 ms
db utilization: normal (under 1%)
completion time: ??? still running

Cursor pagination (this PR)
page size 500
dataset size: 1 mln
time per query p50/p99 in DataDog: 16/ 26 ms
db utilization: normal (under 1%)
completion time: 1 hour 2 mins 46 s
