### PR TITLE
Updated main labelbox-python readme to point to correct notebook branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Using the [GPT repository loader](https://github.com/mpoon/gpt-repository-loader
 The SDK is well-documented to help developers get started quickly and use the SDK effectively. Here are links to that documentation:
 
 - [Labelbox Official Documentation](https://docs.labelbox.com/docs/overview)
-- [Jupyter Notebook Examples](https://github.com/Labelbox/labelbox-python/tree/master/examples)
+- [Jupyter Notebook Examples](https://github.com/Labelbox/labelbox-python/tree/develop/examples)
 - [Python SDK Reference](https://labelbox-python.readthedocs.io/en/latest/)
 
 ## Jupyter Notebooks


### PR DESCRIPTION
# Description

Readme currently points to the wrong notebook branch for up-to-date information. I adjusted the link.

- [x] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?
