### PR TITLE
Wait for data row media info be populated to fix a flaky test

### DIFF
--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -533,10 +533,12 @@ def dataset_pdf_entity(client, rand_gen, document_data_row):
 
 
 @pytest.fixture
-def dataset_conversation_entity(client, rand_gen, conversation_entity_data_row):
+def dataset_conversation_entity(client, rand_gen, conversation_entity_data_row,
+                                wait_for_data_row_processing):
     dataset = client.create_dataset(name=rand_gen(str))
     data_row_ids = []
     data_row = dataset.create_data_row(conversation_entity_data_row)
+    data_row = wait_for_data_row_processing(client, data_row)
     data_row_ids.append(data_row.uid)
     yield dataset, data_row_ids
     dataset.delete()

--- a/tests/integration/annotation_import/test_conversation_import.py
+++ b/tests/integration/annotation_import/test_conversation_import.py
@@ -19,6 +19,7 @@ def test_conversation_entity(client, configured_project_without_data_rows,
 
     labels = []
     _, data_row_uids = dataset_conversation_entity
+
     configured_project_without_data_rows.create_batch(
         rand_gen(str),
         data_row_uids,  # sample of data row objects


### PR DESCRIPTION
So we have this test `tests/integration/annotation_import/test_conversation_import.py::test_conversation_entity` flaky/almost always failing

I have added our std wait to populate media attributes code and it worked to unflake it.