### PR TITLE
Remove sleep between creating and exporting a batch

### DIFF
--- a/tests/integration/export_v2/test_legacy_export.py
+++ b/tests/integration/export_v2/test_legacy_export.py
@@ -171,8 +171,6 @@ def test_export_data_rows(project: Project, dataset: Dataset):
 
     data_rows = [dr.uid for dr in list(dataset.export_data_rows())]
     batch = project.create_batch("batch test", data_rows)
-    # give some time for the data ingestion system to finish processing the batch creation
-    time.sleep(5)
     result = list(batch.export_data_rows())
     exported_data_rows = [dr.uid for dr in result]
 

--- a/tests/integration/export_v2/test_legacy_export.py
+++ b/tests/integration/export_v2/test_legacy_export.py
@@ -171,7 +171,8 @@ def test_export_data_rows(project: Project, dataset: Dataset):
 
     data_rows = [dr.uid for dr in list(dataset.export_data_rows())]
     batch = project.create_batch("batch test", data_rows)
-
+    # give some time for the data ingestion system to finish processing the batch creation
+    time.sleep(5)
     result = list(batch.export_data_rows())
     exported_data_rows = [dr.uid for dr in result]
 

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -157,8 +157,6 @@ def test_archive_batch(project: Project, small_dataset: Dataset):
     data_rows = [dr.uid for dr in list(small_dataset.export_data_rows())]
     batch = project.create_batch("batch to archive", data_rows)
     batch.remove_queued_data_rows()
-    # give some time for the data ingestion system to finish processing the batch creation
-    time.sleep(5)
     exported_data_rows = list(batch.export_data_rows())
 
     assert len(exported_data_rows) == 0
@@ -242,8 +240,6 @@ def test_export_data_rows(project: Project, dataset: Dataset):
 
     data_rows = [dr.uid for dr in list(dataset.export_data_rows())]
     batch = project.create_batch("batch test", data_rows)
-    # give some time for the data ingestion system to finish processing the batch creation
-    time.sleep(5)
     result = list(batch.export_data_rows())
     exported_data_rows = [dr.uid for dr in result]
 
@@ -311,8 +307,6 @@ def test_delete_labels_with_templates(project: Project, small_dataset: Dataset):
     data_rows = [dr.uid for dr in list(small_dataset.export_data_rows())]
     batch = project.create_batch("batch to delete labels w templates",
                                  data_rows)
-    # give some time for the data ingestion system to finish processing the batch creation
-    time.sleep(5)
     exported_data_rows = list(batch.export_data_rows())
     res = batch.delete_labels(labels_as_template=True)
     exported_data_rows = list(batch.export_data_rows())

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -157,6 +157,8 @@ def test_archive_batch(project: Project, small_dataset: Dataset):
     data_rows = [dr.uid for dr in list(small_dataset.export_data_rows())]
     batch = project.create_batch("batch to archive", data_rows)
     batch.remove_queued_data_rows()
+    # give some time for the data ingestion system to finish processing the batch creation
+    time.sleep(5)
     exported_data_rows = list(batch.export_data_rows())
 
     assert len(exported_data_rows) == 0
@@ -240,7 +242,7 @@ def test_export_data_rows(project: Project, dataset: Dataset):
 
     data_rows = [dr.uid for dr in list(dataset.export_data_rows())]
     batch = project.create_batch("batch test", data_rows)
-    # allow time for catapult to sync changes to ES
+    # give some time for the data ingestion system to finish processing the batch creation
     time.sleep(5)
     result = list(batch.export_data_rows())
     exported_data_rows = [dr.uid for dr in result]
@@ -309,6 +311,8 @@ def test_delete_labels_with_templates(project: Project, small_dataset: Dataset):
     data_rows = [dr.uid for dr in list(small_dataset.export_data_rows())]
     batch = project.create_batch("batch to delete labels w templates",
                                  data_rows)
+    # give some time for the data ingestion system to finish processing the batch creation
+    time.sleep(5)
     exported_data_rows = list(batch.export_data_rows())
     res = batch.delete_labels(labels_as_template=True)
     exported_data_rows = list(batch.export_data_rows())

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -228,7 +228,7 @@ def test_create_batch_with_global_keys_sync(project: Project, data_rows):
     global_keys = [dr.global_key for dr in data_rows]
     batch_name = f'batch {uuid.uuid4()}'
     batch = project.create_batch(batch_name, global_keys=global_keys)
-    # allow time for catapult to sync changes to ES
+    # give some time for the data ingestion system to finish processing the batch creation
     time.sleep(5)
     # TODO: Move to export_v2
     batch_data_rows = set(batch.export_data_rows())
@@ -240,6 +240,8 @@ def test_create_batch_with_global_keys_async(project: Project, data_rows):
     global_keys = [dr.global_key for dr in data_rows]
     batch_name = f'batch {uuid.uuid4()}'
     batch = project._create_batch_async(batch_name, global_keys=global_keys)
+    # give some time for the data ingestion system to finish processing the batch creation
+    time.sleep(5)
     # TODO: Move to export_v2
     batch_data_rows = set(batch.export_data_rows())
     assert batch_data_rows == set(data_rows)

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -228,8 +228,6 @@ def test_create_batch_with_global_keys_sync(project: Project, data_rows):
     global_keys = [dr.global_key for dr in data_rows]
     batch_name = f'batch {uuid.uuid4()}'
     batch = project.create_batch(batch_name, global_keys=global_keys)
-    # give some time for the data ingestion system to finish processing the batch creation
-    time.sleep(5)
     # TODO: Move to export_v2
     batch_data_rows = set(batch.export_data_rows())
     assert batch_data_rows == set(data_rows)
@@ -240,8 +238,6 @@ def test_create_batch_with_global_keys_async(project: Project, data_rows):
     global_keys = [dr.global_key for dr in data_rows]
     batch_name = f'batch {uuid.uuid4()}'
     batch = project._create_batch_async(batch_name, global_keys=global_keys)
-    # give some time for the data ingestion system to finish processing the batch creation
-    time.sleep(5)
     # TODO: Move to export_v2
     batch_data_rows = set(batch.export_data_rows())
     assert batch_data_rows == set(data_rows)


### PR DESCRIPTION
Due to improvement in this [PR](https://github.com/Labelbox/intelligence/pull/16571) we no longer need the extra 5 seconds of delay between creating and exporting a batch.