### PR TITLE
[PTDT-1809] Fixed bug that attaches empty ontology with ontologies containing dropdowns

### DIFF
--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -692,10 +692,8 @@ class Project(DbObject, Updateable, Deletable):
         LFO = Entity.LabelingFrontendOptions
         self.client._create(
             LFO, {
-                LFO.project:
-                    self,
-                LFO.labeling_frontend:
-                    labeling_frontend,
+                LFO.project: self,
+                LFO.labeling_frontend: labeling_frontend,
                 LFO.customization_options: ""
             })
 


### PR DESCRIPTION
Testing Steps:

https://www.loom.com/share/19ab5ad56fd6473ca19539dc2e1c5380

* Enable [block-reuse-of-ontology-with-dropdowns](https://app.launchdarkly.com/default/test/features/block-reuse-of-ontology-with-dropdowns/targeting) for your user
* Create an ontology that contains dropdowns

GraphQL Mutation:
```
mutation UpsertOntology($id: ID, $name: String!, $normalized: String!, $mediaType: MediaType, $editorTaskType: EditorTaskType) {
  upsertOntology(
    data: {id: $id, name: $name, normalized: $normalized, mediaType: $mediaType, editorTaskType: $editorTaskType}
  ) {
    id
    name
    normalized
    normalizedAll: normalized(status: ALL)
    mediaType
    editorTaskType
    rootSchemaNodes {
      nodes {
        id
        name
        kind
        __typename
      }
      __typename
    }
    __typename
  }
}
```

Variables
```
{
  "name": "Ontology Containing Dropdown [Test]",
  "normalized": "{\r\n \"id\": \"clohlmvbx0058jkmf99703lpx\",\r\n \"name\": \"Ontology with Dropdown\",\r\n \"tools\": [\r\n  {\r\n   \"schemaNodeId\": \"clohlmvd0005ajkmfcml88wmp\",\r\n   \"featureSchemaId\": \"clohlmvd00059jkmf47vx0q0j\",\r\n   \"required\": false,\r\n   \"name\": \"sdef\",\r\n   \"tool\": \"named-entity\",\r\n   \"color\": \"#1CE6FF\",\r\n   \"archived\": 0,\r\n   \"classifications\": [],\r\n   \"kind\": \"NamedEntity\"\r\n  }\r\n ],\r\n \"classifications\": [\r\n  {\r\n   \"schemaNodeId\": \"clp1300m10016mumfc4fbatbl\",\r\n   \"featureSchemaId\": \"clp1300m1000zmumfa3792z0v\",\r\n   \"archived\": 0,\r\n   \"required\": false,\r\n   \"instructions\": \"Radio with nested dropdown\",\r\n   \"name\": \"radio_with_nested_dropdown\",\r\n   \"type\": \"radio\",\r\n   \"scope\": \"global\",\r\n   \"kind\": \"RadioQuestion\",\r\n   \"options\": [\r\n    {\r\n     \"schemaNodeId\": \"clp1300m10015mumf7hd83tc2\",\r\n     \"featureSchemaId\": \"clp1300m10010mumf0xbe399b\",\r\n     \"label\": \"Option 1\",\r\n     \"value\": \"option 1\",\r\n     \"position\": 0,\r\n     \"options\": [\r\n      {\r\n       \"schemaNodeId\": \"clp1300m10014mumf0i9edqw0\",\r\n       \"featureSchemaId\": \"clp1300m10011mumf0m8u2x8v\",\r\n       \"archived\": 0,\r\n       \"required\": false,\r\n       \"instructions\": \"Nested Dropdown\",\r\n       \"name\": \"nested_dropdown\",\r\n       \"type\": \"dropdown\",\r\n       \"position\": 0,\r\n       \"kind\": \"DropdownQuestion\",\r\n       \"options\": [\r\n        {\r\n         \"schemaNodeId\": \"clp1300m10013mumfcq971bdy\",\r\n         \"featureSchemaId\": \"clp1300m10012mumf68gh4bbv\",\r\n         \"label\": \"Dropdown Option 1\",\r\n         \"value\": \"dropdown_option_1\",\r\n         \"position\": 0,\r\n         \"kind\": \"DropdownOption\"\r\n        }\r\n       ]\r\n      }\r\n     ],\r\n     \"kind\": \"RadioOption\"\r\n    }\r\n   ]\r\n  }\r\n ],\r\n \"relationships\": [],\r\n \"realTime\": false\r\n}",
  "mediaType": "TEXT"
}
```

* Create a brand new text project

Python Script that calls `setup_editor()` which:
* Sets a labeling frontend for the project
* Connects an ontology to the project

```
from labelbox import Client, MediaType, QueueMode, Classification
import os

client = Client(
    api_key=os.environ.get('LOCALHOST_API_KEY'), # Paste your API key here. I keep mine in an env variable.
    endpoint='http://localhost:3000/api/_gql',
)

project = client.get_project(<project_id>)
ontology_with_dropdowns = client.get_ontology(<ontology_id>)
project.setup_editor(ontology_with_dropdowns)
```

* Verify you receive an error message in the console
* View the ontology in the UI and ensure an ontology has not been connected.