### PR TITLE
[PLT-901] Vb/fix some tests plt 901

### DIFF
--- a/libs/labelbox/tests/data/annotation_import/test_model_run.py
+++ b/libs/labelbox/tests/data/annotation_import/test_model_run.py
@@ -168,16 +168,14 @@ def test_model_run_status(model_run_with_data_rows):
                                                errorMessage)
 
 
-def test_model_run_split_assignment_by_data_row_ids(
-        model_run, dataset, image_url, configured_project_with_one_data_row):
+def test_model_run_split_assignment_by_data_row_ids(model_run, dataset,
+                                                    image_url):
     n_data_rows = 2
     data_rows = dataset.create_data_rows([{
         "row_data": image_url
     } for _ in range(n_data_rows)])
     data_rows.wait_till_done()
     data_row_ids = [data_row['id'] for data_row in data_rows.result]
-    configured_project_with_one_data_row._wait_until_data_rows_are_processed(
-        data_row_ids=data_row_ids)
     model_run.upsert_data_rows(data_row_ids)
 
     with pytest.raises(ValueError):

--- a/libs/labelbox/tests/integration/test_filtering.py
+++ b/libs/labelbox/tests/integration/test_filtering.py
@@ -26,7 +26,8 @@ def project_to_test_where(client, rand_gen):
 # other builds simultaneously adding projects to test org
 def test_where(client, project_to_test_where):
     p_a, p_b, p_c = project_to_test_where
-    p_a_name, p_b_name = [p.name for p in [p_a, p_b]]
+    p_a_name = p_a.name
+    p_b_name = p_b.name
 
     def get(where=None):
         date_where = Project.created_at >= p_a.created_at

--- a/libs/labelbox/tests/integration/test_task.py
+++ b/libs/labelbox/tests/integration/test_task.py
@@ -67,7 +67,7 @@ def test_task_success_label_export(client, configured_project_with_label):
     user = client.get_user()
     task = None
     for task in user.created_tasks():
-        if task.name != 'JSON Import' and task.type != 'adv-upsert-data-rows':
+        if task.name != 'JSON Import' and task.type != 'adv-upsert-data-rows' and task.type != 'mea-label-registration':
             break
 
     with pytest.raises(ValueError) as exc_info:


### PR DESCRIPTION
# Description

This PR includes improvements to 3 tests that should make our sdk integration tests less flaky

- For test_model_run_split_assignment_by_data_row_ids removed unnecessary project creation and data row import. The task would not COMPLETE under heavy load for this test before
- test_filtering is a 'consistently' flaky spec. In the past it was failing a lot, I have made some updates and now it failed much less. This new change should hopefully make it stable
- test_task test_task_success_label_export was pulling incorrect task

## Type of change

Please delete options that are not relevant.

- [x] Test fix (non-breaking change which fixes an issue)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
