### PR TITLE
Add various sdk test improvements:

### DIFF
--- a/tests/data/annotation_types/data/test_text.py
+++ b/tests/data/annotation_types/data/test_text.py
@@ -22,7 +22,7 @@ def test_text():
 
 
 def test_url():
-    url = "https://filesamples.com/samples/document/txt/sample3.txt"
+    url = "https://storage.googleapis.com/lb-artifacts-testing-public/sdk_integration_test/sample3.txt"
     text_data = TextData(url=url)
     text = text_data.value
     assert len(text) == 3541


### PR DESCRIPTION
- Use document from a test bucker for a test failing on codefresh

- Use create_data_rows instead of create_data_rows_sync for a test failing due to ADV