### PR TITLE
Vb/set labeling params overrides gk sdk 412

### DIFF
--- a/labelbox/__init__.py
+++ b/labelbox/__init__.py
@@ -34,3 +34,4 @@ from labelbox.schema.slice import Slice, CatalogSlice, ModelSlice
 from labelbox.schema.queue_mode import QueueMode
 from labelbox.schema.task_queue import TaskQueue
 from labelbox.schema.identifiables import UniqueIds, GlobalKeys, DataRowIds
+from labelbox.schema.identifiable import UniqueId, GlobalKey

--- a/labelbox/schema/__init__.py
+++ b/labelbox/schema/__init__.py
@@ -22,3 +22,4 @@ import labelbox.schema.batch
 import labelbox.schema.iam_integration
 import labelbox.schema.media_type
 import labelbox.schema.identifiables
+import labelbox.schema.identifiable

--- a/labelbox/schema/id_type.py
+++ b/labelbox/schema/id_type.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class IdType(str, Enum):
+    """
+    The type of id used to identify a data row.
+    
+    Currently supported types are:
+        - DataRowId: The id assigned to a data row by Labelbox.
+        - GlobalKey: The id assigned to a data row by the user.
+    """
+    DataRowId = "ID"
+    GlobalKey = "GKEY"

--- a/labelbox/schema/identifiable.py
+++ b/labelbox/schema/identifiable.py
@@ -1,5 +1,7 @@
-from abc import ABC, abstractmethod
-from typing import List, Union
+from abc import ABC
+from typing import Union
+
+from labelbox.schema.id_type import IdType
 
 
 class Identifiable(ABC):
@@ -7,32 +9,44 @@ class Identifiable(ABC):
     Base class for any object representing a unique identifier.
     """
 
-    def __init__(self, key: str):
+    def __init__(self, key: str, id_type: IdType):
         self._key = key
+        self._id_type = id_type
 
     @property
     def key(self):
-        return self.key
+        return self._key
+
+    @property
+    def id_type(self):
+        return self._id_type
 
     def __eq__(self, other):
-        return other.key == self.key
+        return other.key == self.key and other.id_type == self.id_type
 
     def __hash__(self):
-        hash(self.key)
+        return hash((self.key, self.id_type))
 
     def __str__(self):
-        return self.key.__str__()
+        return f"{self.id_type}:{self.key}"
 
 
 class UniqueId(Identifiable):
     """
     Represents a unique, internally generated id.
     """
-    pass
+
+    def __init__(self, key: str):
+        super().__init__(key, IdType.DataRowId)
 
 
 class GlobalKey(Identifiable):
     """
     Represents a user generated id.
     """
-    pass
+
+    def __init__(self, key: str):
+        super().__init__(key, IdType.GlobalKey)
+
+
+DataRowIdentifier = Union[UniqueId, GlobalKey]

--- a/labelbox/schema/identifiables.py
+++ b/labelbox/schema/identifiables.py
@@ -1,17 +1,6 @@
-from enum import Enum
 from typing import List, Union
 
-
-class IdType(str, Enum):
-    """
-    The type of id used to identify a data row.
-    
-    Currently supported types are:
-        - DataRowId: The id assigned to a data row by Labelbox.
-        - GlobalKey: The id assigned to a data row by the user.
-    """
-    DataRowId = "ID"
-    GlobalKey = "GKEY"
+from labelbox.schema.id_type import IdType
 
 
 class Identifiables:

--- a/tests/integration/test_labeling_parameter_overrides.py
+++ b/tests/integration/test_labeling_parameter_overrides.py
@@ -1,5 +1,6 @@
 import pytest
 from labelbox import DataRow
+from labelbox.schema.identifiable import GlobalKey, UniqueId
 from labelbox.schema.identifiables import GlobalKeys, UniqueIds
 
 
@@ -27,17 +28,36 @@ def test_labeling_parameter_overrides(consensus_project_with_batch):
     for override in updated_overrides:
         assert isinstance(override.data_row(), DataRow)
 
+    data = [(UniqueId(data_rows[0].uid), 1, 2), (UniqueId(data_rows[1].uid), 2),
+            (UniqueId(data_rows[2].uid), 3)]
+    success = project.set_labeling_parameter_overrides(data)
+    assert success
+    updated_overrides = list(project.labeling_parameter_overrides())
+    assert len(updated_overrides) == 3
+    assert {o.number_of_labels for o in updated_overrides} == {1, 1, 1}
+    assert {o.priority for o in updated_overrides} == {1, 2, 3}
+
+    data = [(GlobalKey(data_rows[0].global_key), 2, 2),
+            (GlobalKey(data_rows[1].global_key), 3, 3),
+            (GlobalKey(data_rows[2].global_key), 4)]
+    success = project.set_labeling_parameter_overrides(data)
+    assert success
+    updated_overrides = list(project.labeling_parameter_overrides())
+    assert len(updated_overrides) == 3
+    assert {o.number_of_labels for o in updated_overrides} == {1, 1, 1}
+    assert {o.priority for o in updated_overrides} == {2, 3, 4}
+
     with pytest.raises(TypeError) as exc_info:
         data = [(data_rows[2], "a_string", 3)]
         project.set_labeling_parameter_overrides(data)
     assert str(exc_info.value) == \
-           f"Priority must be an int. Found <class 'str'> for data_row {data_rows[2]}. Index: 0"
+            f"Priority must be an int. Found <class 'str'> for data_row_identifier {data_rows[2].uid}"
 
     with pytest.raises(TypeError) as exc_info:
         data = [(data_rows[2].uid, 1)]
         project.set_labeling_parameter_overrides(data)
     assert str(exc_info.value) == \
-           "data_row should be be of type DataRow. Found <class 'str'>. Index: 0"
+            f"Data row identifier should be be of type DataRow, UniqueId or GlobalKey. Found <class 'str'> for data_row_identifier {data_rows[2].uid}"
 
 
 def test_set_labeling_priority(consensus_project_with_batch):

--- a/tests/unit/test_unit_project_validate_labeling_parameter_overrides.py
+++ b/tests/unit/test_unit_project_validate_labeling_parameter_overrides.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import MagicMock
+
+from labelbox.schema.data_row import DataRow
+from labelbox.schema.identifiable import GlobalKey, UniqueId
+from labelbox.schema.project import validate_labeling_parameter_overrides
+
+
+def test_validate_labeling_parameter_overrides_valid_data():
+    mock_data_row = MagicMock(spec=DataRow)
+    mock_data_row.uid = "abc"
+    data = [(mock_data_row, 1), (UniqueId("efg"), 2), (GlobalKey("hij"), 3)]
+    validate_labeling_parameter_overrides(data)
+
+
+def test_validate_labeling_parameter_overrides_invalid_data():
+    data = [("abc", 1), (UniqueId("efg"), 2), (GlobalKey("hij"), 3)]
+    with pytest.raises(TypeError):
+        validate_labeling_parameter_overrides(data)
+
+
+def test_validate_labeling_parameter_overrides_invalid_priority():
+    mock_data_row = MagicMock(spec=DataRow)
+    mock_data_row.uid = "abc"
+    data = [(mock_data_row, "invalid"), (UniqueId("efg"), 2),
+            (GlobalKey("hij"), 3)]
+    with pytest.raises(TypeError):
+        validate_labeling_parameter_overrides(data)
+
+
+def test_validate_labeling_parameter_overrides_invalid_tuple_length():
+    mock_data_row = MagicMock(spec=DataRow)
+    mock_data_row.uid = "abc"
+    data = [(mock_data_row, "invalid"), (UniqueId("efg"), 2),
+            (GlobalKey("hij"))]
+    with pytest.raises(TypeError):
+        validate_labeling_parameter_overrides(data)


### PR DESCRIPTION
Story: https://labelbox.atlassian.net/browse/SDK-412

Implemented support for passing `GlobalKey` for .

As a result refactored Project `set_labeling_parameter_overrides`

Corresponding API PR: https://github.com/Labelbox/intelligence/pull/18429