### PR TITLE
fixed minor bug with foundry run_foundry_app method

### DIFF
--- a/labelbox/schema/foundry/app.py
+++ b/labelbox/schema/foundry/app.py
@@ -9,7 +9,7 @@ class App(_CamelCaseMixin, BaseModel):
     id: Optional[str]
     model_id: str
     name: str
-    description: str
+    description: Optional[str] = None
     inference_params: Dict[str, Any]
     class_to_schema_id: Dict[str, str]
     ontology_id: str

--- a/labelbox/schema/foundry/foundry_client.py
+++ b/labelbox/schema/foundry/foundry_client.py
@@ -57,11 +57,6 @@ class FoundryClient:
             raise exceptions.ResourceNotFoundError(App, params)
         except Exception as e:
             raise exceptions.LabelboxError(f'Unable to get app with id {id}', e)
-
-        #if description on foundry app is None changes it to an empty string
-        if not response["findModelFoundryApp"]["description"]:
-            response["findModelFoundryApp"]["description"] = ""
-
         return App(**response["findModelFoundryApp"])
 
     def _delete_app(self, id: str) -> None:

--- a/labelbox/schema/foundry/foundry_client.py
+++ b/labelbox/schema/foundry/foundry_client.py
@@ -57,6 +57,11 @@ class FoundryClient:
             raise exceptions.ResourceNotFoundError(App, params)
         except Exception as e:
             raise exceptions.LabelboxError(f'Unable to get app with id {id}', e)
+
+        #if description on foundry app is None changes it to an empty string
+        if not response["findModelFoundryApp"]["description"]:
+            response["findModelFoundryApp"]["description"] = ""
+
         return App(**response["findModelFoundryApp"])
 
     def _delete_app(self, id: str) -> None:


### PR DESCRIPTION
There is a bug I noticed with one of my notebooks. On the run_foundry_app, it is giving me a traceback. I looked through the methods, and it looks like when it creates the APP item with the response for the Pydantic base model, it expects str for the description, but if it is blank, the response actually gives a None object. I made a minor change that makes that field optional with a default value of None, and it works