### PR TITLE
[PLT-34] add support for custom embeddings to data import

### DIFF
--- a/labelbox/schema/embeddings.py
+++ b/labelbox/schema/embeddings.py
@@ -1,0 +1,15 @@
+from typing import List, Optional, Any, Dict
+
+from labelbox.pydantic_compat import BaseModel
+
+
+class EmbeddingVector(BaseModel):
+    embedding_id: str
+    vector: List[float]
+    clusters: Optional[List[int]]
+
+    def to_gql(self) -> Dict[str, Any]:
+        result = {"embeddingId": self.embedding_id, "vector": self.vector}
+        if self.clusters:
+            result["clusters"] = self.clusters
+        return result


### PR DESCRIPTION
https://labelbox.atlassian.net/browse/PLT-34

This PR has a dependency on changes to our GQL API which can be found here: https://github.com/Labelbox/intelligence/pull/20258

Integration tests will fail until the above is merged and deployed to the corresponding environments.

#### Why are there no integration tests?

A custom embedding needs to be created in order to import a custom embedding with a data row.

Currently, the SDK does not support creating a custom embedding, this will happen as a separate item of work, i.e. deprecating the existing `advlib` tool - this will begin in the very near future.

I have tested this locally (using the UI to create the embedding) and it works correctly.  If however, we need to include an integration test, I can look into importing the existing `advlib` tool (for testing) to create the custom embedding or alternatively we wait until the `advlib` tool is deprecated.