### PR TITLE
Pno/qqc 3095 project get overview

### DIFF
--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -1655,7 +1655,24 @@ class Project(DbObject, Updateable, Deletable):
         return response["queryAllDataRowsHaveBeenProcessed"][
             "allDataRowsHaveBeenProcessed"]
 
-    def get_overview(self, with_issues=False):
+    def get_overview(self, with_issues: bool = False) -> Dict:
+        """Return 
+
+                Args:
+                    with_issues: (optional) boolean to include issues in the overview
+                Returns:
+                    Dictionary with the following structure:
+                    {
+                        'Labeled': (int) Number of labeled data rows,
+                        'InReview': (dict) Name of the in review queue and associated number of data rows
+                        'InRework': (int) Number of data rows in rework,
+                        'Done': (int) Number of completed data rows,
+                        'ToLabel': (int) Number of data rows to label,
+                        'AllDataRows': (int) Total number of data rows,
+                        'Issues': (optional) Number of issues
+                    }
+                """
+
         query = """query GetWorkstreamStateCounts($projectId: ID!) {
             project(where: { id: $projectId }) {      
             workstreamStateCounts {

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -1698,7 +1698,7 @@ class Project(DbObject, Updateable, Deletable):
                                      experimental=True)["project"]
 
         overview = {
-            st["state"]: st["count"]
+            utils.snake_case(st["state"]): st["count"]
             for st in result["workstreamStateCounts"]
             if st["state"] != "NotInTaskQueue"
         }
@@ -1710,15 +1710,15 @@ class Project(DbObject, Updateable, Deletable):
         }
 
         # Store the total number of data rows in review
-        review_queues["All"] = overview["InReview"]
-        overview["InReview"] = review_queues
+        review_queues["all"] = overview["in_review"]
+        overview["in_review"] = review_queues
 
         if with_issues:
-            overview["Issues"] = result["issues"]["totalCount"]
+            overview["issues"] = result["issues"]["totalCount"]
 
         # Rename keys
-        overview["ToLabel"] = overview.pop("Unlabeled")
-        overview["AllDataRows"] = overview.pop("All")
+        overview["to_label"] = overview.pop("unlabeled")
+        overview["all_in_data_rows"] = overview.pop("all")
 
         return overview
 

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -1694,7 +1694,7 @@ class Project(DbObject, Updateable, Deletable):
         """
 
         # Must use experimental to access "issues"
-        result = self.client.execute(query, {"projectId": self.project_id},
+        result = self.client.execute(query, {"projectId": self.uid},
                                      experimental=True)["project"]
 
         overview = {

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -1674,7 +1674,7 @@ class Project(DbObject, Updateable, Deletable):
                     }
                 """
 
-        query = """query GetWorkstreamStateCounts($projectId: ID!) {
+        query = """query ProjectGetOverviewPyApi($projectId: ID!) {
             project(where: { id: $projectId }) {      
             workstreamStateCounts {
                 state

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -1656,7 +1656,8 @@ class Project(DbObject, Updateable, Deletable):
             "allDataRowsHaveBeenProcessed"]
 
     def get_overview(self, with_issues: bool = False) -> Dict:
-        """Return 
+        """ Return the number of data rows per task queue, and issues of a project
+            Equivalent of the Overview tab of a project
 
                 Args:
                     with_issues: (optional) boolean to include issues in the overview

--- a/tests/integration/test_task_queue.py
+++ b/tests/integration/test_task_queue.py
@@ -11,6 +11,9 @@ def test_get_task_queue(project: Project):
         tq for tq in task_queues if tq.queue_type == "MANUAL_REVIEW_QUEUE")
     assert review_queue
 
+    overview = project.get_overview(with_issues=True)
+    assert len(overview.keys) == 7
+
 
 def _validate_moved(project, queue_name, data_row_count):
     timeout_seconds = 30

--- a/tests/integration/test_task_queue.py
+++ b/tests/integration/test_task_queue.py
@@ -12,7 +12,7 @@ def test_get_task_queue(project: Project):
     assert review_queue
 
     overview = project.get_overview(with_issues=True)
-    assert len(overview.keys) == 7
+    assert len(overview.keys()) == 7
 
 
 def _validate_moved(project, queue_name, data_row_count):


### PR DESCRIPTION
`project.get_overview()` provides a shortcut for users to retrieve the number of data rows and their current status. It also provides the number of issues, if requested, like in the _Overview tab_ of a project.

Examples:

```project.get_overview()```
Result:

```
{'labeled': 4124,
 'in_review': {'Initial review task': 0, 'PolyPerception review': 0, 'all': 0},
 'in_rework': 0,
 'done': 4124,
 'to_label': 0,
 'all_data_rows': 4124}
```

```project.get_overview(with_review=True)```
Result:

```
{'labeled': 4124,
 'in_review': {'Initial review task': 0, 'PolyPerception review': 0, 'all': 0},
 'in_rework': 0,
 'done': 4124,
 'issues': 0,
 'to_label': 0,
 'all_data_rows': 4124}
```


