### PR TITLE
fixed bug that would cause ground truth import with label objects to break

### DIFF
--- a/labelbox/data/serialization/ndjson/converter.py
+++ b/labelbox/data/serialization/ndjson/converter.py
@@ -41,7 +41,7 @@ class NDJsonConverter:
             A generator for accessing the ndjson representation of the data
         """
         for example in NDLabel.from_common(labels):
-            res = example.dict(by_alias=True)
+            res = example.dict(by_alias=True, exclude={"uuid"})
             for k, v in list(res.items()):
                 if k in IGNORE_IF_NONE and v is None:
                     del res[k]


### PR DESCRIPTION
Hey! So I was working on a notebook where I was importing some ground truths, and I noticed when you import labels as ground truths from label objects, some would just not import, but if you import them as NDJSON format, they would all import. I did some digging and realized the serialize function to this one with pydanics was adding a UUID field to the NDJSON which was causing some issues but not giving me any errors. It looks like we only validate that the objects have a dataRow item with either a global_key or an id. I'm not sure what other methods use that UUID field as I could have deleted it out on the pedantic models. It seems to be a deprecated feature, but to avoid messing with some of our other methods, I just had it exclude that uuid when it makes the dict this fixed my issue and will show up correctly in the UI, but I think there is still some underlying issues since I believe the label exports are still messed up. 