### PR TITLE
[QQC-2962] Add a method to get label count for project

### DIFF
--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -1149,6 +1149,20 @@ class Project(DbObject, Updateable, Deletable):
 
         return mode
 
+    def get_label_count(self) -> int:
+        """
+        Returns: the total number of labels in this project.
+        """
+
+        query_str = """query LabelCountPyApi($projectId: ID!) {
+            project(where: {id: $projectId}) {
+                labelCount
+            }
+        }"""
+
+        res = self.client.execute(query_str, {'projectId': self.uid})
+        return res["project"]["labelCount"]
+
     def get_queue_mode(self) -> "QueueMode":
         """
         Provides the queue mode used for this project.

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -287,5 +287,6 @@ def test_label_count(client, configured_batch_project_with_label):
     assert project.get_label_count() == 0
     project.delete()
 
-    num_labels = sum([1 for _ in configured_batch_project_with_label.labels()])
-    assert configured_batch_project_with_label.get_label_count() == num_labels
+    [source_project, _, _, _] = configured_batch_project_with_label
+    num_labels = sum([1 for _ in source_project.labels()])
+    assert source_project.get_label_count() == num_labels

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -280,3 +280,12 @@ def test_queue_mode(client, rand_gen):
                                     quality_mode=QualityMode.Consensus)
     assert project.auto_audit_number_of_labels == 3
     assert project.auto_audit_percentage == 0
+
+
+def test_label_count(client, configured_batch_project_with_label):
+    project = client.create_project(name="test label count")
+    assert project.get_label_count() == 0
+    project.delete()
+
+    num_labels = sum([1 for _ in configured_batch_project_with_label.labels()])
+    assert configured_batch_project_with_label.get_label_count() == num_labels


### PR DESCRIPTION
Adds a new method `get_label_count` to the Project class, which allows to effectively find how many labels are in the project. Our customers would do this before:

```python
labels_from_labelbox = sum([1 for _ in target_project.labels()])
```