### PR TITLE
Converted TypedDict to BaseModel for client.send_to_annotate_from_catelog method

### DIFF
--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -2002,7 +2002,7 @@ class Client:
                                       task_queue_id: Optional[str],
                                       batch_name: str,
                                       data_rows: Union[DataRowIds, GlobalKeys],
-                                      params: SendToAnnotateFromCatalogParams):
+                                      params: Dict[str: Any]):
         """
         Sends data rows from catalog to a specified project for annotation.
 

--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -2033,6 +2033,8 @@ class Client:
 
         """
 
+        validated_params = SendToAnnotateFromCatalogParams(**params)
+
         mutation_str = """mutation SendToAnnotateFromCatalogPyApi($input: SendToAnnotateFromCatalogInput!) {
                             sendToAnnotateFromCatalog(input: $input) {
                               taskId
@@ -2044,26 +2046,14 @@ class Client:
             task_queue_id)
         data_rows_query = self.build_catalog_query(data_rows)
 
-        source_model_run_id = params.get("source_model_run_id", None)
-        predictions_ontology_mapping = params.get(
-            "predictions_ontology_mapping", None)
         predictions_input = build_predictions_input(
-            predictions_ontology_mapping,
-            source_model_run_id) if source_model_run_id else None
+            validated_params.predictions_ontology_mapping,
+            validated_params.source_model_run_id
+        ) if validated_params.source_model_run_id else None
 
-        source_project_id = params.get("source_project_id", None)
-        annotations_ontology_mapping = params.get(
-            "annotations_ontology_mapping", None)
         annotations_input = build_annotations_input(
-            annotations_ontology_mapping,
-            source_project_id) if source_project_id else None
-
-        batch_priority = params.get("batch_priority", 5)
-        exclude_data_rows_in_project = params.get(
-            "exclude_data_rows_in_project", False)
-        override_existing_annotations_rule = params.get(
-            "override_existing_annotations_rule",
-            ConflictResolutionStrategy.KeepExisting)
+            validated_params.annotations_ontology_mapping, validated_params.
+            source_project_id) if validated_params.source_project_id else None
 
         res = self.execute(
             mutation_str, {
@@ -2072,18 +2062,18 @@ class Client:
                         destination_project_id,
                     "batchInput": {
                         "batchName": batch_name,
-                        "batchPriority": batch_priority
+                        "batchPriority": validated_params.batch_priority
                     },
                     "destinationTaskQueue":
                         destination_task_queue,
                     "excludeDataRowsInProject":
-                        exclude_data_rows_in_project,
+                        validated_params.exclude_data_rows_in_project,
                     "annotationsInput":
                         annotations_input,
                     "predictionsInput":
                         predictions_input,
                     "conflictLabelsResolutionStrategy":
-                        override_existing_annotations_rule,
+                        validated_params.override_existing_annotations_rule,
                     "searchQuery": {
                         "scope": None,
                         "query": [data_rows_query]

--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -2002,7 +2002,7 @@ class Client:
                                       task_queue_id: Optional[str],
                                       batch_name: str,
                                       data_rows: Union[DataRowIds, GlobalKeys],
-                                      params: Dict[str: Any]):
+                                      params: Dict[str, Any]):
         """
         Sends data rows from catalog to a specified project for annotation.
 

--- a/libs/labelbox/src/labelbox/schema/send_to_annotate_params.py
+++ b/libs/labelbox/src/labelbox/schema/send_to_annotate_params.py
@@ -3,8 +3,7 @@ import sys
 from typing import Optional, Dict
 
 from labelbox.schema.conflict_resolution_strategy import ConflictResolutionStrategy
-from pydantic import model_validator, ConfigDict
-from pydantic.main import BaseModel
+from labelbox import pydantic_compat
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -12,7 +11,7 @@ else:
     from typing_extensions import TypedDict
 
 
-class SendToAnnotateFromCatalogParams(BaseModel):
+class SendToAnnotateFromCatalogParams(pydantic_compat.BaseModel):
     """
     Extra parameters for sending data rows to a project through catalog. At least one of source_model_run_id or
     source_project_id must be provided.
@@ -31,7 +30,6 @@ class SendToAnnotateFromCatalogParams(BaseModel):
         ConflictResolutionStrategy.KEEP_EXISTING.
     :param batch_priority: Optional[int] - The priority of the batch. Defaults to 5.
     """
-    model_config = ConfigDict(extra='forbid')
 
     source_model_run_id: Optional[str] = None
     source_project_id: Optional[str] = None
@@ -42,12 +40,16 @@ class SendToAnnotateFromCatalogParams(BaseModel):
         ConflictResolutionStrategy] = ConflictResolutionStrategy.KeepExisting
     batch_priority: Optional[int] = 5
 
-    @model_validator(mode='after')
+    @pydantic_compat.root_validator
     def check_project_id_or_model_run_id(self):
         if not self.source_model_run_id and not self.source_project_id:
             raise ValueError(
-                'source_project_id or source_model_id are required inside params dictionary'
+                'Either source_project_id or source_model_id are required'
             )
+        if self.source_model_run_id and self.source_project_id:
+            raise ValueError(
+                'Provide either only a source_project_id or source_model_id'
+            ) 
 
 
 class SendToAnnotateFromModelParams(TypedDict):

--- a/libs/labelbox/src/labelbox/schema/send_to_annotate_params.py
+++ b/libs/labelbox/src/labelbox/schema/send_to_annotate_params.py
@@ -3,7 +3,7 @@ import sys
 from typing import Optional, Dict
 
 from labelbox.schema.conflict_resolution_strategy import ConflictResolutionStrategy
-from pydantic import model_validator
+from pydantic import model_validator, ConfigDict
 from pydantic.main import BaseModel
 
 if sys.version_info >= (3, 8):
@@ -31,6 +31,7 @@ class SendToAnnotateFromCatalogParams(BaseModel):
         ConflictResolutionStrategy.KEEP_EXISTING.
     :param batch_priority: Optional[int] - The priority of the batch. Defaults to 5.
     """
+    model_config = ConfigDict(extra='forbid')
 
     source_model_run_id: Optional[str] = None
     source_project_id: Optional[str] = None

--- a/libs/labelbox/src/labelbox/schema/send_to_annotate_params.py
+++ b/libs/labelbox/src/labelbox/schema/send_to_annotate_params.py
@@ -3,6 +3,8 @@ import sys
 from typing import Optional, Dict
 
 from labelbox.schema.conflict_resolution_strategy import ConflictResolutionStrategy
+from pydantic import model_validator
+from pydantic.main import BaseModel
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -10,7 +12,7 @@ else:
     from typing_extensions import TypedDict
 
 
-class SendToAnnotateFromCatalogParams(TypedDict):
+class SendToAnnotateFromCatalogParams(BaseModel):
     """
     Extra parameters for sending data rows to a project through catalog. At least one of source_model_run_id or
     source_project_id must be provided.
@@ -30,13 +32,21 @@ class SendToAnnotateFromCatalogParams(TypedDict):
     :param batch_priority: Optional[int] - The priority of the batch. Defaults to 5.
     """
 
-    source_model_run_id: Optional[str]
-    predictions_ontology_mapping: Optional[Dict[str, str]]
-    source_project_id: Optional[str]
-    annotations_ontology_mapping: Optional[Dict[str, str]]
-    exclude_data_rows_in_project: Optional[bool]
-    override_existing_annotations_rule: Optional[ConflictResolutionStrategy]
-    batch_priority: Optional[int]
+    source_model_run_id: Optional[str] = None
+    source_project_id: Optional[str] = None
+    predictions_ontology_mapping: Optional[Dict[str, str]] = {}
+    annotations_ontology_mapping: Optional[Dict[str, str]] = {}
+    exclude_data_rows_in_project: Optional[bool] = False
+    override_existing_annotations_rule: Optional[
+        ConflictResolutionStrategy] = ConflictResolutionStrategy.KeepExisting
+    batch_priority: Optional[int] = 5
+
+    @model_validator(mode='after')
+    def check_project_id_or_model_run_id(self):
+        if not self.source_model_run_id and not self.source_project_id:
+            raise ValueError(
+                'source_project_id or source_model_id are required inside params dictionary'
+            )
 
 
 class SendToAnnotateFromModelParams(TypedDict):

--- a/libs/labelbox/src/labelbox/schema/send_to_annotate_params.py
+++ b/libs/labelbox/src/labelbox/schema/send_to_annotate_params.py
@@ -48,7 +48,7 @@ class SendToAnnotateFromCatalogParams(pydantic_compat.BaseModel):
             )
         if values.get("source_model_run_id") and values.get("source_project_id"):
             raise ValueError(
-                'Provide either only a source_project_id or source_model_id'
+                'Provide only a source_project_id or source_model_id not both'
             ) 
 
 

--- a/libs/labelbox/src/labelbox/schema/send_to_annotate_params.py
+++ b/libs/labelbox/src/labelbox/schema/send_to_annotate_params.py
@@ -41,12 +41,12 @@ class SendToAnnotateFromCatalogParams(pydantic_compat.BaseModel):
     batch_priority: Optional[int] = 5
 
     @pydantic_compat.root_validator
-    def check_project_id_or_model_run_id(self):
-        if not self.source_model_run_id and not self.source_project_id:
+    def check_project_id_or_model_run_id(cls, values):
+        if not values.get("source_model_run_id") and not values.get("source_project_id"):
             raise ValueError(
                 'Either source_project_id or source_model_id are required'
             )
-        if self.source_model_run_id and self.source_project_id:
+        if values.get("source_model_run_id") and values.get("source_project_id"):
             raise ValueError(
                 'Provide either only a source_project_id or source_model_id'
             ) 

--- a/libs/labelbox/src/labelbox/schema/send_to_annotate_params.py
+++ b/libs/labelbox/src/labelbox/schema/send_to_annotate_params.py
@@ -50,7 +50,7 @@ class SendToAnnotateFromCatalogParams(pydantic_compat.BaseModel):
             raise ValueError(
                 'Provide only a source_project_id or source_model_id not both'
             ) 
-
+        return values
 
 class SendToAnnotateFromModelParams(TypedDict):
     """


### PR DESCRIPTION
* Previous implementation used a typed dictionary which could not check if either a project ID or model run ID is present
* If either one of these is not present the UI looks strange, and there are no errors also doc string specifies one of these two ids are required
* Making this params field a pydantic base model increases validation support with the added benefit of typo checking
* Also managed to clean up code and remove a lot of the .get methods for the dictionaries
* Integration tests already exist on this method and they pass if needed I can write a unit test to test if the source project id or model run id being present passes the validation