### PR TITLE
DEVOPS-2168 - Securing GHA Publish to pypi

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,39 +4,46 @@ name: Publish Python Package
 
 on:
   release:
-    types: [created, updated]
+    types: [created]
 
 jobs:
-  deploy:
-
+  build:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+
+      - name: Build
+        run: |
+          python setup.py sdist bdist_wheel
+      
+      - uses: actions/upload-artifact@v3
+        with:
+            path: ./dist
+
+  pypi-publish:   
+    needs: ['build']
+    environment: 
+      name: publish
+      url: 'https://pypi.org/project/labelbox/'
+    runs-on: ubuntu-latest
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
-
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: artifact/
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-
-    - name: Build
-      run: |
-        python setup.py sdist bdist_wheel
-
-    # - name: Publish
-    #   env:
-    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-    #   run: |
-    #     twine upload dist/*
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+# Note that the build and pypi-publish jobs are split so that the additional permissions are only granted to the pypi-publish job.


### PR DESCRIPTION
Based on security best practice - I split up the build and publish process so that the `      id-token: write` is available in the minimum amount of steps. 
Also added environment so the publish to pypi portion so we can add further security later. Removed twine install because it was no longer needed.