### PR TITLE
[SDK-302] Remove backoff library

### DIFF
--- a/.yapfignore
+++ b/.yapfignore
@@ -1,1 +1,3 @@
-pytest.ini
+Makefile
+*.txt
+*.ini

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,5 @@
 [mypy]
 
-[mypy-backoff.*]
-ignore_missing_imports = True
-
 [mypy-google.*]
 ignore_missing_imports = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-backoff==1.10.0
 geojson
 google-api-core>=1.22.1
 imagesize

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setuptools.setup(
     url="https://labelbox.com",
     packages=setuptools.find_packages(),
     install_requires=[
-        "backoff==1.10.0", "requests>=2.22.0", "google-api-core>=1.22.1",
-        "pydantic>=1.8,<2.0", "tqdm", "python-dateutil>=2.8.2,<2.9.0"
+        "requests>=2.22.0", "google-api-core>=1.22.1", "pydantic>=1.8,<2.0",
+        "tqdm", "python-dateutil>=2.8.2,<2.9.0"
     ],
     extras_require={
         'data': [


### PR DESCRIPTION
Story: https://labelbox.atlassian.net/browse/SDK-302

The backoff library we use is old and it conflicts with the version the lightning-ai library used by Ancestry

Upon further inspection, I have discovered this library can be replaced with  google.api_core.retry we use elsewhere in our code

This will execute exponential backoff for 2 minutes (default), like
```
tests/integration/annotation_import/test_bulk_import_request.py::test_wait_till_done 
Refreshing... at datetime:  18:57:24
Refreshing... at datetime:  18:57:26
Refreshing... at datetime:  18:57:29
Refreshing... at datetime:  18:57:32
Refreshing... at datetime:  18:57:44
Refreshing... at datetime:  18:58:05
...
```