### PR TITLE
Remove incorrect test that is also flaky

### DIFF
--- a/libs/labelbox/tests/integration/test_task.py
+++ b/libs/labelbox/tests/integration/test_task.py
@@ -57,19 +57,3 @@ def test_task_success_json(dataset, image_url, snapshot):
     snapshot.assert_match(json.dumps(task_result),
                           'test_task.test_task_success_json.json')
     assert len(task.result)
-
-
-@pytest.mark.export_v1("export_v1 test remove later")
-def test_task_success_label_export(client, configured_project_with_label):
-    project, _, _, _ = configured_project_with_label
-    # TODO: Move to export_v2
-    project.export_labels()
-    user = client.get_user()
-    task = None
-    for task in user.created_tasks():
-        if task.name != 'JSON Import' and task.type != 'adv-upsert-data-rows' and task.type != 'mea-label-registration':
-            break
-
-    with pytest.raises(ValueError) as exc_info:
-        task.result
-    assert str(exc_info.value).startswith("Task result is only supported for")


### PR DESCRIPTION
# Description

I have removed a flaky test that tests tasks incorrectly:

- It uses  project.export_labels() - a deprecated export v1 - for the sole purpose of getting a task and testing it
- It searches for the applicable task incorrectly (see [here](https://github.com/Labelbox/intelligence/blob/develop/apps/api/src/tasks/resolvers/export-labels-resolver.ts#L136-L137) - it should search by task name specific to export v1)
- It uses `user.created_tasks()` api which we should remove of fix anyway
- We have other tests specific to task in this file that test tasks better

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
