### PR TITLE
Remove stack trace and sql query from error message.

### DIFF
--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -174,7 +174,7 @@ class ModelRun(DbObject):
             if res['status'] == 'COMPLETE':
                 return True
             elif res['status'] == 'FAILED':
-                raise Exception(f"Job failed. Details : {res['errorMessage']}")
+                raise Exception(f"Job failed.")
             timeout_seconds -= sleep_time
             if timeout_seconds <= 0:
                 raise TimeoutError(


### PR DESCRIPTION
Remove SQL query from this particular error state, since it doesn't help the user and exposes our query and schema.