### PR TITLE
[AL-7738] Support custom metrics for predictions

### DIFF
--- a/labelbox/data/annotation_types/annotation.py
+++ b/labelbox/data/annotation_types/annotation.py
@@ -3,13 +3,13 @@ from typing import List, Union
 from labelbox.data.annotation_types.base_annotation import BaseAnnotation
 from labelbox.data.annotation_types.geometry.geometry import Geometry
 
-from labelbox.data.mixins import ConfidenceMixin
+from labelbox.data.mixins import ConfidenceMixin, CustomMetricsMixin
 
 from labelbox.data.annotation_types.classification.classification import ClassificationAnnotation
 from .ner import DocumentEntity, TextEntity, ConversationEntity
 
 
-class ObjectAnnotation(BaseAnnotation, ConfidenceMixin):
+class ObjectAnnotation(BaseAnnotation, ConfidenceMixin, CustomMetricsMixin):
     """Generic localized annotation (non classifications)
 
     >>> ObjectAnnotation(
@@ -27,5 +27,6 @@ class ObjectAnnotation(BaseAnnotation, ConfidenceMixin):
         classifications (Optional[List[ClassificationAnnotation]]): Optional sub classification of the annotation
         extra (Dict[str, Any])
     """
+
     value: Union[TextEntity, ConversationEntity, DocumentEntity, Geometry]
     classifications: List[ClassificationAnnotation] = []

--- a/labelbox/data/annotation_types/classification/classification.py
+++ b/labelbox/data/annotation_types/classification/classification.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Union, Optional
 import warnings
 from labelbox.data.annotation_types.base_annotation import BaseAnnotation
 
-from labelbox.data.mixins import ConfidenceMixin
+from labelbox.data.mixins import ConfidenceMixin, CustomMetricsMixin
 
 try:
     from typing import Literal
@@ -23,7 +23,7 @@ class _TempName(ConfidenceMixin, BaseModel):
         return res
 
 
-class ClassificationAnswer(FeatureSchema, ConfidenceMixin):
+class ClassificationAnswer(FeatureSchema, ConfidenceMixin, CustomMetricsMixin):
     """
     - Represents a classification option.
     - Because it inherits from FeatureSchema
@@ -47,7 +47,7 @@ class ClassificationAnswer(FeatureSchema, ConfidenceMixin):
         return res
 
 
-class Radio(ConfidenceMixin, BaseModel):
+class Radio(ConfidenceMixin, CustomMetricsMixin, BaseModel):
     """ A classification with only one selected option allowed
 
     >>> Radio(answer = ClassificationAnswer(name = "dog"))
@@ -66,7 +66,7 @@ class Checklist(_TempName):
     answer: List[ClassificationAnswer]
 
 
-class Text(ConfidenceMixin, BaseModel):
+class Text(ConfidenceMixin, CustomMetricsMixin, BaseModel):
     """ Free form text
 
     >>> Text(answer = "some text answer")

--- a/labelbox/data/annotation_types/classification/classification.py
+++ b/labelbox/data/annotation_types/classification/classification.py
@@ -93,7 +93,7 @@ class Dropdown(_TempName):
                       "removed in a future release")
 
 
-class ClassificationAnnotation(BaseAnnotation, ConfidenceMixin):
+class ClassificationAnnotation(BaseAnnotation, ConfidenceMixin, CustomMetricsMixin):
     """Classification annotations (non localized)
 
     >>> ClassificationAnnotation(

--- a/labelbox/data/annotation_types/classification/classification.py
+++ b/labelbox/data/annotation_types/classification/classification.py
@@ -93,7 +93,8 @@ class Dropdown(_TempName):
                       "removed in a future release")
 
 
-class ClassificationAnnotation(BaseAnnotation, ConfidenceMixin, CustomMetricsMixin):
+class ClassificationAnnotation(BaseAnnotation, ConfidenceMixin,
+                               CustomMetricsMixin):
     """Classification annotations (non localized)
 
     >>> ClassificationAnnotation(

--- a/labelbox/data/annotation_types/video.py
+++ b/labelbox/data/annotation_types/video.py
@@ -6,7 +6,7 @@ from labelbox.data.annotation_types.annotation import ClassificationAnnotation, 
 
 from labelbox.data.annotation_types.annotation import ClassificationAnnotation, ObjectAnnotation
 from labelbox.data.annotation_types.feature import FeatureSchema
-from labelbox.data.mixins import ConfidenceNotSupportedMixin
+from labelbox.data.mixins import ConfidenceNotSupportedMixin, CustomMetricsNotSupportedMixin
 from labelbox.utils import _CamelCaseMixin, is_valid_uri
 
 
@@ -24,7 +24,7 @@ class VideoClassificationAnnotation(ClassificationAnnotation):
     segment_index: Optional[int] = None
 
 
-class VideoObjectAnnotation(ObjectAnnotation, ConfidenceNotSupportedMixin):
+class VideoObjectAnnotation(ObjectAnnotation, ConfidenceNotSupportedMixin, CustomMetricsNotSupportedMixin):
     """Video object annotation
     >>> VideoObjectAnnotation(
     >>>     keyframe=True,

--- a/labelbox/data/annotation_types/video.py
+++ b/labelbox/data/annotation_types/video.py
@@ -24,7 +24,8 @@ class VideoClassificationAnnotation(ClassificationAnnotation):
     segment_index: Optional[int] = None
 
 
-class VideoObjectAnnotation(ObjectAnnotation, ConfidenceNotSupportedMixin, CustomMetricsNotSupportedMixin):
+class VideoObjectAnnotation(ObjectAnnotation, ConfidenceNotSupportedMixin,
+                            CustomMetricsNotSupportedMixin):
     """Video object annotation
     >>> VideoObjectAnnotation(
     >>>     keyframe=True,

--- a/labelbox/data/mixins.py
+++ b/labelbox/data/mixins.py
@@ -55,8 +55,8 @@ class CustomMetricsMixin(BaseModel):
     def dict(self, *args, **kwargs):
         res = super().dict(*args, **kwargs)
 
-        if "customMetrics" in res and res["customMetrics"] is None:
-            res.pop("customMetrics")
+        if "custom_metrics" in res and res["custom_metrics"] is None:
+            res.pop("custom_metrics")
 
         return res
 

--- a/labelbox/data/mixins.py
+++ b/labelbox/data/mixins.py
@@ -1,32 +1,70 @@
-from typing import Optional
+from typing import Optional, List
 
 from pydantic import BaseModel, validator
 
-from labelbox.exceptions import ConfidenceNotSupportedException
+from labelbox.exceptions import ConfidenceNotSupportedException, CustomMetricsNotSupportedException
 
 
 class ConfidenceMixin(BaseModel):
     confidence: Optional[float] = None
 
-    @validator('confidence')
+    @validator("confidence")
     def confidence_valid_float(cls, value):
         if value is None:
             return value
         if not isinstance(value, (int, float)) or not 0 <= value <= 1:
-            raise ValueError('must be a number within [0,1] range')
+            raise ValueError("must be a number within [0,1] range")
         return value
 
     def dict(self, *args, **kwargs):
         res = super().dict(*args, **kwargs)
-        if 'confidence' in res and res['confidence'] is None:
-            res.pop('confidence')
+        if "confidence" in res and res["confidence"] is None:
+            res.pop("confidence")
         return res
 
 
 class ConfidenceNotSupportedMixin:
-
     def __new__(cls, *args, **kwargs):
-        if 'confidence' in kwargs:
+        if "confidence" in kwargs:
             raise ConfidenceNotSupportedException(
-                'Confidence is not supported for this annotaiton type yet')
+                "Confidence is not supported for this annotation type yet"
+            )
+        return super().__new__(cls)
+
+
+class CustomMetric(BaseModel):
+    name: str
+    value: float
+
+    @validator("name")
+    def confidence_valid_float(cls, value):
+        if not isinstance(value, str):
+            raise ValueError("Name must be a string")
+        return value
+
+    @validator("value")
+    def value_valid_float(cls, value):
+        if not isinstance(value, (int, float)):
+            raise ValueError("Value must be a number")
+        return value
+
+
+class CustomMetricsMixin(BaseModel):
+    custom_metrics: Optional[List[CustomMetric]] = None
+
+    def dict(self, *args, **kwargs):
+        res = super().dict(*args, **kwargs)
+
+        if "customMetrics" in res and res["customMetrics"] is None:
+            res.pop("customMetrics")
+
+        return res
+
+
+class CustomMetricsNotSupportedMixin:
+    def __new__(cls, *args, **kwargs):
+        if "custom_metrics" in kwargs:
+            raise CustomMetricsNotSupportedException(
+                "Custom metrics is not supported for this annotation type yet"
+            )
         return super().__new__(cls)

--- a/labelbox/data/mixins.py
+++ b/labelbox/data/mixins.py
@@ -24,11 +24,11 @@ class ConfidenceMixin(BaseModel):
 
 
 class ConfidenceNotSupportedMixin:
+
     def __new__(cls, *args, **kwargs):
         if "confidence" in kwargs:
             raise ConfidenceNotSupportedException(
-                "Confidence is not supported for this annotation type yet"
-            )
+                "Confidence is not supported for this annotation type yet")
         return super().__new__(cls)
 
 
@@ -62,9 +62,9 @@ class CustomMetricsMixin(BaseModel):
 
 
 class CustomMetricsNotSupportedMixin:
+
     def __new__(cls, *args, **kwargs):
         if "custom_metrics" in kwargs:
             raise CustomMetricsNotSupportedException(
-                "Custom metrics is not supported for this annotation type yet"
-            )
+                "Custom metrics is not supported for this annotation type yet")
         return super().__new__(cls)

--- a/labelbox/data/mixins.py
+++ b/labelbox/data/mixins.py
@@ -55,6 +55,9 @@ class CustomMetricsMixin(BaseModel):
     def dict(self, *args, **kwargs):
         res = super().dict(*args, **kwargs)
 
+        if "customMetrics" in res and res["customMetrics"] is None:
+            res.pop("customMetrics")
+
         if "custom_metrics" in res and res["custom_metrics"] is None:
             res.pop("custom_metrics")
 

--- a/labelbox/data/serialization/ndjson/classification.py
+++ b/labelbox/data/serialization/ndjson/classification.py
@@ -64,20 +64,20 @@ class NDTextSubclass(NDAnswer):
     answer: str
 
     def to_common(self) -> Text:
-        return Text(
-            answer=self.answer, confidence=self.confidence, custom_metrics=self.custom_metrics
-        )
-
+        return Text(answer=self.answer,
+                    confidence=self.confidence,
+                    custom_metrics=self.custom_metrics)
 
     @classmethod
     def from_common(cls, text: Text, name: str,
                     feature_schema_id: Cuid) -> "NDTextSubclass":
-        return cls(answer=text.answer,
-                   name=name,
-                   schema_id=feature_schema_id,
-                   confidence=text.confidence,
-                   custom_metrics=text.custom_metrics,
-                   )
+        return cls(
+            answer=text.answer,
+            name=name,
+            schema_id=feature_schema_id,
+            confidence=text.confidence,
+            custom_metrics=text.custom_metrics,
+        )
 
 
 class NDChecklistSubclass(NDAnswer):
@@ -133,8 +133,7 @@ class NDRadioSubclass(NDAnswer):
                 NDSubclassification.to_common(annot)
                 for annot in self.answer.classifications
             ],
-            custom_metrics=self.answer.custom_metrics
-        ))
+            custom_metrics=self.answer.custom_metrics))
 
     @classmethod
     def from_common(cls, radio: Radio, name: str,
@@ -181,16 +180,18 @@ class NDText(NDAnnotation, NDTextSubclass):
 class NDChecklist(NDAnnotation, NDChecklistSubclass, VideoSupported):
 
     @classmethod
-    def from_common(cls,
-                    uuid: str,
-                    checklist: Checklist,
-                    name: str,
-                    feature_schema_id: Cuid,
-                    extra: Dict[str, Any],
-                    data: Union[VideoData, TextData, ImageData],
-                    message_id: str,
-                    confidence: Optional[float] = None,
-                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDChecklist":
+    def from_common(
+            cls,
+            uuid: str,
+            checklist: Checklist,
+            name: str,
+            feature_schema_id: Cuid,
+            extra: Dict[str, Any],
+            data: Union[VideoData, TextData, ImageData],
+            message_id: str,
+            confidence: Optional[float] = None,
+            custom_metrics: Optional[List[CustomMetric]] = None
+    ) -> "NDChecklist":
 
         return cls(answer=[
             NDAnswer(name=answer.name,

--- a/labelbox/data/serialization/ndjson/classification.py
+++ b/labelbox/data/serialization/ndjson/classification.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Union, Optional
 
 from pydantic import BaseModel, Field, root_validator
-from labelbox.data.mixins import ConfidenceMixin
+from labelbox.data.mixins import ConfidenceMixin, CustomMetric, CustomMetricsMixin
 from labelbox.data.serialization.ndjson.base import DataRow, NDAnnotation
 
 from labelbox.utils import camel_case
@@ -12,7 +12,7 @@ from ...annotation_types.types import Cuid
 from ...annotation_types.data import TextData, VideoData, ImageData
 
 
-class NDAnswer(ConfidenceMixin):
+class NDAnswer(ConfidenceMixin, CustomMetricsMixin):
     name: Optional[str] = None
     schema_id: Optional[Cuid] = None
     classifications: Optional[List['NDSubclassificationType']] = []
@@ -64,7 +64,10 @@ class NDTextSubclass(NDAnswer):
     answer: str
 
     def to_common(self) -> Text:
-        return Text(answer=self.answer, confidence=self.confidence)
+        return Text(
+            answer=self.answer, confidence=self.confidence, custom_metrics=self.custom_metrics
+        )
+
 
     @classmethod
     def from_common(cls, text: Text, name: str,
@@ -72,7 +75,9 @@ class NDTextSubclass(NDAnswer):
         return cls(answer=text.answer,
                    name=name,
                    schema_id=feature_schema_id,
-                   confidence=text.confidence)
+                   confidence=text.confidence,
+                   custom_metrics=text.custom_metrics,
+                   )
 
 
 class NDChecklistSubclass(NDAnswer):
@@ -87,7 +92,8 @@ class NDChecklistSubclass(NDAnswer):
                                  classifications=[
                                      NDSubclassification.to_common(annot)
                                      for annot in answer.classifications
-                                 ])
+                                 ],
+                                 custom_metrics=answer.custom_metrics)
             for answer in self.answer
         ])
 
@@ -101,7 +107,8 @@ class NDChecklistSubclass(NDAnswer):
                      classifications=[
                          NDSubclassification.from_common(annot)
                          for annot in answer.classifications
-                     ])
+                     ],
+                     custom_metrics=answer.custom_metrics)
             for answer in checklist.answer
         ],
                    name=name,
@@ -126,6 +133,7 @@ class NDRadioSubclass(NDAnswer):
                 NDSubclassification.to_common(annot)
                 for annot in self.answer.classifications
             ],
+            custom_metrics=self.answer.custom_metrics
         ))
 
     @classmethod
@@ -137,7 +145,8 @@ class NDRadioSubclass(NDAnswer):
                                    classifications=[
                                        NDSubclassification.from_common(annot)
                                        for annot in radio.answer.classifications
-                                   ]),
+                                   ],
+                                   custom_metrics=radio.answer.custom_metrics),
                    name=name,
                    schema_id=feature_schema_id)
 
@@ -165,6 +174,7 @@ class NDText(NDAnnotation, NDTextSubclass):
             uuid=uuid,
             message_id=message_id,
             confidence=text.confidence,
+            custom_metrics=text.custom_metrics,
         )
 
 
@@ -179,7 +189,8 @@ class NDChecklist(NDAnnotation, NDChecklistSubclass, VideoSupported):
                     extra: Dict[str, Any],
                     data: Union[VideoData, TextData, ImageData],
                     message_id: str,
-                    confidence: Optional[float] = None) -> "NDChecklist":
+                    confidence: Optional[float] = None,
+                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDChecklist":
 
         return cls(answer=[
             NDAnswer(name=answer.name,
@@ -188,7 +199,8 @@ class NDChecklist(NDAnnotation, NDChecklistSubclass, VideoSupported):
                      classifications=[
                          NDSubclassification.from_common(annot)
                          for annot in answer.classifications
-                     ])
+                     ],
+                     custom_metrics=answer.custom_metrics)
             for answer in checklist.answer
         ],
                    data_row=DataRow(id=data.uid, global_key=data.global_key),
@@ -220,7 +232,8 @@ class NDRadio(NDAnnotation, NDRadioSubclass, VideoSupported):
                                    classifications=[
                                        NDSubclassification.from_common(annot)
                                        for annot in radio.answer.classifications
-                                   ]),
+                                   ],
+                                   custom_metrics=radio.answer.custom_metrics),
                    data_row=DataRow(id=data.uid, global_key=data.global_key),
                    name=name,
                    schema_id=feature_schema_id,

--- a/labelbox/data/serialization/ndjson/objects.py
+++ b/labelbox/data/serialization/ndjson/objects.py
@@ -55,16 +55,17 @@ class NDPoint(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
         return Point(x=self.point.x, y=self.point.y)
 
     @classmethod
-    def from_common(cls,
-                    uuid: str,
-                    point: Point,
-                    classifications: List[ClassificationAnnotation],
-                    name: str,
-                    feature_schema_id: Cuid,
-                    extra: Dict[str, Any],
-                    data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None,
-                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDPoint":
+    def from_common(
+            cls,
+            uuid: str,
+            point: Point,
+            classifications: List[ClassificationAnnotation],
+            name: str,
+            feature_schema_id: Cuid,
+            extra: Dict[str, Any],
+            data: Union[ImageData, TextData],
+            confidence: Optional[float] = None,
+            custom_metrics: Optional[List[CustomMetric]] = None) -> "NDPoint":
         return cls(point={
             'x': point.x,
             'y': point.y
@@ -115,16 +116,17 @@ class NDLine(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
         return Line(points=[Point(x=pt.x, y=pt.y) for pt in self.line])
 
     @classmethod
-    def from_common(cls,
-                    uuid: str,
-                    line: Line,
-                    classifications: List[ClassificationAnnotation],
-                    name: str,
-                    feature_schema_id: Cuid,
-                    extra: Dict[str, Any],
-                    data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None,
-                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDLine":
+    def from_common(
+            cls,
+            uuid: str,
+            line: Line,
+            classifications: List[ClassificationAnnotation],
+            name: str,
+            feature_schema_id: Cuid,
+            extra: Dict[str, Any],
+            data: Union[ImageData, TextData],
+            confidence: Optional[float] = None,
+            custom_metrics: Optional[List[CustomMetric]] = None) -> "NDLine":
         return cls(line=[{
             'x': pt.x,
             'y': pt.y
@@ -192,16 +194,17 @@ class NDPolygon(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
         return Polygon(points=[Point(x=pt.x, y=pt.y) for pt in self.polygon])
 
     @classmethod
-    def from_common(cls,
-                    uuid: str,
-                    polygon: Polygon,
-                    classifications: List[ClassificationAnnotation],
-                    name: str,
-                    feature_schema_id: Cuid,
-                    extra: Dict[str, Any],
-                    data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None,
-                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDPolygon":
+    def from_common(
+            cls,
+            uuid: str,
+            polygon: Polygon,
+            classifications: List[ClassificationAnnotation],
+            name: str,
+            feature_schema_id: Cuid,
+            extra: Dict[str, Any],
+            data: Union[ImageData, TextData],
+            confidence: Optional[float] = None,
+            custom_metrics: Optional[List[CustomMetric]] = None) -> "NDPolygon":
         return cls(polygon=[{
             'x': pt.x,
             'y': pt.y
@@ -224,16 +227,18 @@ class NDRectangle(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
                                    y=self.bbox.top + self.bbox.height))
 
     @classmethod
-    def from_common(cls,
-                    uuid: str,
-                    rectangle: Rectangle,
-                    classifications: List[ClassificationAnnotation],
-                    name: str,
-                    feature_schema_id: Cuid,
-                    extra: Dict[str, Any],
-                    data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None,
-                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDRectangle":
+    def from_common(
+            cls,
+            uuid: str,
+            rectangle: Rectangle,
+            classifications: List[ClassificationAnnotation],
+            name: str,
+            feature_schema_id: Cuid,
+            extra: Dict[str, Any],
+            data: Union[ImageData, TextData],
+            confidence: Optional[float] = None,
+            custom_metrics: Optional[List[CustomMetric]] = None
+    ) -> "NDRectangle":
         return cls(bbox=Bbox(top=min(rectangle.start.y, rectangle.end.y),
                              left=min(rectangle.start.x, rectangle.end.x),
                              height=abs(rectangle.end.y - rectangle.start.y),
@@ -261,16 +266,18 @@ class NDDocumentRectangle(NDRectangle):
                                  unit=self.unit)
 
     @classmethod
-    def from_common(cls,
-                    uuid: str,
-                    rectangle: DocumentRectangle,
-                    classifications: List[ClassificationAnnotation],
-                    name: str,
-                    feature_schema_id: Cuid,
-                    extra: Dict[str, Any],
-                    data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None,
-                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDRectangle":
+    def from_common(
+            cls,
+            uuid: str,
+            rectangle: DocumentRectangle,
+            classifications: List[ClassificationAnnotation],
+            name: str,
+            feature_schema_id: Cuid,
+            extra: Dict[str, Any],
+            data: Union[ImageData, TextData],
+            confidence: Optional[float] = None,
+            custom_metrics: Optional[List[CustomMetric]] = None
+    ) -> "NDRectangle":
         return cls(bbox=Bbox(top=min(rectangle.start.y, rectangle.end.y),
                              left=min(rectangle.start.x, rectangle.end.x),
                              height=abs(rectangle.end.y - rectangle.start.y),
@@ -474,16 +481,17 @@ class NDMask(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
             return Mask(mask=MaskData.from_2D_arr(image), color=(1, 1, 1))
 
     @classmethod
-    def from_common(cls,
-                    uuid: str,
-                    mask: Mask,
-                    classifications: List[ClassificationAnnotation],
-                    name: str,
-                    feature_schema_id: Cuid,
-                    extra: Dict[str, Any],
-                    data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None,
-                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDMask":
+    def from_common(
+            cls,
+            uuid: str,
+            mask: Mask,
+            classifications: List[ClassificationAnnotation],
+            name: str,
+            feature_schema_id: Cuid,
+            extra: Dict[str, Any],
+            data: Union[ImageData, TextData],
+            confidence: Optional[float] = None,
+            custom_metrics: Optional[List[CustomMetric]] = None) -> "NDMask":
 
         if mask.mask.url is not None:
             lbv1_mask = _URIMask(instanceURI=mask.mask.url, colorRGB=mask.color)
@@ -568,16 +576,18 @@ class NDTextEntity(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
         return TextEntity(start=self.location.start, end=self.location.end)
 
     @classmethod
-    def from_common(cls,
-                    uuid: str,
-                    text_entity: TextEntity,
-                    classifications: List[ClassificationAnnotation],
-                    name: str,
-                    feature_schema_id: Cuid,
-                    extra: Dict[str, Any],
-                    data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None,
-                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDTextEntity":
+    def from_common(
+            cls,
+            uuid: str,
+            text_entity: TextEntity,
+            classifications: List[ClassificationAnnotation],
+            name: str,
+            feature_schema_id: Cuid,
+            extra: Dict[str, Any],
+            data: Union[ImageData, TextData],
+            confidence: Optional[float] = None,
+            custom_metrics: Optional[List[CustomMetric]] = None
+    ) -> "NDTextEntity":
         return cls(location=Location(
             start=text_entity.start,
             end=text_entity.end,
@@ -600,16 +610,18 @@ class NDDocumentEntity(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
                               text_selections=self.text_selections)
 
     @classmethod
-    def from_common(cls,
-                    uuid: str,
-                    document_entity: DocumentEntity,
-                    classifications: List[ClassificationAnnotation],
-                    name: str,
-                    feature_schema_id: Cuid,
-                    extra: Dict[str, Any],
-                    data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None,
-                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDDocumentEntity":
+    def from_common(
+        cls,
+        uuid: str,
+        document_entity: DocumentEntity,
+        classifications: List[ClassificationAnnotation],
+        name: str,
+        feature_schema_id: Cuid,
+        extra: Dict[str, Any],
+        data: Union[ImageData, TextData],
+        confidence: Optional[float] = None,
+        custom_metrics: Optional[List[CustomMetric]] = None
+    ) -> "NDDocumentEntity":
 
         return cls(text_selections=document_entity.text_selections,
                    dataRow=DataRow(id=data.uid, global_key=data.global_key),
@@ -631,16 +643,17 @@ class NDConversationEntity(NDTextEntity):
 
     @classmethod
     def from_common(
-            cls,
-            uuid: str,
-            conversation_entity: ConversationEntity,
-            classifications: List[ClassificationAnnotation],
-            name: str,
-            feature_schema_id: Cuid,
-            extra: Dict[str, Any],
-            data: Union[ImageData, TextData],
-            confidence: Optional[float] = None,
-            custom_metrics: Optional[List[CustomMetric]] = None) -> "NDConversationEntity":
+        cls,
+        uuid: str,
+        conversation_entity: ConversationEntity,
+        classifications: List[ClassificationAnnotation],
+        name: str,
+        feature_schema_id: Cuid,
+        extra: Dict[str, Any],
+        data: Union[ImageData, TextData],
+        confidence: Optional[float] = None,
+        custom_metrics: Optional[List[CustomMetric]] = None
+    ) -> "NDConversationEntity":
         return cls(location=Location(start=conversation_entity.start,
                                      end=conversation_entity.end),
                    message_id=conversation_entity.message_id,
@@ -664,9 +677,9 @@ class NDObject:
         ]
         confidence = annotation.confidence if hasattr(annotation,
                                                       'confidence') else None
-        
-        custom_metrics = annotation.custom_metrics if hasattr(annotation,
-                                                      'custom_metrics') else None
+
+        custom_metrics = annotation.custom_metrics if hasattr(
+            annotation, 'custom_metrics') else None
         return ObjectAnnotation(value=common_annotation,
                                 name=annotation.name,
                                 feature_schema_id=annotation.schema_id,

--- a/labelbox/data/serialization/ndjson/objects.py
+++ b/labelbox/data/serialization/ndjson/objects.py
@@ -4,7 +4,7 @@ import base64
 
 from labelbox.data.annotation_types.ner.conversation_entity import ConversationEntity
 from labelbox.data.annotation_types.video import VideoObjectAnnotation, DICOMObjectAnnotation
-from labelbox.data.mixins import ConfidenceMixin
+from labelbox.data.mixins import ConfidenceMixin, CustomMetricsMixin, CustomMetric, CustomMetricsNotSupportedMixin
 import numpy as np
 
 from pydantic import BaseModel
@@ -48,7 +48,7 @@ class Bbox(BaseModel):
     width: float
 
 
-class NDPoint(NDBaseObject, ConfidenceMixin):
+class NDPoint(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
     point: _Point
 
     def to_common(self) -> Point:
@@ -63,7 +63,8 @@ class NDPoint(NDBaseObject, ConfidenceMixin):
                     feature_schema_id: Cuid,
                     extra: Dict[str, Any],
                     data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None) -> "NDPoint":
+                    confidence: Optional[float] = None,
+                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDPoint":
         return cls(point={
             'x': point.x,
             'y': point.y
@@ -73,7 +74,8 @@ class NDPoint(NDBaseObject, ConfidenceMixin):
                    schema_id=feature_schema_id,
                    uuid=uuid,
                    classifications=classifications,
-                   confidence=confidence)
+                   confidence=confidence,
+                   custom_metrics=custom_metrics)
 
 
 class NDFramePoint(VideoSupported):
@@ -106,7 +108,7 @@ class NDFramePoint(VideoSupported):
                    classifications=classifications)
 
 
-class NDLine(NDBaseObject, ConfidenceMixin):
+class NDLine(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
     line: List[_Point]
 
     def to_common(self) -> Line:
@@ -121,7 +123,8 @@ class NDLine(NDBaseObject, ConfidenceMixin):
                     feature_schema_id: Cuid,
                     extra: Dict[str, Any],
                     data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None) -> "NDLine":
+                    confidence: Optional[float] = None,
+                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDLine":
         return cls(line=[{
             'x': pt.x,
             'y': pt.y
@@ -131,7 +134,8 @@ class NDLine(NDBaseObject, ConfidenceMixin):
                    schema_id=feature_schema_id,
                    uuid=uuid,
                    classifications=classifications,
-                   confidence=confidence)
+                   confidence=confidence,
+                   custom_metrics=custom_metrics)
 
 
 class NDFrameLine(VideoSupported):
@@ -181,7 +185,7 @@ class NDDicomLine(NDFrameLine):
             group_key=group_key)
 
 
-class NDPolygon(NDBaseObject, ConfidenceMixin):
+class NDPolygon(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
     polygon: List[_Point]
 
     def to_common(self) -> Polygon:
@@ -196,7 +200,8 @@ class NDPolygon(NDBaseObject, ConfidenceMixin):
                     feature_schema_id: Cuid,
                     extra: Dict[str, Any],
                     data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None) -> "NDPolygon":
+                    confidence: Optional[float] = None,
+                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDPolygon":
         return cls(polygon=[{
             'x': pt.x,
             'y': pt.y
@@ -206,10 +211,11 @@ class NDPolygon(NDBaseObject, ConfidenceMixin):
                    schema_id=feature_schema_id,
                    uuid=uuid,
                    classifications=classifications,
-                   confidence=confidence)
+                   confidence=confidence,
+                   custom_metrics=custom_metrics)
 
 
-class NDRectangle(NDBaseObject, ConfidenceMixin):
+class NDRectangle(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
     bbox: Bbox
 
     def to_common(self) -> Rectangle:
@@ -226,7 +232,8 @@ class NDRectangle(NDBaseObject, ConfidenceMixin):
                     feature_schema_id: Cuid,
                     extra: Dict[str, Any],
                     data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None) -> "NDRectangle":
+                    confidence: Optional[float] = None,
+                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDRectangle":
         return cls(bbox=Bbox(top=min(rectangle.start.y, rectangle.end.y),
                              left=min(rectangle.start.x, rectangle.end.x),
                              height=abs(rectangle.end.y - rectangle.start.y),
@@ -238,7 +245,8 @@ class NDRectangle(NDBaseObject, ConfidenceMixin):
                    classifications=classifications,
                    page=extra.get('page'),
                    unit=extra.get('unit'),
-                   confidence=confidence)
+                   confidence=confidence,
+                   custom_metrics=custom_metrics)
 
 
 class NDDocumentRectangle(NDRectangle):
@@ -261,7 +269,8 @@ class NDDocumentRectangle(NDRectangle):
                     feature_schema_id: Cuid,
                     extra: Dict[str, Any],
                     data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None) -> "NDRectangle":
+                    confidence: Optional[float] = None,
+                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDRectangle":
         return cls(bbox=Bbox(top=min(rectangle.start.y, rectangle.end.y),
                              left=min(rectangle.start.x, rectangle.end.x),
                              height=abs(rectangle.end.y - rectangle.start.y),
@@ -273,7 +282,8 @@ class NDDocumentRectangle(NDRectangle):
                    classifications=classifications,
                    page=rectangle.page,
                    unit=rectangle.unit.value,
-                   confidence=confidence)
+                   confidence=confidence,
+                   custom_metrics=custom_metrics)
 
 
 class NDFrameRectangle(VideoSupported):
@@ -446,7 +456,7 @@ class _PNGMask(BaseModel):
     png: str
 
 
-class NDMask(NDBaseObject, ConfidenceMixin):
+class NDMask(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
     mask: Union[_URIMask, _PNGMask]
 
     def to_common(self) -> Mask:
@@ -472,7 +482,8 @@ class NDMask(NDBaseObject, ConfidenceMixin):
                     feature_schema_id: Cuid,
                     extra: Dict[str, Any],
                     data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None) -> "NDMask":
+                    confidence: Optional[float] = None,
+                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDMask":
 
         if mask.mask.url is not None:
             lbv1_mask = _URIMask(instanceURI=mask.mask.url, colorRGB=mask.color)
@@ -489,7 +500,8 @@ class NDMask(NDBaseObject, ConfidenceMixin):
                    schema_id=feature_schema_id,
                    uuid=uuid,
                    classifications=classifications,
-                   confidence=confidence)
+                   confidence=confidence,
+                   custom_metrics=custom_metrics)
 
 
 class NDVideoMasksFramesInstances(BaseModel):
@@ -497,7 +509,7 @@ class NDVideoMasksFramesInstances(BaseModel):
     instances: List[MaskInstance]
 
 
-class NDVideoMasks(NDJsonBase, ConfidenceMixin):
+class NDVideoMasks(NDJsonBase, ConfidenceMixin, CustomMetricsNotSupportedMixin):
     masks: NDVideoMasksFramesInstances
 
     def to_common(self) -> VideoMaskAnnotation:
@@ -549,7 +561,7 @@ class Location(BaseModel):
     end: int
 
 
-class NDTextEntity(NDBaseObject, ConfidenceMixin):
+class NDTextEntity(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
     location: Location
 
     def to_common(self) -> TextEntity:
@@ -564,7 +576,8 @@ class NDTextEntity(NDBaseObject, ConfidenceMixin):
                     feature_schema_id: Cuid,
                     extra: Dict[str, Any],
                     data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None) -> "NDTextEntity":
+                    confidence: Optional[float] = None,
+                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDTextEntity":
         return cls(location=Location(
             start=text_entity.start,
             end=text_entity.end,
@@ -574,10 +587,11 @@ class NDTextEntity(NDBaseObject, ConfidenceMixin):
                    schema_id=feature_schema_id,
                    uuid=uuid,
                    classifications=classifications,
-                   confidence=confidence)
+                   confidence=confidence,
+                   custom_metrics=custom_metrics)
 
 
-class NDDocumentEntity(NDBaseObject, ConfidenceMixin):
+class NDDocumentEntity(NDBaseObject, ConfidenceMixin, CustomMetricsMixin):
     name: str
     text_selections: List[DocumentTextSelection]
 
@@ -594,7 +608,8 @@ class NDDocumentEntity(NDBaseObject, ConfidenceMixin):
                     feature_schema_id: Cuid,
                     extra: Dict[str, Any],
                     data: Union[ImageData, TextData],
-                    confidence: Optional[float] = None) -> "NDDocumentEntity":
+                    confidence: Optional[float] = None,
+                    custom_metrics: Optional[List[CustomMetric]] = None) -> "NDDocumentEntity":
 
         return cls(text_selections=document_entity.text_selections,
                    dataRow=DataRow(id=data.uid, global_key=data.global_key),
@@ -602,7 +617,8 @@ class NDDocumentEntity(NDBaseObject, ConfidenceMixin):
                    schema_id=feature_schema_id,
                    uuid=uuid,
                    classifications=classifications,
-                   confidence=confidence)
+                   confidence=confidence,
+                   custom_metrics=custom_metrics)
 
 
 class NDConversationEntity(NDTextEntity):
@@ -623,7 +639,8 @@ class NDConversationEntity(NDTextEntity):
             feature_schema_id: Cuid,
             extra: Dict[str, Any],
             data: Union[ImageData, TextData],
-            confidence: Optional[float] = None) -> "NDConversationEntity":
+            confidence: Optional[float] = None,
+            custom_metrics: Optional[List[CustomMetric]] = None) -> "NDConversationEntity":
         return cls(location=Location(start=conversation_entity.start,
                                      end=conversation_entity.end),
                    message_id=conversation_entity.message_id,
@@ -632,7 +649,8 @@ class NDConversationEntity(NDTextEntity):
                    schema_id=feature_schema_id,
                    uuid=uuid,
                    classifications=classifications,
-                   confidence=confidence)
+                   confidence=confidence,
+                   custom_metrics=custom_metrics)
 
 
 class NDObject:
@@ -646,6 +664,9 @@ class NDObject:
         ]
         confidence = annotation.confidence if hasattr(annotation,
                                                       'confidence') else None
+        
+        custom_metrics = annotation.custom_metrics if hasattr(annotation,
+                                                      'custom_metrics') else None
         return ObjectAnnotation(value=common_annotation,
                                 name=annotation.name,
                                 feature_schema_id=annotation.schema_id,
@@ -655,7 +676,8 @@ class NDObject:
                                     'page': annotation.page,
                                     'unit': annotation.unit
                                 },
-                                confidence=confidence)
+                                confidence=confidence,
+                                custom_metrics=custom_metrics)
 
     @classmethod
     def from_common(
@@ -692,6 +714,10 @@ class NDObject:
         optional_kwargs = {}
         if (annotation.confidence):
             optional_kwargs['confidence'] = annotation.confidence
+
+        if (annotation.custom_metrics):
+            optional_kwargs['custom_metrics'] = annotation.custom_metrics
+
         return obj.from_common(str(annotation._uuid), annotation.value,
                                subclasses, annotation.name,
                                annotation.feature_schema_id, annotation.extra,

--- a/labelbox/exceptions.py
+++ b/labelbox/exceptions.py
@@ -135,5 +135,9 @@ class ConfidenceNotSupportedException(Exception):
     """Raised when confidence is specified for unsupported annotation type"""
 
 
+class CustomMetricsNotSupportedException(Exception):
+    """Raised when custom_metrics is specified for unsupported annotation type"""
+
+
 class ProcessingWaitTimeout(Exception):
     """Raised when waiting for the data rows to be processed takes longer than allowed"""

--- a/tests/data/annotation_types/classification/test_classification.py
+++ b/tests/data/annotation_types/classification/test_classification.py
@@ -13,11 +13,16 @@ def test_classification_answer():
     feature_schema_id = "schema_id"
     name = "my_feature"
     confidence = 0.9
-    answer = ClassificationAnswer(name=name, confidence=confidence)
+    custom_metrics = [{ 'name': 'metric1', 'value': 2 }]
+    answer = ClassificationAnswer(
+        name=name,
+        confidence=confidence,
+        custom_metrics=custom_metrics)
 
     assert answer.feature_schema_id is None
     assert answer.name == name
     assert answer.confidence == confidence
+    assert answer.custom_metrics == custom_metrics
 
     answer = ClassificationAnswer(feature_schema_id=feature_schema_id,
                                   name=name)
@@ -50,7 +55,7 @@ def test_subclass():
         'feature_schema_id': None,
         'extra': {},
         'value': {
-            'answer': answer
+            'answer': answer,
         },
         'message_id': None,
     }
@@ -63,7 +68,7 @@ def test_subclass():
         'feature_schema_id': feature_schema_id,
         'extra': {},
         'value': {
-            'answer': answer
+            'answer': answer,
         },
         'name': name,
         'message_id': None,
@@ -77,14 +82,17 @@ def test_subclass():
         'feature_schema_id': feature_schema_id,
         'extra': {},
         'value': {
-            'answer': answer
+            'answer': answer,
         },
         'message_id': None,
     }
 
 
 def test_radio():
-    answer = ClassificationAnswer(name="1", confidence=0.81)
+    answer = ClassificationAnswer(
+        name="1",
+        confidence=0.81,
+        custom_metrics=[{ 'name': 'metric1', 'value': 0.99 }])
     feature_schema_id = "feature_schema_id"
     name = "my_feature"
 
@@ -101,30 +109,34 @@ def test_radio():
             'feature_schema_id': None,
             'extra': {},
             'confidence': 0.81,
+            'custom_metrics': [{ 'name': 'metric1', 'value': 0.99 }],
         }
     }
     classification = ClassificationAnnotation(
         value=Radio(answer=answer),
         feature_schema_id=feature_schema_id,
-        name=name)
+        name=name,
+        custom_metrics=[{ 'name': 'metric1', 'value': 0.99 }])
     assert classification.dict() == {
         'name': name,
         'feature_schema_id': feature_schema_id,
         'extra': {},
+        'custom_metrics': [{ 'name': 'metric1', 'value': 0.99 }],
         'value': {
             'answer': {
                 'name': answer.name,
                 'feature_schema_id': None,
                 'extra': {},
-                'confidence': 0.81
-            }
+                'confidence': 0.81,
+                'custom_metrics': [{ 'name': 'metric1', 'value': 0.99 }]
+            },
         },
         'message_id': None,
     }
 
 
 def test_checklist():
-    answer = ClassificationAnswer(name="1", confidence=0.99)
+    answer = ClassificationAnswer(name="1", confidence=0.99, custom_metrics=[{ 'name': 'metric1', 'value': 2 }])
     feature_schema_id = "feature_schema_id"
     name = "my_feature"
 
@@ -140,7 +152,8 @@ def test_checklist():
             'name': answer.name,
             'feature_schema_id': None,
             'extra': {},
-            'confidence': 0.99
+            'confidence': 0.99,
+            'custom_metrics': [{ 'name': 'metric1', 'value': 2 }],
         }]
     }
     classification = ClassificationAnnotation(
@@ -157,7 +170,8 @@ def test_checklist():
                 'name': answer.name,
                 'feature_schema_id': None,
                 'extra': {},
-                'confidence': 0.99
+                'confidence': 0.99,
+                'custom_metrics': [{ 'name': 'metric1', 'value': 2 }],
             }]
         },
         'message_id': None,

--- a/tests/data/annotation_types/classification/test_classification.py
+++ b/tests/data/annotation_types/classification/test_classification.py
@@ -13,11 +13,10 @@ def test_classification_answer():
     feature_schema_id = "schema_id"
     name = "my_feature"
     confidence = 0.9
-    custom_metrics = [{ 'name': 'metric1', 'value': 2 }]
-    answer = ClassificationAnswer(
-        name=name,
-        confidence=confidence,
-        custom_metrics=custom_metrics)
+    custom_metrics = [{'name': 'metric1', 'value': 2}]
+    answer = ClassificationAnswer(name=name,
+                                  confidence=confidence,
+                                  custom_metrics=custom_metrics)
 
     assert answer.feature_schema_id is None
     assert answer.name == name
@@ -89,10 +88,12 @@ def test_subclass():
 
 
 def test_radio():
-    answer = ClassificationAnswer(
-        name="1",
-        confidence=0.81,
-        custom_metrics=[{ 'name': 'metric1', 'value': 0.99 }])
+    answer = ClassificationAnswer(name="1",
+                                  confidence=0.81,
+                                  custom_metrics=[{
+                                      'name': 'metric1',
+                                      'value': 0.99
+                                  }])
     feature_schema_id = "feature_schema_id"
     name = "my_feature"
 
@@ -109,26 +110,38 @@ def test_radio():
             'feature_schema_id': None,
             'extra': {},
             'confidence': 0.81,
-            'custom_metrics': [{ 'name': 'metric1', 'value': 0.99 }],
+            'custom_metrics': [{
+                'name': 'metric1',
+                'value': 0.99
+            }],
         }
     }
     classification = ClassificationAnnotation(
         value=Radio(answer=answer),
         feature_schema_id=feature_schema_id,
         name=name,
-        custom_metrics=[{ 'name': 'metric1', 'value': 0.99 }])
+        custom_metrics=[{
+            'name': 'metric1',
+            'value': 0.99
+        }])
     assert classification.dict() == {
         'name': name,
         'feature_schema_id': feature_schema_id,
         'extra': {},
-        'custom_metrics': [{ 'name': 'metric1', 'value': 0.99 }],
+        'custom_metrics': [{
+            'name': 'metric1',
+            'value': 0.99
+        }],
         'value': {
             'answer': {
                 'name': answer.name,
                 'feature_schema_id': None,
                 'extra': {},
                 'confidence': 0.81,
-                'custom_metrics': [{ 'name': 'metric1', 'value': 0.99 }]
+                'custom_metrics': [{
+                    'name': 'metric1',
+                    'value': 0.99
+                }]
             },
         },
         'message_id': None,
@@ -136,7 +149,12 @@ def test_radio():
 
 
 def test_checklist():
-    answer = ClassificationAnswer(name="1", confidence=0.99, custom_metrics=[{ 'name': 'metric1', 'value': 2 }])
+    answer = ClassificationAnswer(name="1",
+                                  confidence=0.99,
+                                  custom_metrics=[{
+                                      'name': 'metric1',
+                                      'value': 2
+                                  }])
     feature_schema_id = "feature_schema_id"
     name = "my_feature"
 
@@ -153,7 +171,10 @@ def test_checklist():
             'feature_schema_id': None,
             'extra': {},
             'confidence': 0.99,
-            'custom_metrics': [{ 'name': 'metric1', 'value': 2 }],
+            'custom_metrics': [{
+                'name': 'metric1',
+                'value': 2
+            }],
         }]
     }
     classification = ClassificationAnnotation(
@@ -171,7 +192,10 @@ def test_checklist():
                 'feature_schema_id': None,
                 'extra': {},
                 'confidence': 0.99,
-                'custom_metrics': [{ 'name': 'metric1', 'value': 2 }],
+                'custom_metrics': [{
+                    'name': 'metric1',
+                    'value': 2
+                }],
             }]
         },
         'message_id': None,

--- a/tests/data/assets/ndjson/classification_import.json
+++ b/tests/data/assets/ndjson/classification_import.json
@@ -2,7 +2,17 @@
     {
         "answer": {
             "schemaId": "ckrb1sfl8099g0y91cxbd5ftb",
-            "confidence": 0.8
+            "confidence": 0.8,
+            "customMetrics": [
+                {
+                    "name": "customMetric1",
+                    "value": 0.5
+                },
+                {
+                    "name": "customMetric2",
+                    "value": 0.3
+                }
+            ]
         },
         "schemaId": "ckrb1sfjx099a0y914hl319ie",
         "dataRow": {
@@ -14,7 +24,17 @@
         "answer": [
             {
                 "schemaId": "ckrb1sfl8099e0y919v260awv",
-                "confidence": 0.82
+                "confidence": 0.82,
+                "customMetrics": [
+                    {
+                        "name": "customMetric1",
+                        "value": 0.5
+                    },
+                    {
+                        "name": "customMetric2",
+                        "value": 0.3
+                    }
+                ]
             }
         ],
         "schemaId": "ckrb1sfkn099c0y910wbo0p1a",

--- a/tests/data/assets/ndjson/classification_import_global_key.json
+++ b/tests/data/assets/ndjson/classification_import_global_key.json
@@ -2,7 +2,17 @@
     {
         "answer": {
             "schemaId": "ckrb1sfl8099g0y91cxbd5ftb",
-            "confidence": 0.8
+            "confidence": 0.8,
+            "customMetrics": [
+                {
+                    "name": "customMetric1",
+                    "value": 0.5
+                },
+                {
+                    "name": "customMetric2",
+                    "value": 0.3
+                }
+            ]
         },
         "schemaId": "c123",
         "dataRow": {
@@ -14,7 +24,17 @@
         "answer": [
             {
                 "schemaId": "ckrb1sfl8099e0y919v260awv",
-                "confidence": 0.82
+                "confidence": 0.82,
+                "customMetrics": [
+                    {
+                        "name": "customMetric1",
+                        "value": 0.5
+                    },
+                    {
+                        "name": "customMetric2",
+                        "value": 0.3
+                    }
+                ]
             }
         ],
         "schemaId": "ckrb1sfkn099c0y910wbo0p1a",

--- a/tests/data/assets/ndjson/classification_import_name_only.json
+++ b/tests/data/assets/ndjson/classification_import_name_only.json
@@ -2,7 +2,17 @@
   {
     "answer": {
       "name": "choice 1",
-      "confidence": 0.99
+      "confidence": 0.99,
+      "customMetrics": [
+        {
+            "name": "customMetric1",
+            "value": 0.5
+        },
+        {
+            "name": "customMetric2",
+            "value": 0.3
+        }
+      ]
     },
     "name": "classification a",
     "dataRow": {
@@ -14,7 +24,17 @@
     "answer": [
       {
         "name": "choice 2",
-        "confidence": 0.945
+        "confidence": 0.945,
+        "customMetrics": [
+          {
+              "name": "customMetric1",
+              "value": 0.5
+          },
+          {
+              "name": "customMetric2",
+              "value": 0.3
+          }
+        ]
       }
     ],
     "name": "classification b",

--- a/tests/data/assets/ndjson/conversation_entity_import.json
+++ b/tests/data/assets/ndjson/conversation_entity_import.json
@@ -11,5 +11,15 @@
     "name": "some-text-entity",
     "schemaId": "cl6xnuwt95lqq07330tbb3mfd",
     "classifications": [],
-    "confidence": 0.53
+    "confidence": 0.53,
+    "customMetrics": [
+        {
+            "name": "customMetric1",
+            "value": 0.5
+        },
+        {
+            "name": "customMetric2",
+            "value": 0.3
+        }
+    ]
 }]

--- a/tests/data/assets/ndjson/conversation_entity_import_global_key.json
+++ b/tests/data/assets/ndjson/conversation_entity_import_global_key.json
@@ -11,5 +11,15 @@
     "name": "some-text-entity",
     "schemaId": "cl6xnuwt95lqq07330tbb3mfd",
     "classifications": [],
-    "confidence": 0.53
+    "confidence": 0.53,
+    "customMetrics": [
+        {
+            "name": "customMetric1",
+            "value": 0.5
+        },
+        {
+            "name": "customMetric2",
+            "value": 0.3
+        }
+    ]
 }]

--- a/tests/data/assets/ndjson/image_import.json
+++ b/tests/data/assets/ndjson/image_import.json
@@ -6,6 +6,12 @@
             "id": "ckrazctum0z8a0ybc0b0o0g0v"
         },
         "confidence": 0.851,
+        "customMetrics": [
+            {
+              "name": "customMetric1",
+              "value": 0.4
+            }
+        ],
         "bbox": {
             "top": 1352,
             "left": 2275,
@@ -20,6 +26,12 @@
             "id": "ckrazctum0z8a0ybc0b0o0g0v"
         },
         "confidence": 0.834,
+        "customMetrics": [
+            {
+              "name": "customMetric1",
+              "value": 0.3
+            }
+        ],
         "mask": {
             "instanceURI": "https://storage.labelbox.com/ckqcx1czn06830y61gh9v02cs%2F3e729327-f038-f66c-186e-45e921ef9717-1?Expires=1626806874672&KeyName=labelbox-assets-key-3&Signature=YsUOGKrsqmAZ68vT9BlPJOaRyLY",
             "colorRGB": [
@@ -36,6 +48,12 @@
             "id": "ckrazctum0z8a0ybc0b0o0g0v"
         },
         "confidence": 0.986,
+        "customMetrics": [
+            {
+              "name": "customMetric1",
+              "value": 0.9
+            }
+        ],
         "polygon": [
             {
                 "x": 1118,

--- a/tests/data/assets/ndjson/image_import_global_key.json
+++ b/tests/data/assets/ndjson/image_import_global_key.json
@@ -11,7 +11,17 @@
             "left": 2275,
             "height": 350,
             "width": 139
-        }
+        },
+        "customMetrics": [
+            {
+                "name": "customMetric1",
+                "value": 0.5
+            },
+            {
+                "name": "customMetric2",
+                "value": 0.3
+            }
+        ]
     },
     {
         "uuid": "751fc725-f7b6-48ed-89b0-dd7d94d08af6",
@@ -20,6 +30,16 @@
             "globalKey": "05e8ee85-072e-4eb2-b30a-501dee9b0d9d"
         },
         "confidence": 0.834,
+        "customMetrics": [
+            {
+                "name": "customMetric1",
+                "value": 0.5
+            },
+            {
+                "name": "customMetric2",
+                "value": 0.3
+            }
+        ],
         "mask": {
             "instanceURI": "https://storage.labelbox.com/ckqcx1czn06830y61gh9v02cs%2F3e729327-f038-f66c-186e-45e921ef9717-1?Expires=1626806874672&KeyName=labelbox-assets-key-3&Signature=YsUOGKrsqmAZ68vT9BlPJOaRyLY",
             "colorRGB": [
@@ -36,6 +56,16 @@
             "globalKey": "05e8ee85-072e-4eb2-b30a-501dee9b0d9d"
         },
         "confidence": 0.986,
+        "customMetrics": [
+            {
+                "name": "customMetric1",
+                "value": 0.5
+            },
+            {
+                "name": "customMetric2",
+                "value": 0.3
+            }
+        ],
         "polygon": [
             {
                 "x": 1118,

--- a/tests/data/assets/ndjson/image_import_name_only.json
+++ b/tests/data/assets/ndjson/image_import_name_only.json
@@ -11,7 +11,17 @@
       "height": 350,
       "width": 139
     },
-    "confidence": 0.854
+    "confidence": 0.854,
+    "customMetrics": [
+      {
+        "name": "customMetric1",
+        "value": 0.5
+      },
+      {
+        "name": "customMetric2",
+        "value": 0.7
+      }
+    ]
   },
   {
     "uuid": "751fc725-f7b6-48ed-89b0-dd7d94d08af6",
@@ -27,7 +37,17 @@
         0
       ]
     },
-    "confidence": 0.685
+    "confidence": 0.685,
+    "customMetrics": [
+      {
+        "name": "customMetric1",
+        "value": 0.4
+      },
+      {
+        "name": "customMetric2",
+        "value": 0.9
+      }
+    ]
   },
   {
     "uuid": "43d719ac-5d7f-4aea-be00-2ebfca0900fd",
@@ -36,6 +56,12 @@
       "id": "ckrazctum0z8a0ybc0b0o0g0v"
     },
     "confidence": 0.71,
+    "customMetrics": [
+      {
+        "name": "customMetric1",
+        "value": 0.1
+      }
+    ],
     "polygon": [
       {
         "x": 1118,
@@ -786,6 +812,12 @@
       "id": "ckrazctum0z8a0ybc0b0o0g0v"
     },
     "confidence": 0.77,
+    "customMetrics": [
+      {
+        "name": "customMetric2",
+        "value": 1.2
+      }
+    ],
     "point": {
       "x": 2122,
       "y": 1457

--- a/tests/data/assets/ndjson/nested_import.json
+++ b/tests/data/assets/ndjson/nested_import.json
@@ -10,7 +10,17 @@
             {
                 "answer": {
                     "schemaId": "ckrb1sfl8099g0y91cxbd5ftb",
-                    "confidence": 0.34
+                    "confidence": 0.34,
+                    "customMetrics": [
+                        {
+                            "name": "customMetric1",
+                            "value": 0.5
+                        },
+                        {
+                            "name": "customMetric2",
+                            "value": 0.3
+                        }
+                    ]
                 },
                 "schemaId": "ckrb1sfkn099c0y910wbo0p1a"
             }
@@ -54,7 +64,17 @@
                 "answer": [
                     {
                         "schemaId": "ckrb1sfl8099e0y919v260awv",
-                        "confidence": 0.894
+                        "confidence": 0.894,
+                        "customMetrics": [
+                            {
+                                "name": "customMetric1",
+                                "value": 0.5
+                            },
+                            {
+                                "name": "customMetric2",
+                                "value": 0.3
+                            }
+                        ]
                     }
                 ],
                 "schemaId": "ckrb1sfkn099c0y910wbo0p1a"

--- a/tests/data/assets/ndjson/nested_import_name_only.json
+++ b/tests/data/assets/ndjson/nested_import_name_only.json
@@ -10,7 +10,17 @@
       {
         "answer": {
           "name": "first answer",
-          "confidence": 0.811
+          "confidence": 0.811,
+          "customMetrics": [
+            {
+                "name": "customMetric1",
+                "value": 0.5
+            },
+            {
+                "name": "customMetric2",
+                "value": 0.3
+            }
+          ]
         },
         "name": "classification a"
       }
@@ -32,7 +42,17 @@
       {
         "answer": {
           "name": "second answer",
-          "confidence": 0.815
+          "confidence": 0.815,
+          "customMetrics": [
+            {
+                "name": "customMetric1",
+                "value": 0.5
+            },
+            {
+                "name": "customMetric2",
+                "value": 0.3
+            }
+          ]
         },
         "name": "classification b"
       }

--- a/tests/data/assets/ndjson/pdf_import.json
+++ b/tests/data/assets/ndjson/pdf_import.json
@@ -9,6 +9,16 @@
     "page": 4,
     "unit": "POINTS",
     "confidence": 0.53,
+    "customMetrics": [
+        {
+            "name": "customMetric1",
+            "value": 0.5
+        },
+        {
+            "name": "customMetric2",
+            "value": 0.3
+        }
+    ],
     "bbox": {
         "top": 162.73,
         "left": 32.45,
@@ -42,6 +52,16 @@
     "page": 6,
     "unit": "POINTS",
     "confidence": 0.99,
+    "customMetrics": [
+        {
+            "name": "customMetric1",
+            "value": 0.5
+        },
+        {
+            "name": "customMetric2",
+            "value": 0.3
+        }
+    ],
     "bbox": {
         "top": 32.52,
         "left": 218.17,
@@ -59,6 +79,16 @@
     "page": 7,
     "unit": "POINTS",
     "confidence": 0.89,
+    "customMetrics": [
+        {
+            "name": "customMetric1",
+            "value": 0.5
+        },
+        {
+            "name": "customMetric2",
+            "value": 0.3
+        }
+    ],
     "bbox": {
         "top": 117.39,
         "left": 4.25,

--- a/tests/data/assets/ndjson/pdf_import_global_key.json
+++ b/tests/data/assets/ndjson/pdf_import_global_key.json
@@ -9,6 +9,16 @@
     "page": 4,
     "unit": "POINTS",
     "confidence": 0.53,
+    "customMetrics": [
+        {
+            "name": "customMetric1",
+            "value": 0.5
+        },
+        {
+            "name": "customMetric2",
+            "value": 0.3
+        }
+    ],
     "bbox": {
         "top": 162.73,
         "left": 32.45,
@@ -42,6 +52,16 @@
     "page": 6,
     "unit": "POINTS",
     "confidence": 0.99,
+    "customMetrics": [
+        {
+            "name": "customMetric1",
+            "value": 0.5
+        },
+        {
+            "name": "customMetric2",
+            "value": 0.3
+        }
+    ],
     "bbox": {
         "top": 32.52,
         "left": 218.17,
@@ -59,6 +79,16 @@
     "page": 7,
     "unit": "POINTS",
     "confidence": 0.89,
+    "customMetrics": [
+        {
+            "name": "customMetric1",
+            "value": 0.5
+        },
+        {
+            "name": "customMetric2",
+            "value": 0.3
+        }
+    ],
     "bbox": {
         "top": 117.39,
         "left": 4.25,

--- a/tests/data/assets/ndjson/pdf_import_name_only.json
+++ b/tests/data/assets/ndjson/pdf_import_name_only.json
@@ -8,6 +8,16 @@
     "page": 4,
     "unit": "POINTS",
     "confidence": 0.99,
+    "customMetrics": [
+        {
+            "name": "customMetric1",
+            "value": 0.5
+        },
+        {
+            "name": "customMetric2",
+            "value": 0.3
+        }
+    ],
     "bbox": {
         "top": 162.73,
         "left": 32.45,
@@ -54,6 +64,16 @@
     "page": 7,
     "unit": "POINTS",
     "confidence": 0.74,
+    "customMetrics": [
+        {
+            "name": "customMetric1",
+            "value": 0.5
+        },
+        {
+            "name": "customMetric2",
+            "value": 0.3
+        }
+    ],
     "bbox": {
         "top": 117.39,
         "left": 4.25,

--- a/tests/data/assets/ndjson/polyline_import.json
+++ b/tests/data/assets/ndjson/polyline_import.json
@@ -21,6 +21,16 @@
         "name": "some-line",
         "schemaId": "cl6xnuwt95lqq07330tbb3mfd",
         "classifications": [],
-        "confidence": 0.58
+        "confidence": 0.58,
+        "customMetrics": [
+            {
+                "name": "customMetric1",
+                "value": 0.5
+            },
+            {
+                "name": "customMetric2",
+                "value": 0.3
+            }
+        ]
     }
 ]

--- a/tests/data/assets/ndjson/polyline_import_global_key.json
+++ b/tests/data/assets/ndjson/polyline_import_global_key.json
@@ -21,6 +21,16 @@
         "name": "some-line",
         "schemaId": "cl6xnuwt95lqq07330tbb3mfd",
         "classifications": [],
-        "confidence": 0.58
+        "confidence": 0.58,
+        "customMetrics": [
+            {
+                "name": "customMetric1",
+                "value": 0.5
+            },
+            {
+                "name": "customMetric2",
+                "value": 0.3
+            }
+        ]
     }
 ]

--- a/tests/data/assets/ndjson/text_entity_import.json
+++ b/tests/data/assets/ndjson/text_entity_import.json
@@ -11,6 +11,16 @@
         "name": "some-text-entity",
         "schemaId": "cl6xnuwt95lqq07330tbb3mfd",
         "classifications": [],
-        "confidence": 0.53
+        "confidence": 0.53,
+        "customMetrics": [
+            {
+                "name": "customMetric1",
+                "value": 0.5
+            },
+            {
+                "name": "customMetric2",
+                "value": 0.3
+            }
+        ]
     }
 ]

--- a/tests/data/assets/ndjson/text_entity_import_global_key.json
+++ b/tests/data/assets/ndjson/text_entity_import_global_key.json
@@ -11,6 +11,16 @@
         "name": "some-text-entity",
         "schemaId": "cl6xnuwt95lqq07330tbb3mfd",
         "classifications": [],
-        "confidence": 0.53
+        "confidence": 0.53,
+        "customMetrics": [
+            {
+                "name": "customMetric1",
+                "value": 0.5
+            },
+            {
+                "name": "customMetric2",
+                "value": 0.3
+            }
+        ]
     }
 ]

--- a/tests/data/serialization/ndjson/test_image.py
+++ b/tests/data/serialization/ndjson/test_image.py
@@ -25,6 +25,7 @@ def test_image():
 
     res = list(NDJsonConverter.deserialize(data))
     res = list(NDJsonConverter.serialize(res))
+    
     for r in res:
         r.pop('classifications', None)
     assert [round_dict(x) for x in res] == [round_dict(x) for x in data]
@@ -53,7 +54,13 @@ def test_mask():
             "png":
                 "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAAMklEQVR4nD3MuQ3AQADDMOqQ/Vd2ijytaSiZLAcYuyLEYYYl9cvrlGftTHvsYl+u/3EDv0QLI8Z7FlwAAAAASUVORK5CYII="
         },
-        "confidence": 0.8
+        "confidence": 0.8,
+        "customMetrics": [
+            {
+              "name": "customMetric1",
+              "value": 0.4
+            }
+        ],
     }, {
         "uuid": "751fc725-f7b6-48ed-89b0-dd7d94d08af6",
         "schemaId": "ckrazcuec16ok0z66f956apb7",

--- a/tests/data/serialization/ndjson/test_image.py
+++ b/tests/data/serialization/ndjson/test_image.py
@@ -25,7 +25,7 @@ def test_image():
 
     res = list(NDJsonConverter.deserialize(data))
     res = list(NDJsonConverter.serialize(res))
-    
+
     for r in res:
         r.pop('classifications', None)
     assert [round_dict(x) for x in res] == [round_dict(x) for x in data]
@@ -55,12 +55,10 @@ def test_mask():
                 "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAAMklEQVR4nD3MuQ3AQADDMOqQ/Vd2ijytaSiZLAcYuyLEYYYl9cvrlGftTHvsYl+u/3EDv0QLI8Z7FlwAAAAASUVORK5CYII="
         },
         "confidence": 0.8,
-        "customMetrics": [
-            {
-              "name": "customMetric1",
-              "value": 0.4
-            }
-        ],
+        "customMetrics": [{
+            "name": "customMetric1",
+            "value": 0.4
+        }],
     }, {
         "uuid": "751fc725-f7b6-48ed-89b0-dd7d94d08af6",
         "schemaId": "ckrazcuec16ok0z66f956apb7",

--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -761,13 +761,6 @@ def polygon_inference(prediction_id_mapping):
         }, {
             "x": 28.308,
             "y": 169.846
-        }],
-        "customMetrics": [{
-            "name": "customMetric1",
-            "value": 0.4
-        }, {
-            "name": "customMetric2",
-            "value": 0.6
         }]
     })
     del polygon['tool']
@@ -793,10 +786,6 @@ def rectangle_inference(prediction_id_mapping):
             "height": 65,
             "width": 12
         },
-        "customMetrics": [{
-            "name": "customMetric1",
-            "value": 0.4
-        }],
         'classifications': [{
             "schemaId":
                 rectangle['tool']['classifications'][0]['featureSchemaId'],

--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -761,7 +761,17 @@ def polygon_inference(prediction_id_mapping):
         }, {
             "x": 28.308,
             "y": 169.846
-        }]
+        }],
+        "customMetrics": [
+            {
+                "name": "customMetric1",
+                "value": 0.4
+            },
+            {
+                "name": "customMetric2",
+                "value": 0.6
+            }
+        ]
     })
     del polygon['tool']
     return polygon
@@ -786,6 +796,12 @@ def rectangle_inference(prediction_id_mapping):
             "height": 65,
             "width": 12
         },
+        "customMetrics": [
+            {
+                "name": "customMetric1",
+                "value": 0.4
+            }
+        ],
         'classifications': [{
             "schemaId":
                 rectangle['tool']['classifications'][0]['featureSchemaId'],
@@ -797,7 +813,13 @@ def rectangle_inference(prediction_id_mapping):
                     ['featureSchemaId'],
                 "name":
                     rectangle['tool']['classifications'][0]['options'][0]
-                    ['value']
+                    ['value'],
+                "customMetrics": [
+                    {
+                        "name": "customMetric1",
+                        "value": 0.4
+                    }
+                ],
             }
         }]
     })

--- a/tests/integration/annotation_import/conftest.py
+++ b/tests/integration/annotation_import/conftest.py
@@ -762,16 +762,13 @@ def polygon_inference(prediction_id_mapping):
             "x": 28.308,
             "y": 169.846
         }],
-        "customMetrics": [
-            {
-                "name": "customMetric1",
-                "value": 0.4
-            },
-            {
-                "name": "customMetric2",
-                "value": 0.6
-            }
-        ]
+        "customMetrics": [{
+            "name": "customMetric1",
+            "value": 0.4
+        }, {
+            "name": "customMetric2",
+            "value": 0.6
+        }]
     })
     del polygon['tool']
     return polygon
@@ -796,12 +793,10 @@ def rectangle_inference(prediction_id_mapping):
             "height": 65,
             "width": 12
         },
-        "customMetrics": [
-            {
-                "name": "customMetric1",
-                "value": 0.4
-            }
-        ],
+        "customMetrics": [{
+            "name": "customMetric1",
+            "value": 0.4
+        }],
         'classifications': [{
             "schemaId":
                 rectangle['tool']['classifications'][0]['featureSchemaId'],
@@ -814,12 +809,10 @@ def rectangle_inference(prediction_id_mapping):
                 "name":
                     rectangle['tool']['classifications'][0]['options'][0]
                     ['value'],
-                "customMetrics": [
-                    {
-                        "name": "customMetric1",
-                        "value": 0.4
-                    }
-                ],
+                "customMetrics": [{
+                    "name": "customMetric1",
+                    "value": 0.4
+                }],
             }
         }]
     })

--- a/tests/integration/annotation_import/test_mea_prediction_import.py
+++ b/tests/integration/annotation_import/test_mea_prediction_import.py
@@ -186,11 +186,11 @@ def test_create_from_local_file(tmp_path, model_run_with_data_rows,
     assert annotation_import.state == AnnotationImportState.FINISHED
     annotation_import_test_helpers.download_and_assert_status(
         annotation_import.status_file_url)
-    
 
-def test_predictions_with_custom_metrics(model_run,
-                             object_predictions_for_annotation_import,
-                             annotation_import_test_helpers):
+
+def test_predictions_with_custom_metrics(
+        model_run, object_predictions_for_annotation_import,
+        annotation_import_test_helpers):
     name = str(uuid.uuid4())
     object_predictions = object_predictions_for_annotation_import
     use_data_row_ids = [p['dataRow']['id'] for p in object_predictions]
@@ -202,7 +202,7 @@ def test_predictions_with_custom_metrics(model_run,
     assert annotation_import.model_run_id == model_run.uid
     annotation_import.wait_until_done()
     assert annotation_import.state == AnnotationImportState.FINISHED
-    
+
     task = model_run.export_v2(params=ModelRunExportParams(predictions=True))
     task.wait_till_done()
 

--- a/tests/integration/annotation_import/test_mea_prediction_import.py
+++ b/tests/integration/annotation_import/test_mea_prediction_import.py
@@ -4,6 +4,7 @@ import pytest
 
 from labelbox.schema.annotation_import import AnnotationImportState, MEAPredictionImport
 from labelbox.data.serialization import NDJsonConverter
+from labelbox.schema.export_params import ModelRunExportParams
 """
 - Here we only want to check that the uploads are calling the validation
 - Then with unit tests we can check the types of errors raised
@@ -181,6 +182,29 @@ def test_create_from_local_file(tmp_path, model_run_with_data_rows,
         annotation_import.input_file_url,
         object_predictions_for_annotation_import)
     annotation_import.wait_until_done()
+
+    assert annotation_import.state == AnnotationImportState.FINISHED
+    annotation_import_test_helpers.download_and_assert_status(
+        annotation_import.status_file_url)
+    
+
+def test_predictions_with_custom_metrics(model_run,
+                             object_predictions_for_annotation_import,
+                             annotation_import_test_helpers):
+    name = str(uuid.uuid4())
+    object_predictions = object_predictions_for_annotation_import
+    use_data_row_ids = [p['dataRow']['id'] for p in object_predictions]
+    model_run.upsert_data_rows(use_data_row_ids)
+
+    annotation_import = model_run.add_predictions(
+        name=name, predictions=object_predictions)
+
+    assert annotation_import.model_run_id == model_run.uid
+    annotation_import.wait_until_done()
+    assert annotation_import.state == AnnotationImportState.FINISHED
+    
+    task = model_run.export_v2(params=ModelRunExportParams(predictions=True))
+    task.wait_till_done()
 
     assert annotation_import.state == AnnotationImportState.FINISHED
     annotation_import_test_helpers.download_and_assert_status(


### PR DESCRIPTION
Adds "customMetrics" field definition for ndjson and "custom_metrics" for class object for annotations.
It's meant to be used at the prediction level in when adding predictions to MEA.

Should not be merged without respective changes deployed to rest of tech stack.