### PR TITLE
[SDK-210] Update the docstring for client.get_feature_schemas() to explain better the use of None

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -892,7 +892,9 @@ class Client:
         Fetches top level feature schemas with names that match the `name_contains` string
 
         Args:
-            name_contains (str): the string to search top level feature schema names by
+            name_contains (str): search filter for a name of a root feature schema
+                If present, results in a case insensitive 'like' search for feature schemas
+                If None, returns all top level feature schemas
         Returns:
             PaginatedCollection of FeatureSchemas with names that match `name_contains`
         """


### PR DESCRIPTION
@mihhail-m your original proposal was to 
>either would be nice to provide documentation on expected behaviour or check for None values implemented.

We went with updated documentation, here is a rationale I have provided to Kevin:

>When we call client.get_feature_schemas(name_contains=None)  , it returns all root feature schemas. For Mihhail this was confusing and he proposes to throw an error if name_contains in None. However, from the api point of view, this name_contains is converted to a search filter. None means do not filter, so they return every root feature node (paginated). I think this behavior is useful to keep, return is paginated, so I propose just to document it instead of throwing an exception if the name_contains parameter is None

PS I will also create a documentation story 