### PR TITLE
Vb/test annotation upload by global keys

### DIFF
--- a/tests/data/serialization/ndjson/test_video.py
+++ b/tests/data/serialization/ndjson/test_video.py
@@ -12,7 +12,6 @@ from labelbox.data.annotation_types.video import VideoObjectAnnotation
 from labelbox import parser
 
 from labelbox.data.serialization.ndjson.converter import NDJsonConverter
-from labelbox.schema.annotation_import import MALPredictionImport
 
 
 def test_video():

--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -508,8 +508,12 @@ def configured_project(client, initial_dataset, ontology, rand_gen, image_url):
 
     data_row_ids = []
 
-    for _ in range(len(ontology['tools']) + len(ontology['classifications'])):
-        data_row_ids.append(dataset.create_data_row(row_data=image_url).uid)
+    ontologies = ontology['tools'] + ontology['classifications']
+    for ind in range(len(ontologies)):
+        data_row_ids.append(
+            dataset.create_data_row(
+                row_data=image_url,
+                global_key=f"gk_{ontologies[ind]['name']}_{rand_gen(str)}").uid)
     project._wait_until_data_rows_are_processed(data_row_ids=data_row_ids,
                                                 sleep_interval=3)
 

--- a/tests/integration/annotation_import/test_mea_prediction_import.py
+++ b/tests/integration/annotation_import/test_mea_prediction_import.py
@@ -37,6 +37,25 @@ def test_create_from_objects(model_run_with_data_rows, object_predictions,
     annotation_import.wait_until_done()
 
 
+def test_create_from_objects_global_key(client, model_run_with_data_rows,
+                                        entity_inference,
+                                        annotation_import_test_helpers):
+    name = str(uuid.uuid4())
+    dr = client.get_data_row(entity_inference['dataRow']['id'])
+    del entity_inference['dataRow']['id']
+    entity_inference['dataRow']['globalKey'] = dr.global_key
+    object_predictions = [entity_inference]
+
+    annotation_import = model_run_with_data_rows.add_predictions(
+        name=name, predictions=object_predictions)
+
+    assert annotation_import.model_run_id == model_run_with_data_rows.uid
+    annotation_import_test_helpers.check_running_state(annotation_import, name)
+    annotation_import_test_helpers.assert_file_content(
+        annotation_import.input_file_url, object_predictions)
+    annotation_import.wait_until_done()
+
+
 def test_create_from_objects_with_confidence(predictions_with_confidence,
                                              model_run_with_data_rows,
                                              annotation_import_test_helpers):

--- a/tests/integration/annotation_import/test_upsert_prediction_import.py
+++ b/tests/integration/annotation_import/test_upsert_prediction_import.py
@@ -1,8 +1,6 @@
 import uuid
 from labelbox import parser
 import pytest
-
-from labelbox.schema.annotation_import import AnnotationImportState, MEAPredictionImport
 """
 - Here we only want to check that the uploads are calling the validation
 - Then with unit tests we can check the types of errors raised
@@ -28,7 +26,7 @@ def test_create_from_url(client, tmp_path, object_predictions,
         if p['dataRow']['id'] in model_run_data_rows
     ]
     with file_path.open("w") as f:
-        ndjson.dump(predictions, f)
+        parser.dump(predictions, f)
 
     # Needs to have data row ids
 
@@ -114,7 +112,7 @@ def test_create_from_local_file(tmp_path, model_run_with_data_rows,
     ]
 
     with file_path.open("w") as f:
-        ndjson.dump(predictions, f)
+        parser.dump(predictions, f)
 
     annotation_import, batch, mal_prediction_import = model_run_with_data_rows.upsert_predictions_and_send_to_project(
         name=name,


### PR DESCRIPTION
Story: https://labelbox.atlassian.net/browse/SDK-237

This PR adds sdk integration test for predictions upload with a data row global key instead of a uuid

Additional improvements:
- found fixed a test case where we stilled used ndjson lib instead of our parser
- for `configured_project`, our popular fixture that creates a data row for each annotation, added automatically-generated global key