### PR TITLE
Improve usability of create_project for chat evaluation and add basic validations

### DIFF
--- a/.github/workflows/python-package-develop.yml
+++ b/.github/workflows/python-package-develop.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+
 jobs:
   build:
     strategy:

--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -310,9 +310,10 @@ class Client:
         if internal_server_error is not None:
             message = internal_server_error.get("message")
             error_status_code = get_error_status_code(internal_server_error)
-
             if error_status_code == 400:
                 raise labelbox.exceptions.InvalidQueryError(message)
+            elif error_status_code == 422:
+                raise labelbox.exceptions.UnprocessableEntityError(message)
             elif error_status_code == 426:
                 raise labelbox.exceptions.OperationNotAllowedException(message)
             elif error_status_code == 500:
@@ -853,8 +854,8 @@ class Client:
             >>> client.create_model_evaluation_project(name=project_name, dataset_id="clr00u8j0j0j0")
             >>>     This creates a new project, and adds 100 datarows to the dataset with id "clr00u8j0j0j0" and assigns a batch of the newly created data rows to the project.
 
-            >>> client.create_model_evaluation_project(name=project_name, dataset_id="clr00u8j0j0j0", data_row_count=0)
-            >>>     This creates a new project, and adds 100 datarows to the dataset with id "clr00u8j0j0j0" and assigns a batch of the newly created data rows to the project.
+            >>> client.create_model_evaluation_project(name=project_name, dataset_id="clr00u8j0j0j0", data_row_count=10)
+            >>>     This creates a new project, and adds 100 datarows to the dataset with id "clr00u8j0j0j0" and assigns a batch of the newly created 10 data rows to the project.
 
 
         """

--- a/libs/labelbox/src/labelbox/exceptions.py
+++ b/libs/labelbox/src/labelbox/exceptions.py
@@ -71,6 +71,12 @@ class InvalidQueryError(LabelboxError):
     pass
 
 
+class UnprocessableEntityError(LabelboxError):
+    """ Indicates that a resource could not be created in the server side
+    due to a validation or transaction error"""
+    pass
+
+
 class ResourceCreationError(LabelboxError):
     """ Indicates that a resource could not be created in the server side
     due to a validation or transaction error"""

--- a/libs/labelbox/tests/integration/conftest.py
+++ b/libs/labelbox/tests/integration/conftest.py
@@ -363,11 +363,25 @@ def chat_evaluation_ontology(client, rand_gen):
 
 
 @pytest.fixture
-def chat_evaluation_project(client, rand_gen):
+def chat_evaluation_project_create_dataset(client, rand_gen):
     project_name = f"test-model-evaluation-project-{rand_gen(str)}"
-    dataset_name_or_id = f"test-model-evaluation-dataset-{rand_gen(str)}"
-    project = client.create_model_evaluation_project(
-        name=project_name, dataset_name_or_id=dataset_name_or_id)
+    dataset_name = f"test-model-evaluation-dataset-{rand_gen(str)}"
+    project = client.create_model_evaluation_project(name=project_name,
+                                                     dataset_name=dataset_name,
+                                                     data_row_count=1)
+
+    yield project
+
+    project.delete()
+
+
+@pytest.fixture
+def chat_evaluation_project_append_to_dataset(client, dataset, rand_gen):
+    project_name = f"test-model-evaluation-project-{rand_gen(str)}"
+    dataset_id = dataset.uid
+    project = client.create_model_evaluation_project(name=project_name,
+                                                     dataset_id=dataset_id,
+                                                     data_row_count=1)
 
     yield project
 

--- a/libs/labelbox/tests/integration/test_chat_evaluation_ontology_project.py
+++ b/libs/labelbox/tests/integration/test_chat_evaluation_ontology_project.py
@@ -5,9 +5,9 @@ from labelbox.schema.ontology_kind import OntologyKind
 from labelbox.schema.labeling_frontend import LabelingFrontend
 
 
-def test_create_chat_evaluation_ontology_project(client,
-                                                 chat_evaluation_ontology,
-                                                 chat_evaluation_project):
+def test_create_chat_evaluation_ontology_project(
+        client, chat_evaluation_ontology,
+        chat_evaluation_project_create_dataset):
     ontology = chat_evaluation_ontology
 
     # here we are essentially testing the ontology creation which is a fixture
@@ -18,7 +18,20 @@ def test_create_chat_evaluation_ontology_project(client,
         assert tool.schema_id
         assert tool.feature_schema_id
 
-    project = chat_evaluation_project
+    project = chat_evaluation_project_create_dataset
+    project.setup_editor(ontology)
+
+    assert project.labeling_frontend().name == "Editor"
+    assert project.ontology().name == ontology.name
+
+
+def test_create_chat_evaluation_ontology_project_existing_dataset(
+        client, chat_evaluation_ontology,
+        chat_evaluation_project_append_to_dataset):
+    ontology = chat_evaluation_ontology
+
+    project = chat_evaluation_project_append_to_dataset
+    assert project
     project.setup_editor(ontology)
 
     assert project.labeling_frontend().name == "Editor"


### PR DESCRIPTION
This PR addresses several usability issues and minor bugs identified during the initial QA of SDK support for MOE:

Issue: Creating a model configuration with an invalid model ID resulted in retries for 120 seconds before an error was reported.
**Fix**: We have now stopped retrying for HTTP 422 errors.
Issue: The options available during project creation were unclear, leading to end-user confusion and bugs.
**Fix**: I have added overloaded functions and docstring examples to clarify the two scenarios—creating a new project or appending to an existing dataset.
Improvement: Added basic validation for parameters to prevent confusing API error messages.