### PR TITLE
[CCV-3976] Support for CAMERA_IMAGE attachments in SDK

### DIFF
--- a/labelbox/schema/asset_attachment.py
+++ b/labelbox/schema/asset_attachment.py
@@ -33,6 +33,7 @@ class AssetAttachment(DbObject):
         RAW_TEXT = "RAW_TEXT"
         TEXT_URL = "TEXT_URL"
         PDF_URL = "PDF_URL"
+        CAMERA_IMAGE = "CAMERA_IMAGE" # Used by experimental point-cloud editor
 
     for topic in AttachmentType:
         vars()[topic.name] = topic.value

--- a/labelbox/schema/asset_attachment.py
+++ b/labelbox/schema/asset_attachment.py
@@ -33,7 +33,7 @@ class AssetAttachment(DbObject):
         RAW_TEXT = "RAW_TEXT"
         TEXT_URL = "TEXT_URL"
         PDF_URL = "PDF_URL"
-        CAMERA_IMAGE = "CAMERA_IMAGE" # Used by experimental point-cloud editor
+        CAMERA_IMAGE = "CAMERA_IMAGE"  # Used by experimental point-cloud editor
 
     for topic in AttachmentType:
         vars()[topic.name] = topic.value


### PR DESCRIPTION
Adding `CAMERA_IMAGE` attachments which will be used by the experimental point cloud editor (for client demos). For that reason, I didn't add `CAMERA_IMAGE` to any docstrings.

The attachment's value has the following format:

```
{
  url: string; // image URL
  instrinsic_matrix: number[]; // 3x3 matrix
  instrinsic_matrix: number[]; // 4x4 matrix
}
```

Related api / app support: https://github.com/Labelbox/intelligence/pull/19844