### PR TITLE
DEVOPS-1626 - Add Github Action for container release

### DIFF
--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Log in to the Container registry
       uses: docker/login-action@v2
       with:
-        registry: ${{ env.REGISTRY }}
+        registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -38,8 +38,6 @@ jobs:
         platforms: |
           linux/amd64
           linux/arm64
-          darwin/amd64
-          darwin/arm64
 
         tags: |
           latest

--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -44,8 +44,3 @@ jobs:
         tags: |
           latest
           ${{ github.event.release.tag_name }}
-
-        outputs: |
-          image: ${{ steps.build.outputs.imageid }}
-          digest: ${{ steps.build.outputs.digest }}
-          metadata: ${{ steps.build.outputs.metadata }}

--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -1,0 +1,51 @@
+# ref: https://github.com/marketplace/actions/build-and-push-docker-images
+
+name: Release container image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  context:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        push: true
+
+        registry: ghcr.io
+        organization: "${{ github.event.repository.owner.login }}"
+        repository: "${{ github.event.repository.name }}"
+
+        platforms: |
+          linux/amd64
+          linux/arm64
+          darwin/amd64
+          darwin/arm64
+
+        tags: |
+          latest
+          ${{ github.event.release.tag_name }}
+
+        outputs: |
+          image: ${{ steps.build.outputs.imageid }}
+          digest: ${{ steps.build.outputs.digest }}
+          metadata: ${{ steps.build.outputs.metadata }}

--- a/.github/workflows/testing-container.yaml
+++ b/.github/workflows/testing-container.yaml
@@ -1,0 +1,52 @@
+# ref: https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+
+name: Testing container image
+
+on:
+  push:
+    branches:
+      - 'develop'
+
+jobs:
+  context:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        push: true
+
+        registry: ghcr.io
+        organization: "${{ github.event.repository.owner.login }}"
+        repository: "${{ github.event.repository.name }}"
+
+        platforms: |
+          linux/amd64
+          linux/arm64
+          darwin/amd64
+          darwin/arm64
+
+        tags: |
+          develop
+          ${{ github.sha }}
+
+        outputs: |
+          image: ${{ steps.build.outputs.imageid }}
+          digest: ${{ steps.build.outputs.digest }}
+          metadata: ${{ steps.build.outputs.metadata }}

--- a/.github/workflows/testing-container.yaml
+++ b/.github/workflows/testing-container.yaml
@@ -45,8 +45,3 @@ jobs:
         tags: |
           develop
           ${{ github.sha }}
-
-        outputs: |
-          image: ${{ steps.build.outputs.imageid }}
-          digest: ${{ steps.build.outputs.digest }}
-          metadata: ${{ steps.build.outputs.metadata }}

--- a/.github/workflows/testing-container.yaml
+++ b/.github/workflows/testing-container.yaml
@@ -39,8 +39,6 @@ jobs:
         platforms: |
           linux/amd64
           linux/arm64
-          darwin/amd64
-          darwin/arm64
 
         tags: |
           develop

--- a/.github/workflows/testing-container.yaml
+++ b/.github/workflows/testing-container.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Log in to the Container registry
       uses: docker/login-action@v2
       with:
-        registry: ${{ env.REGISTRY }}
+        registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Adding container images to the Github Container Registry automatically upon pushes to `develop` and on creation of `releases`