### PR TITLE
[PLT-0] Do not retry 422 errors

### DIFF
--- a/.github/workflows/python-package-develop.yml
+++ b/.github/workflows/python-package-develop.yml
@@ -45,9 +45,6 @@ jobs:
     environment: 
       name: Test-PyPI
       url: 'https://test.pypi.org/p/labelbox-test'
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -79,6 +76,9 @@ jobs:
   test-container:
     runs-on: ubuntu-latest    
     needs: ['build']
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     env:
       CONTAINER_IMAGE: "ghcr.io/${{ github.repository }}"
     steps:

--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -310,9 +310,10 @@ class Client:
         if internal_server_error is not None:
             message = internal_server_error.get("message")
             error_status_code = get_error_status_code(internal_server_error)
-
             if error_status_code == 400:
                 raise labelbox.exceptions.InvalidQueryError(message)
+            elif error_status_code == 422:
+                raise labelbox.exceptions.UnprocessableEntityError(message)
             elif error_status_code == 426:
                 raise labelbox.exceptions.OperationNotAllowedException(message)
             elif error_status_code == 500:
@@ -596,7 +597,8 @@ class Client:
         res = res["create%s" % db_object_type.type_name()]
         return db_object_type(self, res)
 
-    def create_model_config(self, name: str, model_id: str, inference_params: dict) -> ModelConfig:
+    def create_model_config(self, name: str, model_id: str,
+                            inference_params: dict) -> ModelConfig:
         """ Creates a new model config with the given params.
             Model configs are scoped to organizations, and can be reused between projects.
 
@@ -640,9 +642,7 @@ class Client:
                         success
                     }
                 }"""
-        params = {
-            "id": id
-        }
+        params = {"id": id}
         result = self.execute(query, params)
         return result['deleteModelConfig']['success']
 

--- a/libs/labelbox/src/labelbox/exceptions.py
+++ b/libs/labelbox/src/labelbox/exceptions.py
@@ -71,6 +71,12 @@ class InvalidQueryError(LabelboxError):
     pass
 
 
+class UnprocessableEntityError(LabelboxError):
+    """ Indicates that a resource could not be created in the server side
+    due to a validation or transaction error"""
+    pass
+
+
 class ResourceCreationError(LabelboxError):
     """ Indicates that a resource could not be created in the server side
     due to a validation or transaction error"""


### PR DESCRIPTION
QA discovered this issue when trying to create a model config with an invalid model id. In this case, the model service return http 422 as follows:
```
[{'message': 'Validation Error', 'locations': [{'line': 2, 'column': 21}], 'extensions': {'code': 'INTERNAL_SERVER_ERROR', 'exception': {'name': 'ApiError', 'url': 'http://lb-model-service-primary/api/v1/model-configs', 'status': 422, 'statusText': 'Unprocessable Entity', 'body': {'message': '1 validation error for Request body -> modelId value is not a valid uuid (type=type_error.uuid)'}, 'request': {'method': 'POST', 'url': '/api/v1/model-configs', 'body': {'modelId': 'invalid_valid_model_id', 'inferenceParams': {'param': 'value'}, 'organizationId': 'cl4ywm5aw00ke077lh4mrgpw5', 'name': 'model_config'}, 'mediaType': 'application/json', 'errors': {'422': 'Validation Error'}}}}, 'path': ['createModelConfig']}]
```

This PR prevents unnecessary retries of http 422 errors. 

See https://labelbox.atlassian.net/browse/PLT-773?focusedCommentId=201400 for more