### PR TITLE
Fix instantiation of failed_data_row_ids in Batch

### DIFF
--- a/labelbox/schema/batch.py
+++ b/labelbox/schema/batch.py
@@ -43,7 +43,7 @@ class Batch(DbObject):
                  client,
                  project_id,
                  *args,
-                 failed_data_row_ids=None,
+                 failed_data_row_ids=[],
                  **kwargs):
         super().__init__(client, *args, **kwargs)
         self.project_id = project_id
@@ -187,6 +187,11 @@ class Batch(DbObject):
             experimental=True)
         return res
 
+    # modify this function to return an empty list if there are no failed data rows
+
     @property
     def failed_data_row_ids(self):
+        if self._failed_data_row_ids is None:
+            self._failed_data_row_ids = []
+
         return (x for x in self._failed_data_row_ids)

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -14,9 +14,17 @@ def get_data_row_ids(ds: Dataset):
 
 
 def test_create_batch(project: Project, big_dataset_data_row_ids: List[str]):
-    batch = project.create_batch("test-batch", big_dataset_data_row_ids, 3)
+    batch = project.create_batch("test-batch",
+                                 big_dataset_data_row_ids,
+                                 3,
+                                 consensus_settings={
+                                     'number_of_labels': 3,
+                                     'coverage_percentage': 0.1
+                                 })
+
     assert batch.name == "test-batch"
     assert batch.size == len(big_dataset_data_row_ids)
+    assert len([dr for dr in batch.failed_data_row_ids]) == 0
 
 
 def test_create_batch_with_invalid_data_rows_ids(project: Project):
@@ -101,6 +109,7 @@ def test_create_batch_async(project: Project,
                                         priority=3)
     assert batch.name == "big-batch"
     assert batch.size == len(big_dataset_data_row_ids)
+    assert len([dr for dr in batch.failed_data_row_ids]) == 0
 
 
 def test_create_batch_with_consensus_settings(project: Project,


### PR DESCRIPTION
SDK story: https://labelbox.atlassian.net/browse/SDK-406
Incorrect handling of the member variable `failed_data_row_ids` in the `Batch` class results in the failure of the `_create_batch_async` method. This issue becomes evident when using the `create_batch` method for more than 1,000 data rows. This problem impacts not only Airbnb but also any other client using this SDK call for a larger volume of data rows exceeding 1,000.