### PR TITLE
[PLT-0] Override RTD build commands

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,17 +8,14 @@ version: 2
 # https://github.com/wemake-services/wemake-django-template/blob/master/.readthedocs.yml
 build:
   os: ubuntu-lts-latest
-  tools:
-    python: "3.12"
-  jobs:
-    pre_create_environment:
-      - asdf plugin add rye
-      - asdf install rye 0.32
-      - asdf global rye 0.32
-      - rye config --set-bool behavior.global-python=true
-      - rye config --set-bool behavior.use-uv=true
-    post_install:
-      - rye sync
+  commands:
+    - asdf plugin add rye
+    - asdf install rye latest
+    - asdf global rye latest
+    - rye config --set-bool behavior.global-python=true
+    - rye config --set-bool behavior.use-uv=true
+    - rye sync
+    - rye run sphinx-build ./docs $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
* https://docs.readthedocs.io/en/stable/config-file/v2.html#build-commands
* Override the build commands section to match building docs locally