### PR TITLE
[PLT-582] add example and documentation for custom embeddings

### DIFF
--- a/examples/basics/custom_embeddings_sdk.ipynb
+++ b/examples/basics/custom_embeddings_sdk.ipynb
@@ -1,0 +1,269 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {},
+ "cells": [
+  {
+   "metadata": {},
+   "source": [
+    "<td>\n",
+    "   <a target=\"_blank\" href=\"https://labelbox.com\" ><img src=\"https://labelbox.com/blog/content/images/2021/02/logo-v4.svg\" width=256/></a>\n",
+    "</td>"
+   ],
+   "cell_type": "markdown"
+  },
+  {
+   "metadata": {},
+   "source": [
+    "<td>\n",
+    "<a href=\"https://colab.research.google.com/github/Labelbox/labelbox-python/blob/master/examples/basics/custom_embeddings.ipynb\" target=\"_blank\"><img\n",
+    "src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>\n",
+    "</td>\n",
+    "\n",
+    "<td>\n",
+    "<a href=\"https://github.com/Labelbox/labelbox-python/tree/master/examples/basics/custom_embeddings.ipynb\" target=\"_blank\"><img\n",
+    "src=\"https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white\" alt=\"GitHub\"></a>\n",
+    "</td>"
+   ],
+   "cell_type": "markdown"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Custom Embeddings\n",
+    "\n",
+    "You can improve your data exploration and similarity search experience by adding your own custom embeddings. Labelbox allows you to upload up to 100 different custom embeddings on any kind of data. You can experiment with different embeddings to power your data selection."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# Setup"
+   ],
+   "cell_type": "markdown"
+  },
+  {
+   "metadata": {},
+   "source": [
+    "!pip3 install -q \"labelbox\""
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "import labelbox as lb\n",
+    "import numpy as np\n",
+    "import json"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "API_KEY = \"\"\n",
+    "client = lb.Client(API_KEY)"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# Select data rows in Labelbox for custom embeddings"
+   ],
+   "cell_type": "markdown"
+  },
+  {
+   "metadata": {},
+   "source": [
+    "client.enable_experimental = True\n",
+    "\n",
+    "# get images from a Labelbox dataset\n",
+    "# Our systems start to process data after 1000 embeddings of each type, for this demo make sure your dataset is over 1000 data rows\n",
+    "dataset = client.get_dataset(\"<ADD YOUR DATASET ID>\")\n",
+    "\n",
+    "export_task = dataset.export()\n",
+    "export_task.wait_till_done()"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "data_rows = []\n",
+    "\n",
+    "def json_stream_handler(output: lb.JsonConverterOutput):\n",
+    "  data_row = json.loads(output.json_str)\n",
+    "  data_rows.append(data_row)\n",
+    "\n",
+    "if export_task.has_errors():\n",
+    "  export_task.get_stream(\n",
+    "  converter=lb.JsonConverter(),\n",
+    "  stream_type=lb.StreamType.ERRORS\n",
+    "  ).start(stream_handler=lambda error: print(error))\n",
+    "\n",
+    "if export_task.has_result():\n",
+    "  export_json = export_task.get_stream(\n",
+    "    converter=lb.JsonConverter(),\n",
+    "    stream_type=lb.StreamType.RESULT\n",
+    "  ).start(stream_handler=json_stream_handler)"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "data_row_ids = [dr[\"data_row\"][\"id\"] for dr in data_rows]\n",
+    "\n",
+    "data_row_ids = data_row_ids[:1000] # keep the first 1000 examples for the sake of this demo"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# Create the payload for custom embeddings\n",
+    "-- It should be a .ndjson file.   \n",
+    "-- Every line is a json file that finishes with a \\n character.  \n",
+    "-- It does not have to be created through Python.  "
+   ],
+   "cell_type": "markdown"
+  },
+  {
+   "metadata": {},
+   "source": [
+    "nb_data_rows = len(data_row_ids)\n",
+    "print(\"Number of data rows: \", nb_data_rows)\n",
+    "# Generate random vectors, of dimension 2048 each\n",
+    "# Labelbox supports custom embedding vectors of dimension up to 2048\n",
+    "custom_embeddings = [list(np.random.random(2048)) for _ in range(nb_data_rows)]"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# Create the payload for custom embeddings\n",
+    "payload = []\n",
+    "for data_row_id,custom_embedding in zip(data_row_ids,custom_embeddings):\n",
+    "  payload.append({\"id\": data_row_id, \"vector\": custom_embedding})\n",
+    "\n",
+    "print('payload', len(payload),payload[:1])"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# Delete any pre-existing file\n",
+    "import os\n",
+    "if os.path.exists(\"payload.ndjson\"):\n",
+    "  os.remove(\"payload.ndjson\")\n",
+    "\n",
+    "# Convert the payload to a JSON file\n",
+    "with open('payload.ndjson', 'w') as f:\n",
+    "  for p in payload:\n",
+    "    f.write(json.dumps(p) + \"\\n\")\n",
+    "    # sanity_check_payload = json.dump(payload, f)"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# Sanity check that you can read/load the file and the payload is correct\n",
+    "with open('payload.ndjson') as f:\n",
+    "    sanity_check_payload = [json.loads(l) for l in f.readlines()]\n",
+    "print(\"Nb of custom embedding vectors in sanity_check_payload: \", len(sanity_check_payload))"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# See all custom embeddings available in your Labelbox workspace\n",
+    "embeddings = client.get_embeddings()"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# Create a new custom embedding, unless you want to re-use one\n",
+    "embedding = client.create_embedding(\"my_custom_embedding_2048_dimensions\", 2048)"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# Delete a custom embedding\n",
+    "embedding.delete()"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# Upload the payload to Labelbox"
+   ],
+   "cell_type": "markdown"
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# Replace the current id with the newly generated id from the previous step, or any existing custom embedding id\n",
+    "embedding.import_vectors_from_file(\"./payload.ndjson\")"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# Get the count of imported vectors for a custom embedding"
+   ],
+   "cell_type": "markdown"
+  },
+  {
+   "metadata": {},
+   "source": [
+    "# Count how many data rows have a specific custom embedding (this can take a couple of minutes)\n",
+    "count = embedding.get_imported_vector_count()"
+   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null
+  }
+ ]
+}

--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -1979,6 +1979,12 @@ class Client:
     def get_embedding(self, id: str) -> Embedding:
         """
         Return the embedding for the provided embedding id.
+
+        Args:
+            id: The embedding ID.
+
+        Returns:
+            The embedding object.
         """
         data = self._adv_client.get_embedding(id)
         return Embedding(self._adv_client, **data)
@@ -1986,6 +1992,9 @@ class Client:
     def get_embeddings(self) -> List[Embedding]:
         """
         Return a list of all embeddings for the current organization.
+
+        Returns:
+            A list of embedding objects.
         """
         results = self._adv_client.get_embeddings()
         return [Embedding(self._adv_client, **data) for data in results]

--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -1976,7 +1976,17 @@ class Client:
         data = self._adv_client.create_embedding(name, dims)
         return Embedding(self._adv_client, **data)
 
-    def get_embedding(self, id: str) -> Embedding:
+    def get_embeddings(self) -> List[Embedding]:
+        """
+        Return a list of all embeddings for the current organization.
+
+        Returns:
+            A list of embedding objects.
+        """
+        results = self._adv_client.get_embeddings()
+        return [Embedding(self._adv_client, **data) for data in results]
+
+    def get_embedding_by_id(self, id: str) -> Embedding:
         """
         Return the embedding for the provided embedding id.
 
@@ -1989,12 +1999,20 @@ class Client:
         data = self._adv_client.get_embedding(id)
         return Embedding(self._adv_client, **data)
 
-    def get_embeddings(self) -> List[Embedding]:
+    def get_embedding_by_name(self, name: str) -> Embedding:
         """
-        Return a list of all embeddings for the current organization.
+        Return the embedding for the provided embedding name.
+
+        Args:
+            name: The embedding name
 
         Returns:
-            A list of embedding objects.
+            The embedding object.
         """
-        results = self._adv_client.get_embeddings()
-        return [Embedding(self._adv_client, **data) for data in results]
+        # NB: It's safe to do the filtering client-side as we only allow 10 embeddings per org.
+        embeddings = self.get_embeddings()
+        for e in embeddings:
+            if e.name == name:
+                return e
+        raise labelbox.exceptions.ResourceNotFoundError(Embedding,
+                                                        dict(name=name))

--- a/libs/labelbox/src/labelbox/schema/embedding.py
+++ b/libs/labelbox/src/labelbox/schema/embedding.py
@@ -5,6 +5,14 @@ from labelbox.pydantic_compat import BaseModel, PrivateAttr
 
 
 class EmbeddingVector(BaseModel):
+    """
+    A Vector Embedding for Custom Embedding.
+
+    Attributes:
+        embedding_id (str): The ID of the associated Embedding
+        vector (list): The raw vector values - the number of entries should match the Embedding's dimensions
+        clusters (list): The cluster groupings
+    """
     embedding_id: str
     vector: List[float]
     clusters: Optional[List[int]]
@@ -17,6 +25,18 @@ class EmbeddingVector(BaseModel):
 
 
 class Embedding(BaseModel):
+    """
+    An Embedding is used to power similarity search in Catalog.
+
+    This model supports the representation of both `Precomputed` embeddings that Labelbox provides,
+    and `Custom` embeddings which can be imported directly into Labelbox.
+
+    Attributes:
+        id (str): The ID of the embedding
+        name (str): The name of the embedding
+        dims (int): Refers to the size of the vector space in which words, phrases, or other entities are embedded
+        custom (bool): Indicates whether the embedding is a Precomputed embedding or a Custom embedding
+    """
     id: str
     name: str
     custom: bool

--- a/libs/labelbox/src/labelbox/schema/embedding.py
+++ b/libs/labelbox/src/labelbox/schema/embedding.py
@@ -88,3 +88,7 @@ class Embedding(BaseModel):
             The number of imported vectors.
         """
         return self._client.get_imported_vector_count(self.id)
+
+    @classmethod
+    def type_name(cls):
+        return cls.__name__.split(".")[-1]

--- a/libs/labelbox/tests/integration/test_embedding.py
+++ b/libs/labelbox/tests/integration/test_embedding.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Any
 
 import pytest
 
+import labelbox.exceptions
 from labelbox import Client, Dataset, DataRow
 from labelbox.schema.embedding import Embedding
 
@@ -19,9 +20,19 @@ def embedding(client: Client):
     embedding.delete()
 
 
-def test_get_embedding(client: Client, embedding: Embedding):
-    e = client.get_embedding(embedding.id)
+def test_get_embedding_by_id(client: Client, embedding: Embedding):
+    e = client.get_embedding_by_id(embedding.id)
     assert e.id == embedding.id
+
+
+def test_get_embedding_by_name(client: Client, embedding: Embedding):
+    e = client.get_embedding_by_name(embedding.name)
+    assert e.name == embedding.name
+
+
+def test_get_embedding_by_name_not_found(client: Client):
+    with pytest.raises(labelbox.exceptions.ResourceNotFoundError):
+        client.get_embedding_by_name("does-not-exist")
 
 
 def test_get_embeddings(client: Client, embedding: Embedding):


### PR DESCRIPTION
https://labelbox.atlassian.net/browse/PLT-582

I chose to not update the existing file - https://github.com/Labelbox/labelbox-python/blob/develop/examples/basics/custom_embeddings.ipynb to not break the existing public-facing documentation.

We can remove the above file once `advlib` is deprecated and the public-facing documentation is updated.

https://docs.labelbox.com/reference/custom-embeddings