### PR TITLE
[PLT-817] Determine json via \n, not via brace matching

### DIFF
--- a/libs/labelbox/tests/unit/export_task/test_unit_json_converter.py
+++ b/libs/labelbox/tests/unit/export_task/test_unit_json_converter.py
@@ -39,7 +39,6 @@ class TestJsonConverter:
             ),
             raw_data=file_content,
         )
-        print(file_content)
         with JsonConverter() as converter:
             output = next(converter.convert(input_args))
             assert output.current_line == 0


### PR DESCRIPTION
Find object offsets by splitting on literal '\n', not guessing via braces

JSON convertor assumes NDJSON, not just JSON