### PR TITLE
[SDK-200] Handle invalid enum update properly

### DIFF
--- a/labelbox/schema/data_row_metadata.py
+++ b/labelbox/schema/data_row_metadata.py
@@ -255,7 +255,6 @@ class DataRowMetadataOntology:
                 options = []
                 for option in schema["options"]:
                     option["uid"] = option["id"]
-
                     options.append(
                         DataRowMetadataSchema(**{
                             **option,
@@ -366,7 +365,12 @@ class DataRowMetadataOntology:
             raise ValueError(
                 f"Updating Enum option is only supported for Enum metadata schema"
             )
+        valid_options: List[str] = [o.name for o in schema.options]
 
+        if option not in valid_options:
+            raise ValueError(
+                f"Enum option '{option}' is not a valid option for Enum '{name}', valid options are: {valid_options}"
+            )
         upsert_schema = _UpsertCustomMetadataSchemaInput(id=schema.uid,
                                                          name=schema.name,
                                                          kind=schema.kind.value)


### PR DESCRIPTION
Gracefully handle updates that are not possible:
```
Exception has occurred: ValueError
Enum option 'option 1' is not a valid option for Enum 'f807a16b-6c8a-4798-986a-f52335f504d1', valid options are: ['option3', 'option2']
```