### PR TITLE
[PLT-1107] Add validation for empty row_data for Dataset create_data_rows

### DIFF
--- a/libs/labelbox/src/labelbox/schema/dataset.py
+++ b/libs/labelbox/src/labelbox/schema/dataset.py
@@ -32,7 +32,9 @@ from labelbox.schema.identifiable import UniqueId, GlobalKey
 from labelbox.schema.task import Task, DataUpsertTask
 from labelbox.schema.user import User
 from labelbox.schema.iam_integration import IAMIntegration
-from labelbox.schema.internal.data_row_upsert_item import (DataRowUpsertItem)
+from labelbox.schema.internal.data_row_upsert_item import (DataRowItemBase,
+                                                           DataRowUpsertItem,
+                                                           DataRowCreateItem)
 import labelbox.schema.internal.data_row_uploader as data_row_uploader
 from labelbox.schema.internal.descriptor_file_creator import DescriptorFileCreator
 from labelbox.schema.internal.datarow_upload_constants import (
@@ -288,10 +290,9 @@ class Dataset(DbObject, Updateable, Deletable):
         string_items = [item for item in items if isinstance(item, str)]
         dict_items = [item for item in items if isinstance(item, dict)]
         dict_string_items = []
-
         if len(string_items) > 0:
             dict_string_items = self._build_from_local_paths(string_items)
-        specs = DataRowUpsertItem.build(self.uid,
+        specs = DataRowCreateItem.build(self.uid,
                                         dict_items + dict_string_items)
         return self._exec_upsert_data_rows(specs, file_upload_thread_count)
 
@@ -613,7 +614,7 @@ class Dataset(DbObject, Updateable, Deletable):
 
     def _exec_upsert_data_rows(
         self,
-        specs: List[DataRowUpsertItem],
+        specs: List[DataRowItemBase],
         file_upload_thread_count: int = FILE_UPLOAD_THREAD_COUNT
     ) -> "DataUpsertTask":
 

--- a/libs/labelbox/src/labelbox/schema/internal/data_row_uploader.py
+++ b/libs/labelbox/src/labelbox/schema/internal/data_row_uploader.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import List
 
 from labelbox import pydantic_compat
-from labelbox.schema.internal.data_row_upsert_item import DataRowUpsertItem
+from labelbox.schema.internal.data_row_upsert_item import DataRowItemBase, DataRowUpsertItem, DataRowCreateItem
 from labelbox.schema.internal.descriptor_file_creator import DescriptorFileCreator
 
 
@@ -16,14 +16,19 @@ class UploadManifest(pydantic_compat.BaseModel):
 SOURCE_SDK = "SDK"
 
 
-def upload_in_chunks(client, specs: List[DataRowUpsertItem],
+def upload_in_chunks(client, specs: List[DataRowItemBase],
                      file_upload_thread_count: int,
                      max_chunk_size_bytes: int) -> UploadManifest:
     empty_specs = list(filter(lambda spec: spec.is_empty(), specs))
 
     if empty_specs:
         ids = list(map(lambda spec: spec.id.get("value"), empty_specs))
-        raise ValueError(f"The following items have an empty payload: {ids}")
+        ids = list(filter(lambda x: x is not None and len(x) > 0, ids))
+        if len(ids) > 0:
+            raise ValueError(
+                f"The following items have an empty payload: {ids}")
+        else:  # case of create items
+            raise ValueError("Some items have an empty payload")
 
     chunk_uris = DescriptorFileCreator(client).create(
         specs, max_chunk_size_bytes=max_chunk_size_bytes)

--- a/libs/labelbox/src/labelbox/schema/internal/data_row_upsert_item.py
+++ b/libs/labelbox/src/labelbox/schema/internal/data_row_upsert_item.py
@@ -5,6 +5,7 @@ from typing import List, Tuple, Optional
 from labelbox.pydantic_compat import BaseModel
 from labelbox.schema.identifiable import UniqueId, GlobalKey
 from labelbox import pydantic_compat
+from labelbox.schema.data_row import DataRow
 
 
 class DataRowItemBase(ABC, pydantic_compat.BaseModel):
@@ -78,7 +79,8 @@ class DataRowCreateItem(DataRowItemBase):
             or the only key is `dataset_id`.
         :return: bool
         """
-        row_data = self.payload.get("row_data", None)
+        row_data = self.payload.get("row_data", None) or self.payload.get(
+            DataRow.row_data, None)
         return (not self.payload or len(self.payload.keys()) == 1 and
                 "dataset_id" in self.payload or row_data is None or
                 len(row_data) == 0)

--- a/libs/labelbox/src/labelbox/schema/internal/data_row_upsert_item.py
+++ b/libs/labelbox/src/labelbox/schema/internal/data_row_upsert_item.py
@@ -1,15 +1,23 @@
+from abc import ABC, abstractmethod
+
 from typing import List, Tuple, Optional
 
-from labelbox.schema.identifiable import UniqueId, GlobalKey
 from labelbox.pydantic_compat import BaseModel
+from labelbox.schema.identifiable import UniqueId, GlobalKey
+from labelbox import pydantic_compat
 
 
-class DataRowUpsertItem(BaseModel):
+class DataRowItemBase(ABC, pydantic_compat.BaseModel):
     """
     Base class for creating payloads for upsert operations.
     """
+
     id: dict
     payload: dict
+
+    @abstractmethod
+    def is_empty(self) -> bool:
+        ...
 
     @classmethod
     def build(
@@ -17,7 +25,7 @@ class DataRowUpsertItem(BaseModel):
         dataset_id: str,
         items: List[dict],
         key_types: Optional[Tuple[type, ...]] = ()
-    ) -> List["DataRowUpsertItem"]:
+    ) -> List["DataRowItemBase"]:
         upload_items = []
 
         for item in items:
@@ -41,6 +49,9 @@ class DataRowUpsertItem(BaseModel):
             upload_items.append(cls(payload=item, id=key))
         return upload_items
 
+
+class DataRowUpsertItem(DataRowItemBase):
+
     def is_empty(self) -> bool:
         """
         The payload is considered empty if it's actually empty or the only key is `dataset_id`.
@@ -48,3 +59,35 @@ class DataRowUpsertItem(BaseModel):
         """
         return (not self.payload or
                 len(self.payload.keys()) == 1 and "dataset_id" in self.payload)
+
+    @classmethod
+    def build(
+        cls,
+        dataset_id: str,
+        items: List[dict],
+        key_types: Optional[Tuple[type, ...]] = (UniqueId, GlobalKey)
+    ) -> List["DataRowItemBase"]:
+        return super().build(dataset_id, items, (UniqueId, GlobalKey))
+
+
+class DataRowCreateItem(DataRowItemBase):
+
+    def is_empty(self) -> bool:
+        """
+        The payload is considered empty if it's actually empty or row_data is empty
+            or the only key is `dataset_id`.
+        :return: bool
+        """
+        row_data = self.payload.get("row_data", None)
+        return (not self.payload or len(self.payload.keys()) == 1 and
+                "dataset_id" in self.payload or row_data is None or
+                len(row_data) == 0)
+
+    @classmethod
+    def build(
+        cls,
+        dataset_id: str,
+        items: List[dict],
+        key_types: Optional[Tuple[type, ...]] = ()
+    ) -> List["DataRowItemBase"]:
+        return super().build(dataset_id, items, ())

--- a/libs/labelbox/src/labelbox/schema/internal/descriptor_file_creator.py
+++ b/libs/labelbox/src/labelbox/schema/internal/descriptor_file_creator.py
@@ -13,7 +13,7 @@ from labelbox.orm.model import Field
 from labelbox.schema.embedding import EmbeddingVector
 from labelbox.schema.internal.datarow_upload_constants import (
     FILE_UPLOAD_THREAD_COUNT)
-from labelbox.schema.internal.data_row_upsert_item import DataRowUpsertItem
+from labelbox.schema.internal.data_row_upsert_item import DataRowItemBase, DataRowUpsertItem
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -248,7 +248,7 @@ class DescriptorFileCreator:
             return item
 
         def convert_item(data_row_item):
-            if isinstance(data_row_item, DataRowUpsertItem):
+            if isinstance(data_row_item, DataRowItemBase):
                 item = data_row_item.payload
             else:
                 item = data_row_item
@@ -273,7 +273,7 @@ class DescriptorFileCreator:
             # Upload any local file paths
             item = upload_if_necessary(item)
 
-            if isinstance(data_row_item, DataRowUpsertItem):
+            if isinstance(data_row_item, DataRowItemBase):
                 return {'id': data_row_item.id, 'payload': item}
             else:
                 return item

--- a/libs/labelbox/tests/unit/test_data_row_upsert_data.py
+++ b/libs/labelbox/tests/unit/test_data_row_upsert_data.py
@@ -7,6 +7,7 @@ from labelbox.schema.identifiable import UniqueId, GlobalKey
 from labelbox.schema.asset_attachment import AttachmentType
 from labelbox.schema.dataset import Dataset
 from labelbox.schema.internal.descriptor_file_creator import DescriptorFileCreator
+from labelbox.schema.data_row import DataRow
 
 
 @pytest.fixture
@@ -117,6 +118,11 @@ def test_create_is_empty():
 
     item = DataRowCreateItem(
         id={}, payload={"row_data": "http://my_site.com/photos/img_01.jpg"})
+    assert not item.is_empty()
+
+    item = DataRowCreateItem(
+        id={},
+        payload={DataRow.row_data: "http://my_site.com/photos/img_01.jpg"})
     assert not item.is_empty()
 
 


### PR DESCRIPTION
# Description

During my implementation / refactor of Dataset `create_data_rows`, I somehow dropped validation of empty row_data. This PR restores validation of row_data and throws and error if it is None or an empty string

Fixes the issue discussed here https://labelbox.slack.com/archives/CPVQE6T2T/p1718010997829539

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x ] Have you provided a description?
- [x] Are your changes properly formatted?

## Changes to Core Features

- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
