### PR TITLE
Temporarily skip create_data_rows_sync tests

### DIFF
--- a/tests/integration/test_data_rows.py
+++ b/tests/integration/test_data_rows.py
@@ -964,7 +964,8 @@ def test_data_row_bulk_creation_sync_with_same_global_keys(
         assert list(dataset.data_rows())[0].global_key == global_key_1
 
 
-def test_create_conversational_text(dataset, conversational_content):
+@pytest.mark.skip(reason="create_data_rows_sync not supported by ADV yet")
+def test_create_conversational_text(client, dataset, conversational_content):
     examples = [
         {
             **conversational_content, 'media_type':


### PR DESCRIPTION
This method is not supported by ADV

Depending on when the data platform team fixes this method, I may replace some of the synchronous data row creation calls with asynchronous data row creation in a follow-up PR.