### PR TITLE
[PLT-58] Vb/fix all model runs export timeout plt 58

### DIFF
--- a/labelbox/client.py
+++ b/labelbox/client.py
@@ -217,7 +217,9 @@ class Client:
             elif response.status_code == 502:
                 error_502 = '502 Bad Gateway'
                 raise labelbox.exceptions.InternalServerError(error_502)
-
+            elif response.status_code == 504:
+                error_504 = 'Gateway Timeout'
+                raise labelbox.exceptions.InternalServerError(error_504)
             raise labelbox.exceptions.LabelboxError(
                 "Failed to parse response as JSON: %s" % response.text)
 

--- a/labelbox/client_constants.py
+++ b/labelbox/client_constants.py
@@ -1,3 +1,2 @@
-# type: ignore
 class ClientConstants:
     EXPORT_SUBMISSION_TIMEOUT = 60 * 10  # seconds

--- a/labelbox/client_constants.py
+++ b/labelbox/client_constants.py
@@ -1,0 +1,3 @@
+# type: ignore
+class ClientConstants:
+    EXPORT_SUBMISSION_TIMEOUT = 60 * 10  # seconds

--- a/labelbox/schema/data_row.py
+++ b/labelbox/schema/data_row.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Collection, Dict, List, Optional, Union
 import json
+import pdb
+from labelbox.client_constants import ClientConstants
 from labelbox.exceptions import ResourceNotFoundError
 
 from labelbox.orm import query
@@ -326,6 +328,7 @@ class DataRow(DbObject, Updateable, BulkDeletable):
 
         res = client.execute(create_task_query_str,
                              query_params,
+                             timeout=ClientConstants.EXPORT_SUBMISSION_TIMEOUT,
                              error_log_key="errors")
         print(res)
         res = res[mutation_name]

--- a/labelbox/schema/data_row.py
+++ b/labelbox/schema/data_row.py
@@ -1,7 +1,6 @@
 import logging
 from typing import TYPE_CHECKING, Collection, Dict, List, Optional, Union
 import json
-import pdb
 from labelbox.client_constants import ClientConstants
 from labelbox.exceptions import ResourceNotFoundError
 

--- a/labelbox/schema/dataset.py
+++ b/labelbox/schema/dataset.py
@@ -15,6 +15,7 @@ from io import StringIO
 import requests
 
 from labelbox import pagination
+from labelbox.client_constants import ClientConstants
 from labelbox.exceptions import InvalidQueryError, LabelboxError, ResourceNotFoundError, InvalidAttributeError
 from labelbox.orm.comparison import Comparison
 from labelbox.orm.db_object import DbObject, Updateable, Deletable, experimental
@@ -735,9 +736,11 @@ class Dataset(DbObject, Updateable, Deletable):
 
         query_params["input"]["filters"]["searchQuery"]["query"] = search_query
 
-        res = self.client.execute(create_task_query_str,
-                                  query_params,
-                                  error_log_key="errors")
+        res = self.client.execute(
+            create_task_query_str,
+            query_params,
+            timeout=ClientConstants.EXPORT_SUBMISSION_TIMEOUT,
+            error_log_key="errors")
         res = res[mutation_name]
         task_id = res["taskId"]
         return Task.get_task(self.client, task_id)

--- a/labelbox/schema/export_task.py
+++ b/labelbox/schema/export_task.py
@@ -533,7 +533,9 @@ class ExportTask:
 
     def wait_till_done(self, timeout_seconds: int = 300) -> None:
         """Waits until the task is done."""
-        return self._task.wait_till_done(timeout_seconds)
+
+        while self._task.status != "COMPLETE" and self._task.status != "FAILED":
+            self._task.wait_till_done(timeout_seconds)
 
     @staticmethod
     @lru_cache(maxsize=5)

--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -1,6 +1,7 @@
 # type: ignore
 import logging
 import os
+from socket import timeout
 import time
 import warnings
 from enum import Enum
@@ -10,6 +11,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, Union, List, Optional, Any
 import requests
 
 from labelbox import parser
+from labelbox.client_constants import ClientConstants
 from labelbox.orm.db_object import DbObject, experimental
 from labelbox.orm.model import Field, Relationship, Entity
 from labelbox.orm.query import results_query_part
@@ -573,9 +575,11 @@ class ModelRun(DbObject):
                 "streamable": streamable
             }
         }
-        res = self.client.execute(create_task_query_str,
-                                  query_params,
-                                  error_log_key="errors")
+        res = self.client.execute(
+            create_task_query_str,
+            query_params,
+            timeout=ClientConstants.EXPORT_SUBMISSION_TIMEOUT,
+            error_log_key="errors")
         res = res[mutation_name]
         task_id = res["taskId"]
         return Task.get_task(self.client, task_id)

--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -1,7 +1,6 @@
 # type: ignore
 import logging
 import os
-from socket import timeout
 import time
 import warnings
 from enum import Enum

--- a/labelbox/schema/project.py
+++ b/labelbox/schema/project.py
@@ -13,6 +13,7 @@ import requests
 
 from labelbox import parser
 from labelbox import utils
+from labelbox.client_constants import ClientConstants
 from labelbox.exceptions import (
     InvalidQueryError,
     LabelboxError,
@@ -577,9 +578,11 @@ class Project(DbObject, Updateable, Deletable):
         search_query = build_filters(self.client, _filters)
         query_params["input"]["filters"]["searchQuery"]["query"] = search_query
 
-        res = self.client.execute(create_task_query_str,
-                                  query_params,
-                                  error_log_key="errors")
+        res = self.client.execute(
+            create_task_query_str,
+            query_params,
+            timeout=ClientConstants.EXPORT_SUBMISSION_TIMEOUT,
+            error_log_key="errors")
         res = res[mutation_name]
         task_id = res["taskId"]
         return Task.get_task(self.client, task_id)

--- a/labelbox/schema/slice.py
+++ b/labelbox/schema/slice.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional
 import warnings
+from labelbox.client_constants import ClientConstants
 from labelbox.orm.db_object import DbObject, experimental
 from labelbox.orm.model import Field
 from labelbox.pagination import PaginatedCollection
@@ -223,9 +224,11 @@ class CatalogSlice(Slice):
             }
         }
 
-        res = self.client.execute(create_task_query_str,
-                                  query_params,
-                                  error_log_key="errors")
+        res = self.client.execute(
+            create_task_query_str,
+            query_params,
+            timeout=ClientConstants.EXPORT_SUBMISSION_TIMEOUT,
+            error_log_key="errors")
         res = res[mutation_name]
         task_id = res["taskId"]
         return Task.get_task(self.client, task_id)

--- a/tests/unit/export_task/test_export_task.py
+++ b/tests/unit/export_task/test_export_task.py
@@ -1,0 +1,46 @@
+from unittest import mock
+from unittest.mock import MagicMock
+import pytest
+from labelbox.schema.export_task import ExportTask
+from labelbox.schema.task import Task
+
+
+@pytest.fixture
+def export_task():
+    client = MagicMock()
+    task = Task(
+        client, {
+            "id": "clscg9qsq00o1071v0ao491zm",
+            "completionPercentage": 100,
+            "status": "IN_PROGRESS",
+            "createdAt": "2021-08-25T20:00:00.000Z",
+            "updatedAt": "2021-08-25T20:00:00.000Z",
+            "errors": [],
+            "metadata": {},
+            "name": "TestExportDataRow:test_with_data_row_object",
+            "result": None,
+            "type": "export-data-rows-streamable",
+        })
+    return ExportTask(task)
+
+
+@pytest.fixture
+def export_task_complete(export_task):
+    export_task._task.status = "COMPLETE"
+    return export_task
+
+
+@pytest.fixture
+def export_task_failed(export_task):
+    export_task._task.status = "FAILED"
+    return export_task
+
+
+def test_wait_till_done_complete(export_task_complete):
+    export_task_complete.wait_till_done()
+    assert export_task_complete.status == "COMPLETE"
+
+
+def test_wait_till_done_failed(export_task_failed):
+    export_task_failed.wait_till_done()
+    assert export_task_failed.status == "FAILED"


### PR DESCRIPTION
Story Overview: [PLT-58](https://labelbox.atlassian.net/browse/PLT-58)

Objective: The primary aim of this story was to diagnose and resolve issues related to export timeouts when dealing with a dataset comprising 7 million rows, specifically when using the options all_project and all_labels.

Root Cause: We identified that the direct cause of the timeout was the Elasticsearch (ES) query that retrieves 7 million data row IDs. This query is executed within the synchronous API responsible for initiating the mutation process. Due to time constraints and potential risks, we opted against optimizing the API at this juncture.

Current Solution: This Pull Request (PR) tackles the issue by extending the HTTP read timeout, extending task wait and adding error handling for network timeouts. These adjustments collectively facilitate the fetching of the large dataset.

Additional Requirements: It's important to note that implementing this PR successfully also hinges on specific infrastructure changes. These changes have been outlined and are currently under discussion [here](https://labelbox.slack.com/archives/CLLA9ATM3/p1707423276607449).

Next Steps: Aside from the solutions proposed in this PR, I am also exploring a workaround. This workaround would leverage our existing codebase to meet our objectives without necessitating further updates to the API.

[PLT-58]: https://labelbox.atlassian.net/browse/PLT-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ