### PR TITLE
[AL-6929] adjust ADV specific asserts

### DIFF
--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -929,9 +929,7 @@ def test_data_row_bulk_creation_sync_with_same_global_keys(
         dataset, sample_image, is_adv_enabled):
     global_key_1 = str(uuid.uuid4())
 
-    if is_adv_enabled:
-        # ADV does not throw an error for duplicate global keys
-        # but rather create the first one and reject the second
+    with pytest.raises(labelbox.exceptions.MalformedQueryException):
         dataset.create_data_rows_sync([{
             DataRow.row_data: sample_image,
             DataRow.global_key: global_key_1
@@ -939,18 +937,12 @@ def test_data_row_bulk_creation_sync_with_same_global_keys(
             DataRow.row_data: sample_image,
             DataRow.global_key: global_key_1
         }])
+
+    if is_adv_enabled:
+        # ADV will create the first data row and reject the second
         assert len(list(dataset.data_rows())) == 1
         assert list(dataset.data_rows())[0].global_key == global_key_1
     else:
-        with pytest.raises(labelbox.exceptions.MalformedQueryException):
-            dataset.create_data_rows_sync([{
-                DataRow.row_data: sample_image,
-                DataRow.global_key: global_key_1
-            }, {
-                DataRow.row_data: sample_image,
-                DataRow.global_key: global_key_1
-            }])
-
         assert len(list(dataset.data_rows())) == 0
 
         dataset.create_data_rows_sync([{

--- a/tests/integration/test_global_keys.py
+++ b/tests/integration/test_global_keys.py
@@ -116,8 +116,7 @@ def test_long_global_key_validation(client, dataset, image_url):
         'error'] == 'Invalid assignment. Either DataRow does not exist, or globalKey is invalid'
 
 
-def test_global_key_with_whitespaces_validation(client, dataset, image_url,
-                                                is_adv_enabled):
+def test_global_key_with_whitespaces_validation(client, dataset, image_url):
     dr_1 = dataset.create_data_row(row_data=image_url)
     dr_2 = dataset.create_data_row(row_data=image_url)
     dr_3 = dataset.create_data_row(row_data=image_url)
@@ -138,27 +137,19 @@ def test_global_key_with_whitespaces_validation(client, dataset, image_url,
     }]
     res = client.assign_global_keys_to_data_rows(assignment_inputs)
 
-    if is_adv_enabled:
-        assert res['status'] == 'PARTIAL SUCCESS'
-        assert len(res['results']) == 2
-        assert len(res['errors']) == 1
-        assert res['errors'][0]['global_key'] == gk_3
-        assert res['errors'][0][
-            'error'] == "Invalid assignment. Either DataRow does not exist, or globalKey is invalid"
-    else:
-        assert len(res['results']) == 0
-        assert len(res['errors']) == 3
-        assert res['status'] == 'FAILURE'
-        assign_errors_ids = set([e['data_row_id'] for e in res['errors']])
-        assign_errors_gks = set([e['global_key'] for e in res['errors']])
-        assign_errors_msgs = set([e['error'] for e in res['errors']])
-        assert assign_errors_ids == set([dr_1.uid, dr_2.uid, dr_3.uid])
-        assert assign_errors_gks == set([gk_1, gk_2, gk_3])
-        assert assign_errors_msgs == set([
-            'Invalid assignment. Either DataRow does not exist, or globalKey is invalid',
-            'Invalid assignment. Either DataRow does not exist, or globalKey is invalid',
-            'Invalid assignment. Either DataRow does not exist, or globalKey is invalid'
-        ])
+    assert len(res['results']) == 0
+    assert len(res['errors']) == 3
+    assert res['status'] == 'FAILURE'
+    assign_errors_ids = set([e['data_row_id'] for e in res['errors']])
+    assign_errors_gks = set([e['global_key'] for e in res['errors']])
+    assign_errors_msgs = set([e['error'] for e in res['errors']])
+    assert assign_errors_ids == set([dr_1.uid, dr_2.uid, dr_3.uid])
+    assert assign_errors_gks == set([gk_1, gk_2, gk_3])
+    assert assign_errors_msgs == set([
+        'Invalid assignment. Either DataRow does not exist, or globalKey is invalid',
+        'Invalid assignment. Either DataRow does not exist, or globalKey is invalid',
+        'Invalid assignment. Either DataRow does not exist, or globalKey is invalid'
+    ])
 
 
 def test_get_data_row_ids_for_global_keys(client, dataset, image_url):


### PR DESCRIPTION
After we [aligned](https://github.com/Labelbox/intelligence/pull/16595) global key validation and sanitization in ADV to match with pre-ADV we got 2 tests to change a little bit for ADV.