### PR TITLE
[SDK-425] Remove unnecessary `client` argument from ExportTask methods

### DIFF
--- a/labelbox/schema/export_task.py
+++ b/labelbox/schema/export_task.py
@@ -539,32 +539,32 @@ class ExportTask:
         res = res["task"]["exportMetadataHeader"]
         return _MetadataHeader(**res) if res else None
 
-    def get_total_file_size(self, client, task_id: str,
+    def get_total_file_size(self, task_id: str,
                             stream_type: StreamType) -> Union[int, None]:
         """Returns the total file size for a specific task."""
         if not self._task.status in ["COMPLETE", "FAILED"]:
             raise ExportTask.TaskNotReadyException("Task is not ready yet")
-        header = ExportTask._get_metadata_header(client, task_id, stream_type)
+        header = ExportTask._get_metadata_header(self._task.client, task_id,
+                                                 stream_type)
         return header.total_size if header else None
 
-    def get_total_lines(self, client, task_id: str,
+    def get_total_lines(self, task_id: str,
                         stream_type: StreamType) -> Union[int, None]:
         """Returns the total file size for a specific task."""
         if not self._task.status in ["COMPLETE", "FAILED"]:
             raise ExportTask.TaskNotReadyException("Task is not ready yet")
-        header = ExportTask._get_metadata_header(client, task_id, stream_type)
+        header = ExportTask._get_metadata_header(self._task.client, task_id,
+                                                 stream_type)
         return header.total_lines if header else None
 
     def has_result(self) -> bool:
         """Returns whether the task has a result."""
-        total_size = self.get_total_file_size(self._task.client, self._task.uid,
-                                              StreamType.RESULT)
+        total_size = self.get_total_file_size(self._task.uid, StreamType.RESULT)
         return total_size is not None and total_size > 0
 
     def has_errors(self) -> bool:
         """Returns whether the task has errors."""
-        total_size = self.get_total_file_size(self._task.client, self._task.uid,
-                                              StreamType.ERRORS)
+        total_size = self.get_total_file_size(self._task.uid, StreamType.ERRORS)
         return total_size is not None and total_size > 0
 
     @overload


### PR DESCRIPTION
`client` is not necessary as it can be obtained from the Task itself.