### PR TITLE
Use correct project type in tests/integration/test_project_model_config.py

### DIFF
--- a/libs/labelbox/tests/integration/test_project_model_config.py
+++ b/libs/labelbox/tests/integration/test_project_model_config.py
@@ -1,30 +1,54 @@
+from _pytest import config
 import pytest
 from labelbox.exceptions import ResourceNotFoundError
 
-def test_add_single_model_config(configured_project, model_config):
-    project_model_config_id = configured_project.add_model_config(model_config.uid)
 
-    assert set(config.uid for config in configured_project.project_model_configs()) == set([project_model_config_id])
+def test_add_single_model_config(chat_evaluation_project_create_dataset,
+                                 model_config):
+    configured_project = chat_evaluation_project_create_dataset
+    project_model_config_id = configured_project.add_model_config(
+        model_config.uid)
 
-    assert configured_project.delete_project_model_config(project_model_config_id)
+    assert set(config.uid
+               for config in configured_project.project_model_configs()) == set(
+                   [project_model_config_id])
+
+    assert configured_project.delete_project_model_config(
+        project_model_config_id)
 
 
-def test_add_multiple_model_config(client, rand_gen, configured_project, model_config, valid_model_id):
-    second_model_config = client.create_model_config(rand_gen(str), valid_model_id, {"param": "value"})
-    first_project_model_config_id = configured_project.add_model_config(model_config.uid)
-    second_project_model_config_id = configured_project.add_model_config(second_model_config.uid)
-    expected_model_configs = set([first_project_model_config_id, second_project_model_config_id])
+def test_add_multiple_model_config(client, rand_gen,
+                                   chat_evaluation_project_create_dataset,
+                                   model_config, valid_model_id):
+    configured_project = chat_evaluation_project_create_dataset
+    second_model_config = client.create_model_config(rand_gen(str),
+                                                     valid_model_id,
+                                                     {"param": "value"})
+    first_project_model_config_id = configured_project.add_model_config(
+        model_config.uid)
+    second_project_model_config_id = configured_project.add_model_config(
+        second_model_config.uid)
+    expected_model_configs = set(
+        [first_project_model_config_id, second_project_model_config_id])
 
-    assert set(config.uid for config in configured_project.project_model_configs()) == expected_model_configs
+    assert set(
+        config.uid for config in configured_project.project_model_configs()
+    ) == expected_model_configs
 
     for project_model_config_id in expected_model_configs:
-        assert configured_project.delete_project_model_config(project_model_config_id)
+        assert configured_project.delete_project_model_config(
+            project_model_config_id)
 
 
-def test_delete_project_model_config(configured_project, model_config):
-    assert configured_project.delete_project_model_config(configured_project.add_model_config(model_config.uid))
+def test_delete_project_model_config(chat_evaluation_project_create_dataset,
+                                     model_config):
+    configured_project = chat_evaluation_project_create_dataset
+    assert configured_project.delete_project_model_config(
+        configured_project.add_model_config(model_config.uid))
     assert not len(configured_project.project_model_configs())
+
 
 def test_delete_nonexistant_project_model_config(configured_project):
     with pytest.raises(ResourceNotFoundError):
-        configured_project.delete_project_model_config("nonexistant_project_model_config")
+        configured_project.delete_project_model_config(
+            "nonexistant_project_model_config")


### PR DESCRIPTION
# Description

This fix addresses the api change that checks for project type before adding model configurations. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
