### PR TITLE
Vb/chat eval ontology

### DIFF
--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -1228,6 +1228,33 @@ class Client:
         return Entity.Ontology(self, res['upsertOntology'])
 
     def create_model_chat_evaluation_ontology(self, name, normalized):
+        """
+        Creates a model chat evalutation ontology from normalized data
+            >>> normalized = {"tools" : [{'tool': 'model-output-single-selection', 'name': 'model output single selection', 'color': '#ff0000',}, 
+                                         {'tool': 'model-output-multi-selection', 'name': 'model output multi selection', 'color': '#00ff00',}, 
+                                         {'tool': 'model-output-ranking', 'name': 'model output multi ranking', 'color': '#0000ff',}]
+                             }
+            >>> ontology = client.create_ontology("ontology-name", normalized)
+
+        Or use the ontology builder
+            >>> ontology_builder = OntologyBuilder(tools=[
+                Tool(tool=Tool.Type.MODEL_OUTPUT_SINGLE_SELECTION,
+                    name="model output single selection"),
+                Tool(tool=Tool.Type.MODEL_OUTPUT_MULTI_SELECTION,
+                    name="model output multi selection"),
+                Tool(tool=Tool.Type.MODEL_OUTPUT_MULTI_RANKING,
+                    name="model output multi ranking"),
+            ],)
+
+            >>> ontology = client.create_model_chat_evaluation_ontology("Multi-chat ontology", ontology_builder.asdict())
+
+        Args:
+            name (str): Name of the ontology
+            normalized (dict): A normalized ontology payload. See above for details.
+        Returns:
+            The created Ontology
+        """
+
         return self.create_ontology(
             name=name,
             normalized=normalized,
@@ -1236,6 +1263,17 @@ class Client:
 
     def create_model_chat_evaluation_ontology_from_feature_schemas(
             self, name, feature_schema_ids):
+        """
+        Creates an ontology from a list of feature schema ids
+
+        Args:
+            name (str): Name of the ontology
+            feature_schema_ids (List[str]): List of feature schema ids corresponding to
+                top level tools and classifications to include in the ontology
+        Returns:
+            The created Ontology
+        """
+
         return self.create_ontology_from_feature_schemas(
             name=name,
             feature_schema_ids=feature_schema_ids,

--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -1230,19 +1230,19 @@ class Client:
     def create_model_chat_evaluation_ontology(self, name, normalized):
         """
         Creates a model chat evalutation ontology from normalized data
-            >>> normalized = {"tools" : [{'tool': 'model-output-single-selection', 'name': 'model output single selection', 'color': '#ff0000',}, 
-                                         {'tool': 'model-output-multi-selection', 'name': 'model output multi selection', 'color': '#00ff00',}, 
-                                         {'tool': 'model-output-ranking', 'name': 'model output multi ranking', 'color': '#0000ff',}]
+            >>> normalized = {"tools" : [{'tool': 'message-single-selection', 'name': 'model output single selection', 'color': '#ff0000',},
+                                         {'tool': 'message-multi-selection', 'name': 'model output multi selection', 'color': '#00ff00',},
+                                         {'tool': 'message-ranking', 'name': 'model output multi ranking', 'color': '#0000ff',}]
                              }
             >>> ontology = client.create_ontology("ontology-name", normalized)
 
         Or use the ontology builder
             >>> ontology_builder = OntologyBuilder(tools=[
-                Tool(tool=Tool.Type.MODEL_OUTPUT_SINGLE_SELECTION,
+                Tool(tool=Tool.Type.MESSAGE_SINGLE_SELECTION,
                     name="model output single selection"),
-                Tool(tool=Tool.Type.MODEL_OUTPUT_MULTI_SELECTION,
+                Tool(tool=Tool.Type.MESSAGE_MULTI_SELECTION,
                     name="model output multi selection"),
-                Tool(tool=Tool.Type.MODEL_OUTPUT_MULTI_RANKING,
+                Tool(tool=Tool.Type.MESSAGE_RANKING,
                     name="model output multi ranking"),
             ],)
 

--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -939,10 +939,12 @@ class Client:
                                    rootSchemaPayloadToFeatureSchema,
                                    ['rootSchemaNodes', 'nextCursor'])
 
-    def create_ontology_from_feature_schemas(self,
-                                             name,
-                                             feature_schema_ids,
-                                             media_type=None) -> Ontology:
+    def create_ontology_from_feature_schemas(
+            self,
+            name,
+            feature_schema_ids,
+            media_type: MediaType = None,
+            editor_task_type: EditorTaskType = None) -> Ontology:
         """
         Creates an ontology from a list of feature schema ids
 
@@ -980,7 +982,10 @@ class Client:
                     "Neither `tool` or `classification` found in the normalized feature schema"
                 )
         normalized = {'tools': tools, 'classifications': classifications}
-        return self.create_ontology(name, normalized, media_type)
+        return self.create_ontology(name=name,
+                                    normalized=normalized,
+                                    media_type=media_type,
+                                    editor_task_type=editor_task_type)
 
     def delete_unused_feature_schema(self, feature_schema_id: str) -> None:
         """
@@ -1167,13 +1172,11 @@ class Client:
                 "Failed to get unused feature schemas, message: " +
                 str(response.json()['message']))
 
-    def create_ontology(
-            self,
-            name,
-            normalized,
-            media_type: MediaType = None,
-            editor_task_type: EditorTaskType = None
-    ) -> Ontology:
+    def create_ontology(self,
+                        name,
+                        normalized,
+                        media_type: MediaType = None,
+                        editor_task_type: EditorTaskType = None) -> Ontology:
         """
         Creates an ontology from normalized data
             >>> normalized = {"tools" : [{'tool': 'polygon',  'name': 'cat', 'color': 'black'}], "classifications" : []}
@@ -1205,7 +1208,8 @@ class Client:
             if EditorTaskType.is_supported(editor_task_type):
                 editor_task_type = editor_task_type.value
             else:
-                raise EditorTaskType.get_editor_task_type_validation_error(editor_task_type)
+                raise EditorTaskType.get_editor_task_type_validation_error(
+                    editor_task_type)
 
         query_str = """mutation upsertRootSchemaNodePyApi($data:  UpsertOntologyInput!){
                            upsertOntology(data: $data){ %s }
@@ -1228,8 +1232,15 @@ class Client:
             name=name,
             normalized=normalized,
             media_type=MediaType.Conversational,
-            editor_task_type=EditorTaskType.ModelChatEvaluation
-        )
+            editor_task_type=EditorTaskType.ModelChatEvaluation)
+
+    def create_model_chat_evaluation_ontology_from_feature_schemas(
+            self, name, feature_schema_ids):
+        return self.create_ontology_from_feature_schemas(
+            name=name,
+            feature_schema_ids=feature_schema_ids,
+            media_type=MediaType.Conversational,
+            editor_task_type=EditorTaskType.ModelChatEvaluation)
 
     def create_feature_schema(self, normalized):
         """

--- a/libs/labelbox/src/labelbox/schema/editor_task_type.py
+++ b/libs/labelbox/src/labelbox/schema/editor_task_type.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class EditorTaskType(Enum):
+    ModelEvaluationWithUploadedAsset = "MODEL_EVALUATION_WITH_UPLOADED_ASSET",
+    ResponseCreation = "RESPONSE_CREATION",
+    ModelChatEvaluation = "MODEL_CHAT_EVALUATION"
+
+    @classmethod
+    def is_supported(cls, value):
+        return isinstance(value, cls)
+
+    @classmethod
+    def get_media_type_validation_error(cls, editor_task_type):
+        return TypeError(f"{editor_task_type}: is not a valid media type. Use"
+                         f" any of {EditorTaskType.__members__.items()}"
+                         " from EditorTaskType.")

--- a/libs/labelbox/src/labelbox/schema/ontology.py
+++ b/libs/labelbox/src/labelbox/schema/ontology.py
@@ -252,9 +252,9 @@ class Tool:
         LINE = "line"
         NER = "named-entity"
         RELATIONSHIP = "edge"
-        MODEL_OUTPUT_SINGLE_SELECTION = "model-output-single-selection"
-        MODEL_OUTPUT_MULTI_SELECTION = "model-output-multi-selection"
-        MODEL_OUTPUT_MULTI_RANKING = "model-output-ranking"
+        MESSAGE_SINGLE_SELECTION = 'message-single-selection'
+        MESSAGE_MULTI_SELECTION = 'message-multi-selection'
+        MESSAGE_RANKING = 'message-ranking'
 
     tool: Type
     name: str

--- a/libs/labelbox/src/labelbox/schema/ontology.py
+++ b/libs/labelbox/src/labelbox/schema/ontology.py
@@ -252,6 +252,9 @@ class Tool:
         LINE = "line"
         NER = "named-entity"
         RELATIONSHIP = "edge"
+        MODEL_OUTPUT_SINGLE_SELECTION = "model-output-single-selection"
+        MODEL_OUTPUT_MULTI_SELECTION = "model-output-multi-selection"
+        MODEL_OUTPUT_MULTI_RANKING = "model-output-ranking"
 
     tool: Type
     name: str

--- a/libs/labelbox/tests/integration/test_model_chat_evaluation_ontology.py
+++ b/libs/labelbox/tests/integration/test_model_chat_evaluation_ontology.py
@@ -1,0 +1,26 @@
+from labelbox import OntologyBuilder, Tool
+
+
+def test_create_model_chat_evaluation_ontology(client, rand_gen):
+    ontology_name = f"test-model-chat-evaluation-ontology-{rand_gen(str)}"
+    ontology_builder = OntologyBuilder(
+        tools=[
+            Tool(tool=Tool.Type.MODEL_OUTPUT_SINGLE_SELECTION, name="model output single selection"),
+            Tool(tool=Tool.Type.MODEL_OUTPUT_MULTI_SELECTION, name="model output multi selection"),
+            Tool(tool=Tool.Type.MODEL_OUTPUT_MULTI_RANKING, name="model output multi ranking"),
+        ],
+    )
+    ontology = None
+
+    try:
+        ontology = client.create_model_chat_evaluation_ontology(ontology_name, ontology_builder.asdict())
+        assert ontology
+        assert ontology.name == ontology_name
+        assert len(ontology.tools()) == 3
+        for tool in ontology.tools():
+            assert tool.schema_id
+            assert tool.feature_schema_id
+
+    finally:
+        if ontology:
+            client.delete_unused_ontology(ontology.uid)

--- a/libs/labelbox/tests/integration/test_model_chat_evaluation_ontology.py
+++ b/libs/labelbox/tests/integration/test_model_chat_evaluation_ontology.py
@@ -60,7 +60,7 @@ def test_ontology_create_feature_schema(client, rand_gen):
             'featureSchemaId': None
         }]
 
-        features = {client.create_feature_schema(t) for t in tools}
+        features = {client.create_feature_schema(t) for t in tools if t}
         feature_schema_ids = {f.uid for f in features}
         assert len(feature_schema_ids) == 3
 

--- a/libs/labelbox/tests/integration/test_model_chat_evaluation_ontology.py
+++ b/libs/labelbox/tests/integration/test_model_chat_evaluation_ontology.py
@@ -5,12 +5,11 @@ from labelbox import MediaType
 def test_create_model_chat_evaluation_ontology(client, rand_gen):
     ontology_name = f"test-model-chat-evaluation-ontology-{rand_gen(str)}"
     ontology_builder = OntologyBuilder(tools=[
-        Tool(tool=Tool.Type.MODEL_OUTPUT_SINGLE_SELECTION,
+        Tool(tool=Tool.Type.MESSAGE_SINGLE_SELECTION,
              name="model output single selection"),
-        Tool(tool=Tool.Type.MODEL_OUTPUT_MULTI_SELECTION,
+        Tool(tool=Tool.Type.MESSAGE_MULTI_SELECTION,
              name="model output multi selection"),
-        Tool(tool=Tool.Type.MODEL_OUTPUT_MULTI_RANKING,
-             name="model output multi ranking"),
+        Tool(tool=Tool.Type.MESSAGE_RANKING, name="model output multi ranking"),
     ],)
     ontology = None
 
@@ -35,7 +34,7 @@ def test_ontology_create_feature_schema(client, rand_gen):
         features = None
         ontology_name = f"test-model-chat-evaluation-ontology-from-features{rand_gen(str)}"
         tools = [{
-            'tool': 'model-output-single-selection',
+            'tool': 'message-single-selection',
             'name': 'model output single selection',
             'required': False,
             'color': '#ff0000',
@@ -43,7 +42,7 @@ def test_ontology_create_feature_schema(client, rand_gen):
             'schemaNodeId': None,
             'featureSchemaId': None
         }, {
-            'tool': 'model-output-multi-selection',
+            'tool': 'message-multi-selection',
             'name': 'model output multi selection',
             'required': False,
             'color': '#00ff00',
@@ -51,7 +50,7 @@ def test_ontology_create_feature_schema(client, rand_gen):
             'schemaNodeId': None,
             'featureSchemaId': None
         }, {
-            'tool': 'model-output-ranking',
+            'tool': 'message-ranking',
             'name': 'model output multi ranking',
             'required': False,
             'color': '#0000ff',

--- a/libs/labelbox/tests/integration/test_model_chat_evaluation_ontology.py
+++ b/libs/labelbox/tests/integration/test_model_chat_evaluation_ontology.py
@@ -1,19 +1,22 @@
 from labelbox import OntologyBuilder, Tool
+from labelbox import MediaType
 
 
 def test_create_model_chat_evaluation_ontology(client, rand_gen):
     ontology_name = f"test-model-chat-evaluation-ontology-{rand_gen(str)}"
-    ontology_builder = OntologyBuilder(
-        tools=[
-            Tool(tool=Tool.Type.MODEL_OUTPUT_SINGLE_SELECTION, name="model output single selection"),
-            Tool(tool=Tool.Type.MODEL_OUTPUT_MULTI_SELECTION, name="model output multi selection"),
-            Tool(tool=Tool.Type.MODEL_OUTPUT_MULTI_RANKING, name="model output multi ranking"),
-        ],
-    )
+    ontology_builder = OntologyBuilder(tools=[
+        Tool(tool=Tool.Type.MODEL_OUTPUT_SINGLE_SELECTION,
+             name="model output single selection"),
+        Tool(tool=Tool.Type.MODEL_OUTPUT_MULTI_SELECTION,
+             name="model output multi selection"),
+        Tool(tool=Tool.Type.MODEL_OUTPUT_MULTI_RANKING,
+             name="model output multi ranking"),
+    ],)
     ontology = None
 
     try:
-        ontology = client.create_model_chat_evaluation_ontology(ontology_name, ontology_builder.asdict())
+        ontology = client.create_model_chat_evaluation_ontology(
+            ontology_name, ontology_builder.asdict())
         assert ontology
         assert ontology.name == ontology_name
         assert len(ontology.tools()) == 3
@@ -24,3 +27,61 @@ def test_create_model_chat_evaluation_ontology(client, rand_gen):
     finally:
         if ontology:
             client.delete_unused_ontology(ontology.uid)
+
+
+def test_ontology_create_feature_schema(client, rand_gen):
+    try:
+        created_ontology = None
+        features = None
+        ontology_name = f"test-model-chat-evaluation-ontology-from-features{rand_gen(str)}"
+        tools = [{
+            'tool': 'model-output-single-selection',
+            'name': 'model output single selection',
+            'required': False,
+            'color': '#ff0000',
+            'classifications': [],
+            'schemaNodeId': None,
+            'featureSchemaId': None
+        }, {
+            'tool': 'model-output-multi-selection',
+            'name': 'model output multi selection',
+            'required': False,
+            'color': '#00ff00',
+            'classifications': [],
+            'schemaNodeId': None,
+            'featureSchemaId': None
+        }, {
+            'tool': 'model-output-ranking',
+            'name': 'model output multi ranking',
+            'required': False,
+            'color': '#0000ff',
+            'classifications': [],
+            'schemaNodeId': None,
+            'featureSchemaId': None
+        }]
+
+        features = {client.create_feature_schema(t) for t in tools}
+        feature_schema_ids = {f.uid for f in features}
+        assert len(feature_schema_ids) == 3
+
+        created_ontology = client.create_model_chat_evaluation_ontology_from_feature_schemas(
+            name=ontology_name,
+            feature_schema_ids=feature_schema_ids,
+        )
+        tools_normalized = created_ontology.normalized['tools']
+
+        for tool in tools:
+            generated_tool = next(
+                t for t in tools_normalized if t['name'] == tool['name'])
+            assert generated_tool['schemaNodeId'] is not None
+            assert generated_tool['featureSchemaId'] in feature_schema_ids
+            assert generated_tool['tool'] == tool['tool']
+            assert generated_tool['name'] == tool['name']
+            assert generated_tool['required'] == tool['required']
+            assert generated_tool['color'] == tool['color']
+    finally:
+        if created_ontology:
+            client.delete_unused_ontology(created_ontology.uid)
+        if features:
+            for f in features:
+                client.delete_unused_feature_schema(f.uid)


### PR DESCRIPTION
Story: https://labelbox.atlassian.net/browse/PLT-774

This PR adds support for creating ontologies for multi-modal chat evaluation.

I have introduced distinct methods for both create_ontology and create_monotony_from_feature_schemas. These methods are designed to shield users from the complexities of the implementation details.
