### PR TITLE
[SDK-546] Must pass model run id in order for model slices to work correctly

### DIFF
--- a/labelbox/schema/slice.py
+++ b/labelbox/schema/slice.py
@@ -239,9 +239,10 @@ class ModelSlice(Slice):
     @classmethod
     def query_str(cls):
         query_str = """
-        query getDataRowIdenfifiersBySavedModelQueryPyApi($id: ID!, $from: DataRowIdentifierCursorInput, $first: Int!) {
+        query getDataRowIdenfifiersBySavedModelQueryPyApi($id: ID!, $modelRunId: ID, $from: DataRowIdentifierCursorInput, $first: Int!) {
             getDataRowIdentifiersBySavedModelQuery(input: {
                 savedQueryId: $id,
+                modelRunId: $modelRunId,
                 after: $from
                 first: $first
             }) {
@@ -263,9 +264,12 @@ class ModelSlice(Slice):
         """
         return query_str
 
-    def get_data_row_ids(self) -> PaginatedCollection:
+    def get_data_row_ids(self, model_run_id: str) -> PaginatedCollection:
         """
         Fetches all data row ids that match this Slice
+
+        Params
+        model_run_id: str, required, uid or cuid of model run
 
         Returns:
             A PaginatedCollection of data row ids
@@ -273,7 +277,10 @@ class ModelSlice(Slice):
         return PaginatedCollection(
             client=self.client,
             query=ModelSlice.query_str(),
-            params={'id': str(self.uid)},
+            params={
+                'id': str(self.uid),
+                'modelRunId': model_run_id
+            },
             dereferencing=['getDataRowIdentifiersBySavedModelQuery', 'nodes'],
             obj_class=lambda _, data_row_id_and_gk: data_row_id_and_gk.get('id'
                                                                           ),
@@ -282,9 +289,13 @@ class ModelSlice(Slice):
                 'endCursor'
             ])
 
-    def get_data_row_identifiers(self) -> PaginatedCollection:
+    def get_data_row_identifiers(self,
+                                 model_run_id: str) -> PaginatedCollection:
         """
         Fetches all data row ids and global keys (where defined) that match this Slice
+
+        Params:
+        model_run_id : str, required, uid or cuid of model run
 
         Returns:
             A PaginatedCollection of Slice.DataRowIdAndGlobalKey
@@ -292,7 +303,10 @@ class ModelSlice(Slice):
         return PaginatedCollection(
             client=self.client,
             query=ModelSlice.query_str(),
-            params={'id': str(self.uid)},
+            params={
+                'id': str(self.uid),
+                'modelRunId': model_run_id
+            },
             dereferencing=['getDataRowIdentifiersBySavedModelQuery', 'nodes'],
             obj_class=lambda _, data_row_id_and_gk: Slice.DataRowIdAndGlobalKey(
                 data_row_id_and_gk.get('id'),


### PR DESCRIPTION
I want to bring to attention the recent updates made to the SDK's ModelSlice methods, specifically `get_data_row_identifiers` and `get_data_row_ids`. We've modified these methods to now require a model run id as a parameter. It's important to note that these changes are **NOT backward-compatible**.

Prior to the last SDK release (version 3.61.0), these methods were non-functional. After the release of 3.61.0, they have not been operating correctly. This update, involving the inclusion of a model run id, is essentially a fix to ensure these methods work as intended.

While this change does break backward compatibility, it is necessary to correct the functionality that was previously either broken or incorrect.

Required API PR: https://github.com/Labelbox/intelligence/pull/19099