### PR TITLE
[QQC-2474] Expose quality mode through SDK create_project method

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -31,7 +31,8 @@ from labelbox.schema.model import Model
 from labelbox.schema.model_run import ModelRun
 from labelbox.schema.ontology import Ontology, Tool, Classification, FeatureSchema
 from labelbox.schema.organization import Organization
-from labelbox.schema.quality_mode import QualityMode
+from labelbox.schema.quality_mode import QualityMode, BENCHMARK_AUTO_AUDIT_NUMBER_OF_LABELS, \
+    BENCHMARK_AUTO_AUDIT_PERCENTAGE, CONSENSUS_AUTO_AUDIT_NUMBER_OF_LABELS, CONSENSUS_AUTO_AUDIT_PERCENTAGE
 from labelbox.schema.user import User
 from labelbox.schema.project import Project
 from labelbox.schema.role import Role
@@ -683,11 +684,13 @@ class Client:
         data = kwargs
         data.pop("quality_mode", None)
         if quality_mode is None or quality_mode is QualityMode.Benchmark:
-            data["auto_audit_number_of_labels"] = 1
-            data["auto_audit_percentage"] = 1
+            data[
+                "auto_audit_number_of_labels"] = BENCHMARK_AUTO_AUDIT_NUMBER_OF_LABELS
+            data["auto_audit_percentage"] = BENCHMARK_AUTO_AUDIT_PERCENTAGE
         else:
-            data["auto_audit_number_of_labels"] = 3
-            data["auto_audit_percentage"] = 0
+            data[
+                "auto_audit_number_of_labels"] = CONSENSUS_AUTO_AUDIT_NUMBER_OF_LABELS
+            data["auto_audit_percentage"] = CONSENSUS_AUTO_AUDIT_PERCENTAGE
 
         return self._create(Entity.Project, {
             **data,

--- a/labelbox/orm/query.py
+++ b/labelbox/orm/query.py
@@ -314,7 +314,7 @@ def relationship(source, relationship, where, order_by):
 
 
 def create(entity, data):
-    """ Generats a query and parameters for creating a new DB object.
+    """ Generates a query and parameters for creating a new DB object.
 
     Args:
         entity (type): An Entity subtype indicating which kind of

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -120,12 +120,10 @@ class Project(DbObject, Updateable, Deletable):
         for a project is inferred through the following attributes:
 
         Benchmark:
-            auto_audit_number_of_labels = 1
-            auto_audit_percentage = 1.0
+            auto_audit_number_of_labels = 1 and auto_audit_percentage = 1.0
 
         Consensus:
-            auto_audit_number_of_labels > 1
-            auto_audit_percentage <= 1.0
+            auto_audit_number_of_labels > 1 or auto_audit_percentage <= 1.0
 
         Attempting to switch between benchmark and consensus modes is an invalid operation and will result
         in an error.

--- a/labelbox/schema/quality_mode.py
+++ b/labelbox/schema/quality_mode.py
@@ -1,6 +1,12 @@
 from enum import Enum
 
 
-class QualityMode(str):
+class QualityMode(str, Enum):
     Benchmark = "BENCHMARK"
     Consensus = "CONSENSUS"
+
+
+BENCHMARK_AUTO_AUDIT_NUMBER_OF_LABELS = 1
+BENCHMARK_AUTO_AUDIT_PERCENTAGE = 1
+CONSENSUS_AUTO_AUDIT_NUMBER_OF_LABELS = 3
+CONSENSUS_AUTO_AUDIT_PERCENTAGE = 0

--- a/labelbox/schema/quality_mode.py
+++ b/labelbox/schema/quality_mode.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class QualityMode(str):
+    Benchmark = "BENCHMARK"
+    Consensus = "CONSENSUS"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,6 +22,7 @@ from labelbox.schema.annotation_import import LabelImport
 from labelbox.schema.enums import AnnotationImportState
 from labelbox.schema.invite import Invite
 from labelbox.schema.project import Project
+from labelbox.schema.quality_mode import QualityMode
 from labelbox.schema.queue_mode import QueueMode
 from labelbox.schema.user import User
 
@@ -231,7 +232,7 @@ def project(client, rand_gen):
 @pytest.fixture
 def consensus_project(client, rand_gen):
     project = client.create_project(name=rand_gen(str),
-                                    auto_audit_percentage=0,
+                                    quality_mode=QualityMode.Consensus,
                                     queue_mode=QueueMode.Batch,
                                     media_type=MediaType.Image)
     yield project

--- a/tests/integration/test_legacy_project.py
+++ b/tests/integration/test_legacy_project.py
@@ -1,15 +1,13 @@
 import pytest
 
-from labelbox.exceptions import InvalidQueryError, MalformedQueryException
-from labelbox.schema.media_type import MediaType
 from labelbox.schema.queue_mode import QueueMode
 
 
 def test_project_dataset(client, rand_gen):
     with pytest.raises(
-            MalformedQueryException,
+            ValueError,
             match=
-            "DataSet queue mode is deprecated. Please prefer Batch queue mode."
+            "Dataset queue mode is deprecated. Please prefer Batch queue mode."
     ):
         client.create_project(
             name=rand_gen(str),
@@ -18,6 +16,21 @@ def test_project_dataset(client, rand_gen):
 
 
 def test_legacy_project_dataset_relationships(project, dataset):
-
     assert [ds for ds in project.datasets()] == []
     assert [p for p in dataset.projects()] == []
+
+
+def test_project_auto_audit_parameters(client, rand_gen):
+    with pytest.raises(
+            ValueError,
+            match=
+            "quality_mode must be set instead of auto_audit_percentage or auto_audit_number_of_labels."
+    ):
+        client.create_project(name=rand_gen(str), auto_audit_percentage=0.5)
+
+    with pytest.raises(
+            ValueError,
+            match=
+            "quality_mode must be set instead of auto_audit_percentage or auto_audit_number_of_labels."
+    ):
+        client.create_project(name=rand_gen(str), auto_audit_number_of_labels=2)

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -8,11 +8,11 @@ import requests
 from labelbox import Project, LabelingFrontend, Dataset
 from labelbox.exceptions import InvalidQueryError
 from labelbox.schema.media_type import MediaType
+from labelbox.schema.quality_mode import QualityMode
 from labelbox.schema.queue_mode import QueueMode
 
 
 def test_project(client, rand_gen):
-
     data = {
         "name": rand_gen(str),
         "description": rand_gen(str),
@@ -260,3 +260,19 @@ def test_media_type(client, project: Project, rand_gen):
                                         media_type=MediaType[media_type])
         assert project.media_type == MediaType[media_type]
         project.delete()
+
+
+def test_queue_mode(client, rand_gen):
+    project = client.create_project(name=rand_gen(str))  # defaults to benchmark
+    assert project.auto_audit_number_of_labels == 1
+    assert project.auto_audit_percentage == 1
+
+    project = client.create_project(name=rand_gen(str),
+                                    quality_mode=QualityMode.Benchmark)
+    assert project.auto_audit_number_of_labels == 1
+    assert project.auto_audit_percentage == 1
+
+    project = client.create_project(name=rand_gen(str),
+                                    quality_mode=QualityMode.Consensus)
+    assert project.auto_audit_number_of_labels == 3
+    assert project.auto_audit_percentage == 0


### PR DESCRIPTION
* Removes the `auto_audit_percentage` and `auto_audit_number_of_labels` parameters from `labelbox.client.Client.create_project` and replaces them with the `quality_mode` enum