### PR TITLE
Refactor Dataset create_data_rows_sync to use upsert

### DIFF
--- a/libs/labelbox/src/labelbox/schema/dataset.py
+++ b/libs/labelbox/src/labelbox/schema/dataset.py
@@ -124,7 +124,6 @@ class Dataset(DbObject, Updateable, Deletable):
 
     def create_data_row(self, items=None, **kwargs) -> "DataRow":
         """ Creates a single DataRow belonging to this dataset.
-        Now users upsert
         >>> dataset.create_data_row(row_data="http://my_site.com/photos/img_01.jpg")
 
         Args:
@@ -139,7 +138,7 @@ class Dataset(DbObject, Updateable, Deletable):
                 in `kwargs`.
             InvalidAttributeError: in case the DB object type does not contain
                 any of the field names given in `kwargs`.
-
+            ResourceCreationError: If data row creation failed on the server side.
         """
         file_upload_thread_count = 1
         args = items if items is not None else kwargs
@@ -184,8 +183,7 @@ class Dataset(DbObject, Updateable, Deletable):
             None. If the function doesn't raise an exception then the import was successful.
 
         Raises:
-            ResourceCreationError: Errors in data row upload
-            InvalidQueryError: If the `items` parameter does not conform to
+            ResourceCreationError: If the `items` parameter does not conform to
                 the specification in Dataset._create_descriptor_file or if the server did not accept the
                 DataRow creation request (unknown reason).
             InvalidAttributeError: If there are fields in `items` not valid for

--- a/libs/labelbox/src/labelbox/schema/dataset.py
+++ b/libs/labelbox/src/labelbox/schema/dataset.py
@@ -124,7 +124,7 @@ class Dataset(DbObject, Updateable, Deletable):
 
     def create_data_row(self, items=None, **kwargs) -> "DataRow":
         """ Creates a single DataRow belonging to this dataset.
-
+        Now users upsert
         >>> dataset.create_data_row(row_data="http://my_site.com/photos/img_01.jpg")
 
         Args:

--- a/libs/labelbox/src/labelbox/schema/dataset.py
+++ b/libs/labelbox/src/labelbox/schema/dataset.py
@@ -183,6 +183,10 @@ class Dataset(DbObject, Updateable, Deletable):
                 a DataRow.
             ValueError: When the upload parameters are invalid
         """
+        warnings.warn(
+            "This method is deprecated and will be "
+            "removed in a future release. Please use create_data_rows instead.")
+
         self._create_data_rows_sync(
             items, file_upload_thread_count=file_upload_thread_count)
 

--- a/libs/labelbox/src/labelbox/schema/dataset.py
+++ b/libs/labelbox/src/labelbox/schema/dataset.py
@@ -154,7 +154,7 @@ class Dataset(DbObject, Updateable, Deletable):
         res = completed_task.result
         if res is None or len(res) == 0:
             raise ResourceCreationError(
-                f"Data row upload did not complete, task status {task.status} task id {task.uid}"
+                f"Data row upload did not complete, task status {completed_task.status} task id {completed_task.uid}"
             )
 
         return self.client.get_data_row(res[0]['id'])
@@ -183,7 +183,6 @@ class Dataset(DbObject, Updateable, Deletable):
                 a DataRow.
             ValueError: When the upload parameters are invalid
         """
-        max_attachments_per_data_row = 5
         self._create_data_rows_sync(
             items, file_upload_thread_count=file_upload_thread_count)
 

--- a/libs/labelbox/src/labelbox/schema/dataset.py
+++ b/libs/labelbox/src/labelbox/schema/dataset.py
@@ -206,10 +206,8 @@ class Dataset(DbObject, Updateable, Deletable):
             raise ValueError(
                 "file_upload_thread_count must be a positive integer")
 
-        upload_items = self._separate_and_process_items(items)
-        specs = DataRowCreateItem.build(self.uid, upload_items)
-        task: DataUpsertTask = self._exec_upsert_data_rows(
-            specs, file_upload_thread_count)
+        task: DataUpsertTask = self.create_data_rows(items,
+                                                     file_upload_thread_count)
         task.wait_till_done()
 
         if task.has_errors():

--- a/libs/labelbox/tests/data/annotation_import/conftest.py
+++ b/libs/labelbox/tests/data/annotation_import/conftest.py
@@ -622,12 +622,15 @@ def configured_project(client, initial_dataset, ontology, rand_gen, image_url):
     data_row_ids = []
 
     ontologies = ontology["tools"] + ontology["classifications"]
+    data_row_data = []
     for ind in range(len(ontologies)):
-        data_row_ids.append(
-            dataset.create_data_row(
-                row_data=image_url,
-                global_key=f"gk_{ontologies[ind]['name']}_{rand_gen(str)}",
-            ).uid)
+        data_row_data.append({
+            "row_data": image_url,
+            "global_key": f"gk_{ontologies[ind]['name']}_{rand_gen(str)}"
+        })
+    task = dataset.create_data_rows(data_row_data)
+    task.wait_till_done()
+    data_row_ids = [row['id'] for row in task.result]
     project._wait_until_data_rows_are_processed(data_row_ids=data_row_ids,
                                                 sleep_interval=3)
 

--- a/libs/labelbox/tests/integration/test_data_rows.py
+++ b/libs/labelbox/tests/integration/test_data_rows.py
@@ -1111,8 +1111,6 @@ def test_create_tiled_layer(dataset, tile_content):
             **tile_content, 'media_type': 'TMS_GEO'
         },
         tile_content,
-        # Old way to check for backwards compatibility
-        tile_content['row_data']
     ]
     dataset.create_data_rows_sync(examples)
     data_rows = list(dataset.data_rows())

--- a/libs/labelbox/tests/integration/test_data_rows.py
+++ b/libs/labelbox/tests/integration/test_data_rows.py
@@ -10,10 +10,9 @@ import pytest
 
 from labelbox.schema.media_type import MediaType
 from labelbox import DataRow, AssetAttachment
-from labelbox.exceptions import MalformedQueryException
-from labelbox.schema.task import Task
+from labelbox.exceptions import MalformedQueryException, ResourceCreationError
+from labelbox.schema.task import Task, DataUpsertTask
 from labelbox.schema.data_row_metadata import DataRowMetadataField, DataRowMetadataKind
-import labelbox.exceptions
 
 SPLIT_SCHEMA_ID = "cko8sbczn0002h2dkdaxb5kal"
 TEST_SPLIT_ID = "cko8scbz70005h2dkastwhgqt"
@@ -1050,7 +1049,7 @@ def test_data_row_bulk_creation_sync_with_same_global_keys(
         dataset, sample_image):
     global_key_1 = str(uuid.uuid4())
 
-    with pytest.raises(labelbox.exceptions.MalformedQueryException) as exc_info:
+    with pytest.raises(ResourceCreationError) as exc_info:
         dataset.create_data_rows_sync([{
             DataRow.row_data: sample_image,
             DataRow.global_key: global_key_1
@@ -1061,8 +1060,8 @@ def test_data_row_bulk_creation_sync_with_same_global_keys(
 
     assert len(list(dataset.data_rows())) == 1
     assert list(dataset.data_rows())[0].global_key == global_key_1
-    assert "Some data rows were not imported. Check error output here" in str(
-        exc_info.value)
+    assert "Duplicate global key" in str(exc_info.value)
+    assert exc_info.value.args[1]  # task id
 
 
 @pytest.fixture

--- a/libs/labelbox/tests/integration/test_data_rows.py
+++ b/libs/labelbox/tests/integration/test_data_rows.py
@@ -362,10 +362,6 @@ def test_create_data_row_with_invalid_input(dataset, image_url):
     with pytest.raises(ResourceCreationError) as exc:
         dataset.create_data_row("asdf")
 
-    dr = {"row_data": image_url}
-    with pytest.raises(ResourceCreationError) as exc:
-        dataset.create_data_row(dr, row_data=image_url)
-
 
 def test_create_data_row_with_metadata(mdo, dataset, image_url):
     client = dataset.client

--- a/libs/labelbox/tests/integration/test_dataset.py
+++ b/libs/labelbox/tests/integration/test_dataset.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 from unittest.mock import MagicMock
 from labelbox import Dataset
-from labelbox.exceptions import ResourceNotFoundError, InvalidQueryError
+from labelbox.exceptions import ResourceNotFoundError, ResourceCreationError
 
 from labelbox.schema.internal.descriptor_file_creator import DescriptorFileCreator
 
@@ -128,7 +128,7 @@ def test_create_pdf(dataset):
     },
                             media_type="PDF")
 
-    with pytest.raises(InvalidQueryError):
+    with pytest.raises(ResourceCreationError):
         # Wrong media type
         dataset.create_data_row(row_data={
             "pdfUrl":

--- a/libs/labelbox/tests/integration/test_project_model_config.py
+++ b/libs/labelbox/tests/integration/test_project_model_config.py
@@ -1,4 +1,3 @@
-from _pytest import config
 import pytest
 from labelbox.exceptions import ResourceNotFoundError
 


### PR DESCRIPTION
# Description

This PR introduces improvements to the data row creation process within the SDK.
This PR refactors the following two data row creation methods:

- `Dataset.create_data_row`
- `Dataset.create_data_row_sync`

Both methods now leverage the upsert mutation for data row creation.

Since the upsert mutation is asynchronous, a task waiting mechanism has been implemented within these methods to ensure synchronous data row creation behavior.

A new ResourceCreationError exception has been introduced. This exception provides informative error messages in case of data creation failures, replacing the previous approach of returning None.

Stories:
https://labelbox.atlassian.net/browse/PLT-1066
https://labelbox.atlassian.net/browse/PLT-1067

On test failures:

- User group creation tests fail, [this PR](https://github.com/Labelbox/labelbox-python/pull/1698) should fix it
- A couple of tests failed due to data row creation task not completing. I have verified these tests pass when run on my laptop against stage

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
