### PR TITLE
[AL-6791] fix media type hint

### DIFF
--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -983,7 +983,7 @@ def test_invalid_media_type(dataset, conversational_content):
 def test_create_tiled_layer(dataset, tile_content):
     examples = [
         {
-            **tile_content, 'media_type': 'TMS_SIMPLE'
+            **tile_content, 'media_type': 'TMS_GEO'
         },
         tile_content,
         # Old way to check for backwards compatibility


### PR DESCRIPTION
In this test case `test_create_tiled_layer` we import geo data and provide a media type hint once. 
It was TMS_SIMPLE before but the tile content actually has TMS_GEO data indicated by `"epsg": "EPSG4326"`

In pre-ADV world both TMS_SIMPLE and TMS_GEO media attribute hints are validated with the same logic but this is not true for ADV world where we have a bit stricter validation logic.
So in pre-ADV both TMS_SIMPLE and TMS_GEO works but in ADV world only TMS_GEO, hence I make this small change here.