### PR TITLE
Vb/bulk delete datarow id sdk 33

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -1002,6 +1002,35 @@ class Client:
                 "Failed to delete the ontology, message: " +
                 str(response.json()['message']))
 
+    def delete_data_rows(
+        self,
+        data_rows: List[str],
+    ) -> None:
+        """ Deletes data rows given data row ids
+
+        Args:
+            List of data row ids to delete.
+
+        Returns:
+            NOTE current implementation returns None since the API returns all data row ids we have sent and 
+                and it does not actually report any rows that could not be deleted
+            If needed, we recommend verifying data rows have been deleted by trying to fetch them after deletion.
+        """
+        if len(data_rows) == 0:
+            return None
+
+        mutation_name = "deleteDataRows"
+        query = """mutation DeleteDataRowsPyApi($where: DeleteDataRowsInput!)  {
+                        %s(where: $where)
+                            { id deleted }
+                        }
+                    """ % (mutation_name)
+        query_params = {"where": {"dataRowIds": data_rows,}}
+
+        self.execute(query, query_params, error_log_key="errors")
+
+        return None
+
     def update_feature_schema_title(self, feature_schema_id: str,
                                     title: str) -> FeatureSchema:
         """

--- a/labelbox/schema/data_row.py
+++ b/labelbox/schema/data_row.py
@@ -89,7 +89,6 @@ class DataRow(DbObject, Updateable, BulkDeletable):
         """
         BulkDeletable._bulk_delete(data_rows, True)
 
-
     @staticmethod
     def bulk_delete_by_ids(client, data_row_ids: List[str]) -> None:
         """ Deletes DataRows given data row ids.
@@ -97,7 +96,7 @@ class DataRow(DbObject, Updateable, BulkDeletable):
         Args:
             data_row_ids (list of data row ids)
         """
-        
+
         if len(data_row_ids) == 0:
             return
 
@@ -105,16 +104,15 @@ class DataRow(DbObject, Updateable, BulkDeletable):
         search_query.append(build_id_filters(data_row_ids, "data_row_id"))
 
         mutation_name = "deleteDataRowsByQuery"
-        query = """mutation deleteDataRowsByQueryPyApi($$where: DeleteDataRowsByQueryInput)  {
-                        %s(where: $$where)
+        query = """mutation DeleteDataRowsByQueryPyApi($searchQueryInput: SearchServiceQueryInput!)  {
+                        %s(where: {searchQuery: $searchQueryInput})
                             { taskId }
                         }
-                    """% (mutation_name)
+                    """ % (mutation_name)
         query_params = {
-            "where": {
-                "searchQuery": {
-                    "query": search_query
-                }
+            "searchQueryInput": {
+                "query": search_query,
+                "scope": None
             }
         }
 

--- a/labelbox/schema/es_filters.py
+++ b/labelbox/schema/es_filters.py
@@ -1,0 +1,27 @@
+import sys
+
+from datetime import datetime, timezone
+from typing import Collection, Dict, Tuple, List, Optional
+from labelbox.typing_imports import Literal
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+SEARCH_LIMIT_PER_EXPORT_V2 = 2_000
+ISO_8061_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+
+
+def build_id_filters(
+        ids: list,
+        type_name: str,
+        search_where_limit: int = SEARCH_LIMIT_PER_EXPORT_V2) -> dict:
+    if not isinstance(ids, list):
+        raise ValueError(f"{type_name} filter expects a list.")
+    if len(ids) == 0:
+        raise ValueError(f"{type_name} filter expects a non-empty list.")
+    if len(ids) > search_where_limit:
+        raise ValueError(
+            f"{type_name} filter only supports a max of {search_where_limit} items."
+        )
+    return {"ids": ids, "operator": "is", "type": type_name}

--- a/labelbox/schema/es_filters.py
+++ b/labelbox/schema/es_filters.py
@@ -1,21 +1,10 @@
-import sys
-
-from datetime import datetime, timezone
-from typing import Collection, Dict, Tuple, List, Optional
-from labelbox.typing_imports import Literal
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
-
-SEARCH_LIMIT_PER_EXPORT_V2 = 2_000
+SEARCH_LIMIT = 2_000
 ISO_8061_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 
 
-def build_id_filters(
-        ids: list,
-        type_name: str,
-        search_where_limit: int = SEARCH_LIMIT_PER_EXPORT_V2) -> dict:
+def build_id_filters(ids: list,
+                     type_name: str,
+                     search_where_limit: int = SEARCH_LIMIT) -> dict:
     if not isinstance(ids, list):
         raise ValueError(f"{type_name} filter expects a list.")
     if len(ids) == 0:

--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -648,7 +648,9 @@ def test_data_row_deletion_by_ids(client, dataset,
 
     data_row_ids = [dr.uid for dr in data_rows]
     delete_data_row_ids = data_row_ids[:2]
-    success = DataRow.bulk_delete_by_ids(client, [delete_data_row_ids])
+    success = DataRow.bulk_delete(delete_data_row_ids, client)
+    import pdb
+    pdb.set_trace()
     assert success
     success = DataRow.bulk_delete_by_ids(client, ['foobar'])
     assert success

--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -610,7 +610,7 @@ def create_datarows_for_data_row_deletion(dataset, image_url):
     task = dataset.create_data_rows([{
         DataRow.row_data: image_url,
         DataRow.external_id: str(i)
-    } for i in range(10)])
+    } for i in range(5)])
     task.wait_till_done()
 
     data_rows = list(dataset.data_rows())
@@ -623,22 +623,35 @@ def create_datarows_for_data_row_deletion(dataset, image_url):
 def test_data_row_deletion(dataset, create_datarows_for_data_row_deletion):
     create_datarows_for_data_row_deletion
     data_rows = list(dataset.data_rows())
-    expected = set(map(str, range(10)))
+    expected = set(map(str, range(5)))
     assert {dr.external_id for dr in data_rows} == expected
 
     for dr in data_rows:
-        if dr.external_id in "37":
+        if dr.external_id in "13":
             dr.delete()
-    expected -= set("37")
+    expected -= set("13")
 
     data_rows = list(dataset.data_rows())
     assert {dr.external_id for dr in data_rows} == expected
 
-    DataRow.bulk_delete([dr for dr in data_rows if dr.external_id in "2458"])
-    expected -= set("2458")
+    DataRow.bulk_delete([dr for dr in data_rows if dr.external_id in "24"])
+    expected -= set("24")
 
     data_rows = list(dataset.data_rows())
     assert {dr.external_id for dr in data_rows} == expected
+
+
+def test_data_row_deletion_by_ids(client, dataset,
+                                  create_datarows_for_data_row_deletion):
+    create_datarows_for_data_row_deletion
+    data_rows = list(dataset.data_rows())
+
+    data_row_ids = [dr.uid for dr in data_rows]
+    delete_data_row_ids = data_row_ids[:2]
+    success = DataRow.bulk_delete_by_ids(client, [delete_data_row_ids])
+    assert success
+    success = DataRow.bulk_delete_by_ids(client, ['foobar'])
+    assert success
 
 
 def test_data_row_iteration(dataset, image_url) -> None:

--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -648,12 +648,15 @@ def test_data_row_deletion_by_ids(client, dataset,
 
     data_row_ids = [dr.uid for dr in data_rows]
     delete_data_row_ids = data_row_ids[:2]
-    success = DataRow.bulk_delete(delete_data_row_ids, client)
-    import pdb
-    pdb.set_trace()
-    assert success
-    success = DataRow.bulk_delete_by_ids(client, ['foobar'])
-    assert success
+    client.delete_data_rows(delete_data_row_ids)
+
+    remaining_data_rows = list(
+        dataset.data_rows(where=(DataRow.uid == delete_data_row_ids[0])))
+    assert len(remaining_data_rows) == 0
+
+    remaining_data_rows = list(
+        dataset.data_rows(where=(DataRow.uid == delete_data_row_ids[1])))
+    assert len(remaining_data_rows) == 0
 
 
 def test_data_row_iteration(dataset, image_url) -> None:

--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -641,15 +641,16 @@ def test_data_row_deletion(dataset, create_datarows_for_data_row_deletion):
     assert {dr.external_id for dr in data_rows} == expected
 
 
-def test_data_row_deletion_by_ids(client, dataset,
+def test_data_row_bulk_delete(client, dataset,
                                   create_datarows_for_data_row_deletion):
-    create_datarows_for_data_row_deletion
-    data_rows = list(dataset.data_rows())
+    data_rows = create_datarows_for_data_row_deletion
 
-    data_row_ids = [dr.uid for dr in data_rows]
-    delete_data_row_ids = data_row_ids[:2]
-    client.delete_data_rows(delete_data_row_ids)
+    all_data_row_ids = [dr.uid for dr in data_rows]
 
+    delete_data_row_ids = all_data_row_ids[:2]
+    task = client.bulk_delete_data_rows(delete_data_row_ids)
+    task.wait_till_done()
+    
     remaining_data_rows = list(
         dataset.data_rows(where=(DataRow.uid == delete_data_row_ids[0])))
     assert len(remaining_data_rows) == 0


### PR DESCRIPTION
[EXPERIMENTAL]

Story: https://labelbox.atlassian.net/browse/SDK-33

The original intent for this story was to reduce friction in bulk deleting data rows and allow using both data row ids and global keys (currently a user passes an array of whole `DataRow`s plus there is a 4K limitation on total number of data rows)

As I started working, I have discovered that we have a different mutation (not the one used in bulk_delete) that allows us to delete data rows by ids of global keysn and at bulk numbers too

The most important point to review in this PR is user-facing method signature and packaging since, in the future, we will rewrite the internal implementation

- Even though we already have a `DataRow.bulk_delete(data_rows)`, I thought adding more parameters might be confusing for a caller and will make implementation convoluted since this method uses a generic way to bulk_delete any entity and the entity itself must be present (not the ids or global keys)
- I have implement, instead, in the `client` which has it's own drawbacks. Our client has been polluted with many methods and I feel like the only reason we stick it there because we always need access to the client and we have no easy way to inject it. 
