### PR TITLE
Removed Catelog export experiment flag

### DIFF
--- a/libs/labelbox/src/labelbox/schema/catalog.py
+++ b/libs/labelbox/src/labelbox/schema/catalog.py
@@ -47,7 +47,6 @@ class Catalog:
             return ExportTask(task, True)
         return task
 
-    @experimental
     def export(
         self,
         task_name: Optional[str] = None,

--- a/libs/labelbox/src/labelbox/schema/catalog.py
+++ b/libs/labelbox/src/labelbox/schema/catalog.py
@@ -68,22 +68,6 @@ class Catalog:
         >>>             "label_details": True
         >>>         })
         >>>     export_task.wait_till_done()
-        >>>
-        >>>     # Return a JSON output string from the export task results/errors one by one:
-        >>>     def json_stream_handler(output: lb.JsonConverterOutput):
-        >>>       print(output.json_str)
-        >>>
-        >>>     if export_task.has_errors():
-        >>>       export_task.get_stream(
-        >>>         converter=lb.JsonConverter(),
-        >>>         stream_type=lb.StreamType.ERRORS
-        >>>       ).start(stream_handler=lambda error: print(error))
-        >>>
-        >>>     if export_task.has_result():
-        >>>       export_json = export_task.get_stream(
-        >>>         converter=lb.JsonConverter(),
-        >>>         stream_type=lb.StreamType.RESULT
-        >>>       ).start(stream_handler=json_stream_handler)
         """
         task, _ = self._export(task_name, filters, params, streamable=True)
         return ExportTask(task)


### PR DESCRIPTION
# Description

* Removed experiment flag on Catalog export. This matches all other export methods. I think we just missed this flag because export_v2 for catalog does not have this present and it uses the same backend

## Type of change

- [x] Bug fix

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?
