### PR TITLE
[SE-2960] Add roles to project members qgl query

### DIFF
--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -150,7 +150,7 @@ class Project(DbObject, Updateable, Deletable):
         """
         id_param = "projectId"
         query_str = """query ProjectMemberOverviewPyApi($%s: ID!) {
-             project(where: {id : $%s}) { id members(skip: %%d first: %%d){ id user { %s } role { id name } }
+             project(where: {id : $%s}) { id members(skip: %%d first: %%d){ id user { %s } role { id name } accessFrom }
            }
         }""" % (id_param, id_param, query.results_query_part(Entity.User))
         return PaginatedCollection(self.client, query_str,
@@ -1360,6 +1360,7 @@ class Project(DbObject, Updateable, Deletable):
 class ProjectMember(DbObject):
     user = Relationship.ToOne("User", cache=True)
     role = Relationship.ToOne("Role", cache=True)
+    access_from = Field.String("access_from")
 
 
 class LabelingParameterOverride(DbObject):

--- a/tests/integration/test_user_management.py
+++ b/tests/integration/test_user_management.py
@@ -60,6 +60,7 @@ def test_project_invite(client, organization, project_pack, queries):
                           for proj_role in [project_role_1, project_role_2]])
 
     project_members = project_1.members()
+
     project_member = [
         member for member in project_members
         if member.user().uid == client.get_user().uid
@@ -68,6 +69,7 @@ def test_project_invite(client, organization, project_pack, queries):
     assert len(project_member) == 1
     project_member = project_member[0]
 
+    assert project_member.access_from == 'ORGANIZATION'
     assert project_member.role().name.upper() == roles['ADMIN'].name.upper()
     queries.cancel_invite(client, invite.uid)
 


### PR DESCRIPTION
[Ticket](https://labelbox.atlassian.net/browse/EF-369)

## Context

A user has requested the roles of project members be returned in the SDK response. This GQL query is already being made by the App. As discussed in the Slack thread, exposing the `accessFrom` field has a risk of introducing latency.

If possible, the updated query should be released for beta testing to further test the performance when used for programmatic access. 

[Slack Thread](https://labelbox.slack.com/archives/C03PTTCEFUJ/p1690372488230829)

## Analysis

[Datadog APM](https://app.datadoghq.com/apm/services/lb-api-public/operations/graphql.execute/resources?env=labelbox-193903-prod-usc1&graphType=flamegraph&resources=qson%3A%28data%3A%28visible%3A%21t%2Chits%3A%28selected%3Atotal%29%2Cerrors%3A%28selected%3Atotal%29%2Clatency%3A%28selected%3Ap50%29%2CtopN%3A%215%2Csearch%3AProjectMemberOverview%29%2Cversion%3A%210%29&shouldShowLegend=true&sort=time&summary=qson%3A%28data%3A%21f%2Cversion%3A%211%29&topGraphs=latency%3Alatency%2Chits%3Aversion_count%2Cerrors%3Aversion_count%2CbreakdownAs%3Apercentage&start=1687976792840&end=1690568792840&paused=false)

The analysis shows that the queries made by both the App and the SDK are somewhat expensive because the resolver has to iterate several collections to compute the result. 

The difference between query performance with the field (in the App) and query performance without the field (in the SDK today) was not large enough to be significant. 


## Description

If merged, this PR adds the `accessFrom` field to the `ProjectMemberOverviewPyApi` query. This field resolves to the role assigned to each member of a project within that project. 