### PR TITLE
[PLT-0] Move codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 # SDK team's approval is required for all code changes (excluding notebook changes)
-* @Labelbox/platform
-*.ipynb


### PR DESCRIPTION
Move codeowners file to .github folder to cleanup root of repository