### PR TITLE
[PLT-74] Add model_run_details to export params to support splits etc.

### DIFF
--- a/labelbox/schema/export_params.py
+++ b/labelbox/schema/export_params.py
@@ -38,6 +38,7 @@ class CatalogExportParams(DataRowParams):
 
 class ModelRunExportParams(DataRowParams):
     predictions: Optional[bool]
+    model_run_details: Optional[bool]
 
 
 def _validate_array_length(array, max_length, array_name):

--- a/labelbox/schema/model_run.py
+++ b/labelbox/schema/model_run.py
@@ -569,6 +569,8 @@ class ModelRun(DbObject):
                         _params.get('data_row_details', False),
                     "includePredictions":
                         _params.get('predictions', False),
+                    "includeModelRunDetails":
+                        _params.get('model_run_details', False),
                 },
                 "streamable": streamable
             }


### PR DESCRIPTION
Story: https://labelbox.atlassian.net/browse/PLT-74

Fixing a missing exporter option in the sdk