### PR TITLE
Fix for opencv-python build for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt install -y libsm6 \
                 libxrender1 \
                 libgl1-mesa-glx \
                 libgeos-dev \
-                gcc
+                gcc \
+                build-essential
 
 WORKDIR /usr/src/
 COPY requirements.txt /usr/src/


### PR DESCRIPTION
Background
When I ran `make test-staging` today, it failed to build the opencv-python library with a message related to CMAKE not being able to build it's dependencies. I have searched online, and found that adding build-essential package resolved the issue
Note this issue is on Docker / Linux for opencv version 4.8 and above