### PR TITLE
Remove exports v1 deprecation warning

### DIFF
--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -328,9 +328,6 @@ class Project(DbObject, Updateable, Deletable):
             URL of the data file with this Project's labels. If the server didn't
             generate during the `timeout_seconds` period, None is returned.
         """
-        warnings.warn(
-            "You are currently utilizing exports v1 for this action, which will be deprecated after December 31st, 2023. We recommend transitioning to exports v2. To view export v2 details, visit our docs: https://docs.labelbox.com/reference/label-export",
-            DeprecationWarning)
 
         def _string_from_dict(dictionary: dict, value_with_quotes=False) -> str:
             """Returns a concatenated string of the dictionary's keys and values


### PR DESCRIPTION
Removing the deprecation message for exports v1 by Dec 31st, 2023.