### PR TITLE
Add support of model_run_details to export_v2() for Model Runs

### DIFF
--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -558,6 +558,8 @@ class ModelRun(DbObject):
                         _params.get('data_row_details', False),
                     "includePredictions":
                         _params.get('predictions', False),
+                    "includeModelRunDetails":
+                        _params.get('model_run_details', False),
                 },
                 "streamable": streamable
             }


### PR DESCRIPTION
Before this PR, the following code will not work correctly because "model_run_details" is not implemented

## Before the PR:

```# load the annotations
model_run = lb_client.get_model_run(model_run_id)

export_params= {
    "data_row_details": True,
    "metadata_fields": True,
    "attachments": True,
    "predictions": True,
    "model_run_details": True
    }
```

Log:

DEBUG:labelbox.client:Query: mutation exportDataRowsInModelRunPyApi($input: ExportDataRowsInModelRunInput!){exportDataRowsInModelRun(input: $input){taskId}}, params: {'input': {'taskName': None, 'filters': {'modelRunId': 'a30daa11-37cd-0875-c05a-40ca39035c1e'}, 'params': {'mediaTypeOverride': None, 'includeAttachments': True, 'includeMetadata': True, 'includeDataRowDetails': True, 'includePredictions': True}, 'streamable': False}}, data None


## After the PR:

For the same code as above, the log now shows the following, with **includeModelRunDetails** now included


DEBUG:labelbox.client:Query: mutation exportDataRowsInModelRunPyApi($input: ExportDataRowsInModelRunInput!){exportDataRowsInModelRun(input: $input){taskId}}, params: {'input': {'taskName': None, 'filters': {'modelRunId': 'a30daa11-37cd-0875-c05a-40ca39035c1e'}, 'params': {'mediaTypeOverride': None, 'includeAttachments': True, 'includeMetadata': True, 'includeDataRowDetails': True, 'includePredictions': True, '**includeModelRunDetails**': True}, 'streamable': False}}, data None





