### PR TITLE
GH Issue: Set Numpy < 2.0.0 as a requirement since it breaks our package

### DIFF
--- a/libs/labelbox/pyproject.toml
+++ b/libs/labelbox/pyproject.toml
@@ -47,7 +47,8 @@ data = [
     "shapely>=2.0.3",
     # numpy v2 breaks package since it only supports python >3.9
     "numpy>=1.24.4, <2.0.0",
-    "pillow>=10.2.0",
+    # pinned pillow to under 10.1.0 for imageio 2.31.6 support
+    "pillow<=10.1.0",
     "typeguard>=4.1.5",
     "imagesize>=1.4.1",
     "pyproj>=3.5.0",

--- a/libs/labelbox/pyproject.toml
+++ b/libs/labelbox/pyproject.toml
@@ -2,9 +2,7 @@
 name = "labelbox"
 version = "3.72.2"
 description = "Labelbox Python API"
-authors = [
-    { name = "Labelbox", email = "engineering@labelbox.com" }
-]
+authors = [{ name = "Labelbox", email = "engineering@labelbox.com" }]
 dependencies = [
     "google-api-core>=1.22.1",
     "pydantic>=1.8",
@@ -16,7 +14,7 @@ dependencies = [
 ]
 readme = "README.md"
 requires-python = ">=3.8"
-classifiers=[
+classifiers = [
     # How mature is this project?
     "Development Status :: 5 - Production/Stable",
     # Indicate who your project is intended for
@@ -27,7 +25,7 @@ classifiers=[
     "Intended Audience :: Education",
     # Pick your license as you wish
     "License :: OSI Approved :: Apache Software License",
-     # Specify the Python versions you support here.
+    # Specify the Python versions you support here.
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -47,7 +45,8 @@ Changelog = "https://github.com/Labelbox/labelbox-python/blob/develop/libs/label
 [project.optional-dependencies]
 data = [
     "shapely>=2.0.3",
-    "numpy>=1.24.4",
+    # numpy v2 breaks package since it only supports python >3.9
+    "numpy>=1.24.4, <2.0.0",
     "pillow>=10.2.0",
     "typeguard>=4.1.5",
     "imagesize>=1.4.1",
@@ -85,12 +84,12 @@ unit = "pytest tests/unit"
 # LABELBOX_TEST_ENVIRON="ephemeral" \
 # SERVICE_API_KEY=${SERVICE_API_KEY} \
 # LABELBOX_TEST_BASE_URL="http://host.docker.internal:8080" \
-integration = { cmd = "pytest tests/integration"  }
+integration = { cmd = "pytest tests/integration" }
 data = { cmd = "pytest tests/data" }
 yapf-lint = "yapf tests src -i --verbose --recursive --parallel --style \"google\""
 mypy-lint = "mypy src --pretty --show-error-codes --non-interactive --install-types"
 lint = { chain = ["yapf-lint", "mypy-lint"] }
-test = { chain = ["lint", "unit", "integration" ] }
+test = { chain = ["lint", "unit", "integration"] }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/libs/labelbox/pyproject.toml
+++ b/libs/labelbox/pyproject.toml
@@ -47,8 +47,8 @@ data = [
     "shapely>=2.0.3",
     # numpy v2 breaks package since it only supports python >3.9
     "numpy>=1.24.4, <2.0.0",
-    # pinned pillow to under 10.1.0 for imageio 2.31.6 support
-    "pillow<=10.1.0",
+    # pinned pillow to 10.1.0 for imageio 2.31.6 support
+    "pillow==10.1.0",
     "typeguard>=4.1.5",
     "imagesize>=1.4.1",
     "pyproj>=3.5.0",

--- a/libs/labelbox/pyproject.toml
+++ b/libs/labelbox/pyproject.toml
@@ -47,8 +47,7 @@ data = [
     "shapely>=2.0.3",
     # numpy v2 breaks package since it only supports python >3.9
     "numpy>=1.24.4, <2.0.0",
-    # pinned pillow to 10.1.0 for imageio 2.31.6 support
-    "pillow==10.1.0",
+    "pillow>=10.2.0",
     "typeguard>=4.1.5",
     "imagesize>=1.4.1",
     "pyproj>=3.5.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -4,7 +4,7 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: false
+#   all-features: true
 #   with-sources: false
 #   generate-hashes: false
 
@@ -32,6 +32,7 @@ bleach==6.1.0
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
+    # via pyproj
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -75,11 +76,13 @@ googleapis-common-protos==1.63.0
 idna==3.7
     # via requests
 imagesize==1.4.1
+    # via labelbox
     # via sphinx
 importlib-metadata==7.1.0
     # via jupyter-client
     # via nbconvert
     # via sphinx
+    # via typeguard
     # via yapf
 importlib-resources==6.4.0
     # via jsonschema
@@ -127,7 +130,12 @@ nbformat==5.10.4
     # via nbclient
     # via nbconvert
 numpy==1.24.4
+    # via labelbox
+    # via opencv-python-headless
     # via pandas
+    # via shapely
+opencv-python-headless==4.10.0.84
+    # via labelbox
 packaging==24.0
     # via black
     # via nbconvert
@@ -146,6 +154,8 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pillow==10.3.0
+    # via labelbox
 pkgutil-resolve-name==1.3.10
     # via jsonschema
 platformdirs==4.2.2
@@ -176,11 +186,15 @@ pydantic==2.7.2
     # via labelbox
 pydantic-core==2.18.3
     # via pydantic
+pygeotile==1.0.6
+    # via labelbox
 pygments==2.18.0
     # via ipython
     # via nbconvert
     # via rich
     # via sphinx
+pyproj==3.5.0
+    # via labelbox
 pytest==8.2.1
     # via pytest-cov
     # via pytest-rerunfailures
@@ -217,6 +231,8 @@ rpds-py==0.18.1
     # via referencing
 rsa==4.9
     # via google-auth
+shapely==2.0.4
+    # via labelbox
 shellingham==1.5.4
     # via typer
 six==1.16.0
@@ -278,6 +294,8 @@ traitlets==5.14.3
     # via nbclient
     # via nbconvert
     # via nbformat
+typeguard==4.3.0
+    # via labelbox
 typer==0.12.3
     # via databooks
     # via toml-cli
@@ -290,10 +308,12 @@ typing-extensions==4.12.0
     # via black
     # via databooks
     # via ipython
+    # via labelbox
     # via mypy
     # via pydantic
     # via pydantic-core
     # via rich
+    # via typeguard
     # via typer
 tzdata==2024.1
     # via pandas

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,7 +4,7 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: false
+#   all-features: true
 #   with-sources: false
 #   generate-hashes: false
 
@@ -18,6 +18,7 @@ babel==2.15.0
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
+    # via pyproj
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -35,15 +36,25 @@ googleapis-common-protos==1.63.0
 idna==3.7
     # via requests
 imagesize==1.4.1
+    # via labelbox
     # via sphinx
 importlib-metadata==7.1.0
     # via sphinx
+    # via typeguard
 jinja2==3.1.4
     # via sphinx
 markupsafe==2.1.5
     # via jinja2
+numpy==1.24.4
+    # via labelbox
+    # via opencv-python-headless
+    # via shapely
+opencv-python-headless==4.10.0.84
+    # via labelbox
 packaging==24.0
     # via sphinx
+pillow==10.3.0
+    # via labelbox
 proto-plus==1.23.0
     # via google-api-core
 protobuf==4.25.3
@@ -59,8 +70,12 @@ pydantic==2.7.2
     # via labelbox
 pydantic-core==2.18.3
     # via pydantic
+pygeotile==1.0.6
+    # via labelbox
 pygments==2.18.0
     # via sphinx
+pyproj==3.5.0
+    # via labelbox
 python-dateutil==2.8.2
     # via labelbox
 pytz==2024.1
@@ -71,6 +86,8 @@ requests==2.32.2
     # via sphinx
 rsa==4.9
     # via google-auth
+shapely==2.0.4
+    # via labelbox
 six==1.16.0
     # via python-dateutil
 snowballstemmer==2.2.0
@@ -98,10 +115,14 @@ strenum==0.4.15
     # via labelbox
 tqdm==4.66.4
     # via labelbox
+typeguard==4.3.0
+    # via labelbox
 typing-extensions==4.12.0
     # via annotated-types
+    # via labelbox
     # via pydantic
     # via pydantic-core
+    # via typeguard
 urllib3==2.2.1
     # via requests
 zipp==3.19.0


### PR DESCRIPTION
# Description

* From the linked issue, if someone has numpy >2.0, it breaks our package. This is due to Numpy >2,0 supporting Python 3.9 and above and 2.0 being a major release (first major release since 2006), i.e., changing a lot of how Numpy functions. Specified version 2.0 or below with rye to avoid confusion. Also cleaned up whitespace in pyproject file. See linked issue for more information

* [ Numpy](https://numpy.org/devdocs/release/2.0.0-notes.html) just released this version on the 6/13. Provided a comment to pyproject for information we can remove this once we removed support for 3.8 in Oct due to EOL of 3.8

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?
