### PR TITLE
Vb/remove label data plt 37

### DIFF
--- a/labelbox/data/annotation_types/data/generic_data_row_data.py
+++ b/labelbox/data/annotation_types/data/generic_data_row_data.py
@@ -1,0 +1,28 @@
+from typing import Callable, Literal, Optional
+
+from labelbox import pydantic_compat
+from labelbox.data.annotation_types.data.base_data import BaseData
+from labelbox.utils import _NoCoercionMixin
+
+
+class GenericDataRowData(BaseData, _NoCoercionMixin):
+    """Generic data row data
+    """
+    url: Optional[str] = None
+    class_name: Literal["GenericDataRowData"] = "GenericDataRowData"
+
+    def create_url(self, signer: Callable[[bytes], str]) -> None:
+        return None
+
+    @pydantic_compat.root_validator(pre=True)
+    def validate_one_datarow_key_present(cls, data):
+        keys = ['external_id', 'global_key', 'uid']
+        count = 0
+        for key in keys:
+            if data.get(key):
+                count += 1
+        if count < 1:
+            raise ValueError(f"Exactly one of {keys} must be present.")
+        if count > 1:
+            raise ValueError(f"Only one of {keys} can be present.")
+        return data

--- a/labelbox/data/annotation_types/data/generic_data_row_data.py
+++ b/labelbox/data/annotation_types/data/generic_data_row_data.py
@@ -11,8 +11,8 @@ class GenericDataRowData(BaseData, _NoCoercionMixin):
     url: Optional[str] = None
     class_name: Literal["GenericDataRowData"] = "GenericDataRowData"
 
-    def create_url(self, signer: Callable[[bytes], str]) -> None:
-        return None
+    def create_url(self, signer: Callable[[bytes], str]) -> Optional[str]:
+        return self.url
 
     @pydantic_compat.root_validator(pre=True)
     def validate_one_datarow_key_present(cls, data):

--- a/labelbox/data/annotation_types/data/generic_data_row_data.py
+++ b/labelbox/data/annotation_types/data/generic_data_row_data.py
@@ -17,10 +17,8 @@ class GenericDataRowData(BaseData, _NoCoercionMixin):
     @pydantic_compat.root_validator(pre=True)
     def validate_one_datarow_key_present(cls, data):
         keys = ['external_id', 'global_key', 'uid']
-        count = 0
-        for key in keys:
-            if data.get(key):
-                count += 1
+        count = sum([key in data for key in keys])
+
         if count < 1:
             raise ValueError(f"Exactly one of {keys} must be present.")
         if count > 1:

--- a/labelbox/data/annotation_types/data/generic_data_row_data.py
+++ b/labelbox/data/annotation_types/data/generic_data_row_data.py
@@ -6,7 +6,7 @@ from labelbox.utils import _NoCoercionMixin
 
 
 class GenericDataRowData(BaseData, _NoCoercionMixin):
-    """Generic data row data
+    """Generic data row data. This is replacing all other DataType passed into Label
     """
     url: Optional[str] = None
     class_name: Literal["GenericDataRowData"] = "GenericDataRowData"

--- a/labelbox/data/annotation_types/label.py
+++ b/labelbox/data/annotation_types/label.py
@@ -29,7 +29,7 @@ class Label(pydantic_compat.BaseModel):
     """Container for holding data and annotations
 
     >>> Label(
-    >>>    data = ImageData(url = "http://my-img.jpg"),
+    >>>    data = {'global_key': 'my-data-row-key'} # also accepts uid, external_id as keys
     >>>    annotations = [
     >>>        ObjectAnnotation(
     >>>            value = Point(x = 10, y = 10),
@@ -40,7 +40,8 @@ class Label(pydantic_compat.BaseModel):
 
     Args:
         uid: Optional Label Id in Labelbox
-        data: Data of Label, Image, Video, Text
+        data: Data of Label, Image, Video, Text or dict with a single key uid | global_key | external_id. 
+            Note use of classes as data is deprecated. Use GenericDataRowData or dict with a single key instead.
         annotations: List of Annotations in the label
         extra: additional context
     """
@@ -62,6 +63,10 @@ class Label(pydantic_compat.BaseModel):
     def validate_data(cls, label):
         if not Label.is_data_type(label.get("data")):
             label["data"]["class_name"] = "GenericDataRowData"
+        else:
+            warnings.warn(
+                f"Using {type(label['data']).__name__} class for label.data is deprecated. "
+                "Use a dict or an instance of GenericDataRowData instead.")
         return label
 
     def object_annotations(self) -> List[ObjectAnnotation]:

--- a/labelbox/data/annotation_types/label.py
+++ b/labelbox/data/annotation_types/label.py
@@ -53,15 +53,9 @@ class Label(pydantic_compat.BaseModel):
                             RelationshipAnnotation]] = []
     extra: Dict[str, Any] = {}
 
-    @staticmethod
-    def is_data_type(data: Union[Dict[str, Any], DataType]) -> bool:
-        if isinstance(data, DataType):
-            return True
-        return False
-
     @pydantic_compat.root_validator(pre=True)
     def validate_data(cls, label):
-        if not Label.is_data_type(label.get("data")):
+        if isinstance(label.get("data"), Dict):
             label["data"]["class_name"] = "GenericDataRowData"
         else:
             warnings.warn(

--- a/labelbox/schema/id_type.py
+++ b/labelbox/schema/id_type.py
@@ -1,7 +1,18 @@
-from strenum import StrEnum
+import sys
+
+if sys.version_info > (3, 8):
+    from strenum import StrEnum
+
+    class BaseStrEnum(StrEnum):
+        pass
+else:
+    from enum import Enum
+
+    class BaseStrEnum(str, Enum):
+        pass
 
 
-class IdType(StrEnum):
+class IdType(BaseStrEnum):
     """
     The type of id used to identify a data row.
     

--- a/labelbox/schema/id_type.py
+++ b/labelbox/schema/id_type.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.version_info > (3, 8):
+if sys.version_info >= (3, 9):
     from strenum import StrEnum
 
     class BaseStrEnum(StrEnum):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,13 +121,13 @@ def rest_url(environ: str) -> str:
     return 'http://host.docker.internal:8080/api/v1'
 
 
-def testing_api_key(environ: str) -> str:
-    for var in [
-            "LABELBOX_TEST_API_KEY_PROD", "LABELBOX_TEST_API_KEY_STAGING",
-            "LABELBOX_TEST_API_KEY_CUSTOM", "LABELBOX_TEST_API_KEY_LOCAL",
-            "LABELBOX_TEST_API_KEY"
-    ]:
-        value = os.environ.get(var)
+def testing_api_key(environ: Environ) -> str:
+    keys = [
+        f"LABELBOX_TEST_API_KEY_{environ.value.upper()}",
+        "LABELBOX_TEST_API_KEY"
+    ]
+    for key in keys:
+        value = os.environ.get(key)
         if value is not None:
             return value
     raise Exception("Cannot find API to use for tests")
@@ -147,7 +147,6 @@ class IntegrationClient(Client):
         api_url = graphql_url(environ)
         api_key = testing_api_key(environ)
         rest_endpoint = rest_url(environ)
-
         super().__init__(api_key,
                          api_url,
                          enable_experimental=True,

--- a/tests/data/annotation_import/conftest.py
+++ b/tests/data/annotation_import/conftest.py
@@ -1922,20 +1922,3 @@ class Helpers:
 @pytest.fixture
 def helpers():
     return Helpers
-
-
-@pytest.fixture
-def create_data_row_for_project(project, dataset, data_row_ndjson, batch_name):
-    data_row = dataset.create_data_row(data_row_ndjson)
-
-    project.create_batch(
-        batch_name,
-        [data_row.uid],  # sample of data row objects
-        5,  # priority between 1(Highest) - 5(lowest)
-    )
-    project.data_row_ids.append(data_row.uid)
-
-    yield data_row
-
-    data_row.delete()
-    project.delete()

--- a/tests/data/annotation_import/conftest.py
+++ b/tests/data/annotation_import/conftest.py
@@ -1918,6 +1918,30 @@ class Helpers:
                     if isinstance(i, dict):
                         Helpers.rename_cuid_key_recursive(i)
 
+    @staticmethod
+    def set_project_media_type_from_data_type(project, data_type_class):
+
+        def to_pascal_case(name: str) -> str:
+            return "".join([word.capitalize() for word in name.split("_")])
+
+        data_type_string = data_type_class.__name__[:-4].lower()
+        media_type = to_pascal_case(data_type_string)
+        if media_type == "Conversation":
+            media_type = "Conversational"
+        elif media_type == "Llmpromptcreation":
+            media_type = "LLMPromptCreation"
+        elif media_type == "Llmpromptresponsecreation":
+            media_type = "LLMPromptResponseCreation"
+        elif media_type == "Llmresponsecreation":
+            media_type = "Text"
+        elif media_type == "Genericdatarow":
+            media_type = "Image"
+        project.update(media_type=MediaType[media_type])
+
+    @staticmethod
+    def find_data_row_filter(data_row):
+        return lambda dr: dr['data_row']['id'] == data_row.uid
+
 
 @pytest.fixture
 def helpers():

--- a/tests/data/annotation_import/conftest.py
+++ b/tests/data/annotation_import/conftest.py
@@ -1885,3 +1885,57 @@ def bbox_video_annotation_objects():
     ]
 
     return bbox_annotation
+
+
+class Helpers:
+
+    @staticmethod
+    def remove_keys_recursive(d, keys):
+        for k in keys:
+            if k in d:
+                del d[k]
+        for k, v in d.items():
+            if isinstance(v, dict):
+                Helpers.remove_keys_recursive(v, keys)
+            elif isinstance(v, list):
+                for i in v:
+                    if isinstance(i, dict):
+                        Helpers.remove_keys_recursive(i, keys)
+
+    @staticmethod
+    # NOTE this uses quite a primitive check for cuids but I do not think it is worth coming up with a better one
+    # Also this function is NOT written with performance in mind, good for small to mid size dicts like we have in our test
+    def rename_cuid_key_recursive(d):
+        new_key = "<cuid>"
+        for k in list(d.keys()):
+            if len(k) == 25 and not k.isalpha():  # primitive check for cuid
+                d[new_key] = d.pop(k)
+        for k, v in d.items():
+            if isinstance(v, dict):
+                Helpers.rename_cuid_key_recursive(v)
+            elif isinstance(v, list):
+                for i in v:
+                    if isinstance(i, dict):
+                        Helpers.rename_cuid_key_recursive(i)
+
+
+@pytest.fixture
+def helpers():
+    return Helpers
+
+
+@pytest.fixture
+def create_data_row_for_project(project, dataset, data_row_ndjson, batch_name):
+    data_row = dataset.create_data_row(data_row_ndjson)
+
+    project.create_batch(
+        batch_name,
+        [data_row.uid],  # sample of data row objects
+        5,  # priority between 1(Highest) - 5(lowest)
+    )
+    project.data_row_ids.append(data_row.uid)
+
+    yield data_row
+
+    data_row.delete()
+    project.delete()

--- a/tests/data/annotation_import/test_data_types.py
+++ b/tests/data/annotation_import/test_data_types.py
@@ -131,6 +131,19 @@ def get_annotation_comparison_dicts_from_export(export_result, data_row_id,
     return converted_annotations
 
 
+def create_data_row_for_project(project, dataset, data_row_ndjson, batch_name):
+    data_row = dataset.create_data_row(data_row_ndjson)
+
+    project.create_batch(
+        batch_name,
+        [data_row.uid],  # sample of data row objects
+        5,  # priority between 1(Highest) - 5(lowest)
+    )
+    project.data_row_ids.append(data_row.uid)
+
+    return data_row
+
+
 # TODO: Add VideoData. Currently label import job finishes without errors but project.export_labels() returns empty list.
 @pytest.mark.parametrize(
     "data_type_class",
@@ -147,10 +160,15 @@ def get_annotation_comparison_dicts_from_export(export_result, data_row_id,
         LlmResponseCreationData,
     ],
 )
-def test_import_data_types(client, configured_project, initial_dataset,
-                           rand_gen, data_row_json_by_data_type,
-                           annotations_by_data_type, data_type_class,
-                           create_data_row_for_project):
+def test_import_data_types(
+    client,
+    configured_project,
+    initial_dataset,
+    rand_gen,
+    data_row_json_by_data_type,
+    annotations_by_data_type,
+    data_type_class,
+):
     project = configured_project
     project_id = project.uid
     dataset = initial_dataset
@@ -193,7 +211,6 @@ def test_import_data_types_by_global_key(
     rand_gen,
     data_row_json_by_data_type,
     annotations_by_data_type,
-    create_data_row_for_project,
 ):
     project = configured_project
     project_id = project.uid
@@ -285,7 +302,6 @@ def test_import_data_types_v2(
     export_v2_test_helpers,
     rand_gen,
     helpers,
-    create_data_row_for_project,
 ):
     project = configured_project
     dataset = initial_dataset
@@ -355,7 +371,6 @@ def test_import_label_annotations(
     data_class,
     annotations,
     rand_gen,
-    create_data_row_for_project,
 ):
     project = configured_project_with_one_data_row
     dataset = initial_dataset

--- a/tests/data/annotation_import/test_data_types.py
+++ b/tests/data/annotation_import/test_data_types.py
@@ -168,12 +168,13 @@ def test_import_data_types(
     data_row_json_by_data_type,
     annotations_by_data_type,
     data_type_class,
+    helpers,
 ):
     project = configured_project
     project_id = project.uid
     dataset = initial_dataset
 
-    set_project_media_type_from_data_type(project, data_type_class)
+    helpers.set_project_media_type_from_data_type(project, data_type_class)
 
     data_type_string = data_type_class.__name__[:-4].lower()
     data_row_ndjson = data_row_json_by_data_type[data_type_string]
@@ -211,12 +212,13 @@ def test_import_data_types_by_global_key(
     rand_gen,
     data_row_json_by_data_type,
     annotations_by_data_type,
+    helpers,
 ):
     project = configured_project
     project_id = project.uid
     dataset = initial_dataset
     data_type_class = ImageData
-    set_project_media_type_from_data_type(project, data_type_class)
+    helpers.set_project_media_type_from_data_type(project, data_type_class)
 
     data_row_ndjson = data_row_json_by_data_type["image"]
     data_row_ndjson["global_key"] = str(uuid.uuid4())
@@ -257,24 +259,6 @@ def validate_iso_format(date_string: str):
     assert parsed_t.second is not None
 
 
-def to_pascal_case(name: str) -> str:
-    return "".join([word.capitalize() for word in name.split("_")])
-
-
-def set_project_media_type_from_data_type(project, data_type_class):
-    data_type_string = data_type_class.__name__[:-4].lower()
-    media_type = to_pascal_case(data_type_string)
-    if media_type == "Conversation":
-        media_type = "Conversational"
-    elif media_type == "Llmpromptcreation":
-        media_type = "LLMPromptCreation"
-    elif media_type == "Llmpromptresponsecreation":
-        media_type = "LLMPromptResponseCreation"
-    elif media_type == "Llmresponsecreation":
-        media_type = "Text"
-    project.update(media_type=MediaType[media_type])
-
-
 @pytest.mark.parametrize(
     "data_type_class",
     [
@@ -307,7 +291,7 @@ def test_import_data_types_v2(
     dataset = initial_dataset
     project_id = project.uid
 
-    set_project_media_type_from_data_type(project, data_type_class)
+    helpers.set_project_media_type_from_data_type(project, data_type_class)
 
     data_type_string = data_type_class.__name__[:-4].lower()
     data_row_ndjson = data_row_json_by_data_type[data_type_string]
@@ -371,10 +355,11 @@ def test_import_label_annotations(
     data_class,
     annotations,
     rand_gen,
+    helpers,
 ):
     project = configured_project_with_one_data_row
     dataset = initial_dataset
-    set_project_media_type_from_data_type(project, data_class)
+    helpers.set_project_media_type_from_data_type(project, data_class)
 
     data_row_json = data_row_json_by_data_type[data_type]
     data_row = create_data_row_for_project(project, dataset, data_row_json,
@@ -442,10 +427,11 @@ def test_import_mal_annotations(
     annotations,
     rand_gen,
     one_datarow,
+    helpers,
 ):
     data_row = one_datarow
-    set_project_media_type_from_data_type(configured_project_with_one_data_row,
-                                          data_class)
+    helpers.set_project_media_type_from_data_type(
+        configured_project_with_one_data_row, data_class)
 
     configured_project_with_one_data_row.create_batch(
         rand_gen(str),
@@ -471,12 +457,13 @@ def test_import_mal_annotations(
 
 def test_import_mal_annotations_global_key(client,
                                            configured_project_with_one_data_row,
-                                           rand_gen, one_datarow_global_key):
+                                           rand_gen, one_datarow_global_key,
+                                           helpers):
     data_class = lb_types.VideoData
     data_row = one_datarow_global_key
     annotations = [video_mask_annotation]
-    set_project_media_type_from_data_type(configured_project_with_one_data_row,
-                                          data_class)
+    helpers.set_project_media_type_from_data_type(
+        configured_project_with_one_data_row, data_class)
 
     configured_project_with_one_data_row.create_batch(
         rand_gen(str),

--- a/tests/unit/test_label_data_type.py
+++ b/tests/unit/test_label_data_type.py
@@ -1,0 +1,58 @@
+from email import message
+import pytest
+from pydantic import ValidationError
+
+from labelbox.data.annotation_types.data.generic_data_row_data import GenericDataRowData
+from labelbox.data.annotation_types.data.video import VideoData
+from labelbox.data.annotation_types.label import Label
+
+
+def test_generic_data_type():
+    data = {
+        'global_key':
+            'https://lb-test-data.s3.us-west-1.amazonaws.com/image-samples/sample-image-1.jpg-BEidMVWRmyXjVCnr',
+    }
+    label = Label(data=data)
+    data = label.data
+    assert isinstance(data, GenericDataRowData)
+    assert data.global_key == 'https://lb-test-data.s3.us-west-1.amazonaws.com/image-samples/sample-image-1.jpg-BEidMVWRmyXjVCnr'
+
+
+def test_generic_data_type_validations():
+    data = {
+        'row_data':
+            'https://lb-test-data.s3.us-west-1.amazonaws.com/image-samples/sample-image-1.jpg-BEidMVWRmyXjVCnr',
+    }
+    with pytest.raises(ValueError, match="Exactly one of"):
+        Label(data=data)
+
+    data = {
+        'uid':
+            "abcd",
+        'global_key':
+            'https://lb-test-data.s3.us-west-1.amazonaws.com/image-samples/sample-image-1.jpg-BEidMVWRmyXjVCnr',
+    }
+    with pytest.raises(ValueError, match="Only one of"):
+        Label(data=data)
+
+
+def test_video_data_type():
+    data = {
+        'global_key':
+            'https://lb-test-data.s3.us-west-1.amazonaws.com/image-samples/sample-image-1.jpg-BEidMVWRmyXjVCnr',
+    }
+    label = Label(data=VideoData(**data))
+    data = label.data
+    assert isinstance(data, VideoData)
+    assert data.global_key == 'https://lb-test-data.s3.us-west-1.amazonaws.com/image-samples/sample-image-1.jpg-BEidMVWRmyXjVCnr'
+
+
+def test_generic_data_row():
+    data = {
+        'global_key':
+            'https://lb-test-data.s3.us-west-1.amazonaws.com/image-samples/sample-image-1.jpg-BEidMVWRmyXjVCnr',
+    }
+    label = Label(data=GenericDataRowData(**data))
+    data = label.data
+    assert isinstance(data, GenericDataRowData)
+    assert data.global_key == 'https://lb-test-data.s3.us-west-1.amazonaws.com/image-samples/sample-image-1.jpg-BEidMVWRmyXjVCnr'

--- a/tests/unit/test_label_data_type.py
+++ b/tests/unit/test_label_data_type.py
@@ -41,7 +41,8 @@ def test_video_data_type():
         'global_key':
             'https://lb-test-data.s3.us-west-1.amazonaws.com/image-samples/sample-image-1.jpg-BEidMVWRmyXjVCnr',
     }
-    label = Label(data=VideoData(**data))
+    with pytest.warns(UserWarning, match="Use a dict"):
+        label = Label(data=VideoData(**data))
     data = label.data
     assert isinstance(data, VideoData)
     assert data.global_key == 'https://lb-test-data.s3.us-west-1.amazonaws.com/image-samples/sample-image-1.jpg-BEidMVWRmyXjVCnr'


### PR DESCRIPTION
Story: https://labelbox.atlassian.net/browse/PLT-37

**Label Validation Update:**

Modified the Label pydantic validator to automatically convert a dictionary into a GenericDataRowData object for user convenience. For the time being, usage of other *RowData classes is allowed, but a deprecation warning will be issued.

**Other Improvements:**

- Enum Support for Python 3.8: Implemented a workaround to support string enums in Python 3.8, as it does not support StrEnum. Notably, the Foo(string, Enum) approach is deprecated in Python 3.9.
- Integration Test Client Fix: Resolved an issue where the IntegrationTestClient was using an incorrect API key or failing to find the correct one.
- Test Logic Refactoring: Consolidated some repetitive test logic into shared fixtures for efficiency.

