### PR TITLE
remove dateutil max version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pydantic>=1.8
 pygeotile
 pyproj
 pytest-xdist
-python-dateutil>=2.8.2,<2.9.0
+python-dateutil>=2.8.2
 requests==2.31.0
 shapely
 tqdm


### PR DESCRIPTION
remove dateutil max version constraint

otherwise labelbox will conflict with other packages now that python-dateutil is widespread