### PR TITLE
Add missing project.delete() in fixtures

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -416,6 +416,7 @@ def configured_project_with_label(client, rand_gen, image_url, project, dataset,
 
     for label in project.labels():
         label.delete()
+    project.delete()
 
 
 @pytest.fixture
@@ -443,6 +444,7 @@ def configured_batch_project_with_label(client, rand_gen, image_url, project,
 
     for label in project.labels():
         label.delete()
+    project.delete()
 
 
 @pytest.fixture
@@ -465,6 +467,7 @@ def configured_batch_project_with_multiple_datarows(project, dataset, data_rows,
 
     for label in project.labels():
         label.delete()
+    project.delete()
 
 
 def _create_label(project, data_row, ontology, wait_for_label_processing):


### PR DESCRIPTION
This causes large number of 'leaked' projects with our test orgs and, consequently, slowing down sdk tests

Here are the numbers:

**stage**
org cl4y7fpx81gbj0yye44u903ze - 27581 active projects
cl50xnuaf0wis0y00anwugb1m - 11126
cl50xryei0993102idj5x3e6j - 10737

**prod**
ckcz6bubudyfi0855o1dt1g9s - 221
ckvjyoz2o1y8m0z9b1lh8bihc - 338
clfhhl7ag00q00722g8kdbu53 - 0 (not sure this is the right org)

source for org ids: see https://labelbox.atlassian.net/wiki/spaces/AIENG/pages/2110816271/How+to+labelbox-python+SDK+CI+Tests