### PR TITLE
Provide ability to get model configs with a model id

### DIFF
--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -654,6 +654,29 @@ class Client:
         if not result:
             raise labelbox.exceptions.ResourceNotFoundError(Entity.ModelConfig, params)
         return result['deleteModelConfig']['success']
+    
+    def get_model_configs(self, model_id: str) -> List[ModelConfig]:
+        """ Gets all model configs attached to a given model id
+
+        Args:
+            model_id (str): ID of the model associated with the model configs
+
+        Returns:
+            List[ModelConfig], list of ModelConfigs if the operation was a success.
+        """
+        
+        query = """query SearchModelConfigsPyApi($modelId: ID!) {
+                    modelConfigs(
+                        where: {modelId: $modelId}
+                    ) {
+                        id
+                        inferenceParams
+                        name
+                    }
+                }"""
+        params = {"modelId": model_id}
+        result = self.execute(query, params)
+        return [ModelConfig(self, {**model_config, "modelId":model_id}) for model_config in result["modelConfigs"]]
 
     def create_dataset(self,
                        iam_integration=IAMIntegration._DEFAULT,

--- a/libs/labelbox/tests/integration/test_model_config.py
+++ b/libs/labelbox/tests/integration/test_model_config.py
@@ -15,3 +15,8 @@ def test_delete_model_config(client, valid_model_id):
 def test_delete_nonexistant_model_config(client):
     with pytest.raises(ResourceNotFoundError):
         client.delete_model_config("invalid_model_id")
+
+def test_get_model_configs(client, valid_model_id):
+    model_config = client.create_model_config("model_config_1", valid_model_id, {"param": "value"})
+    model_config = client.create_model_config("model_config_2", valid_model_id, {"param": "value"})
+    assert len(client.get_model_configs(valid_model_id)) == 2


### PR DESCRIPTION
# Description

* I noticed there is no way to get model config ids from the UI or easily from SDK without attaching it to a project. So I made a method to get model configs for Live model evaluation projects based on a model id you can get from the UI.

* This allows the flexibility to quickly add them to projects or just manage them in general, which is not even available on the UI yet. 

Loom to explain issue: 
https://www.loom.com/share/d086b0f8b4e5456c97a5077cf395f1b3?sid=e0ac0a7a-a48f-42fa-9725-0ef268a65d5f
## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [x] Have you added thorough tests for your new feature?
- [x] Have you commented your code, particularly in hard-to-understand areas?
- [x] Have you added a Docstring?
