### PR TITLE
Add more test for adding batch to live chat model eval projects

### DIFF
--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -53,6 +53,7 @@ LabelingParameterOverrideInput = Tuple[Union[DataRow, DataRowIdentifier],
                                        DataRowPriority]
 
 logger = logging.getLogger(__name__)
+MAX_SYNC_BATCH_ROW_COUNT = 1_000
 
 
 def validate_labeling_parameter_overrides(
@@ -861,7 +862,6 @@ class Project(DbObject, Updateable, Deletable):
 
         Returns: the created batch
         """
-
         # @TODO: make this automatic?
         if self.queue_mode != QueueMode.Batch:
             raise ValueError("Project must be in batch mode")
@@ -897,7 +897,7 @@ class Project(DbObject, Updateable, Deletable):
             consensus_settings = ConsensusSettings(**consensus_settings).dict(
                 by_alias=True)
 
-        if row_count >= 1_000:
+        if row_count >= MAX_SYNC_BATCH_ROW_COUNT:
             return self._create_batch_async(name, dr_ids, global_keys, priority,
                                             consensus_settings)
         else:

--- a/libs/labelbox/tests/integration/test_chat_evaluation_ontology_project.py
+++ b/libs/labelbox/tests/integration/test_chat_evaluation_ontology_project.py
@@ -1,4 +1,6 @@
 import pytest
+from unittest.mock import patch
+
 from labelbox import MediaType
 from labelbox.schema.ontology_kind import OntologyKind
 from labelbox.exceptions import MalformedQueryException
@@ -6,8 +8,8 @@ from labelbox.exceptions import MalformedQueryException
 
 def test_create_chat_evaluation_ontology_project(
         client, chat_evaluation_ontology,
-        live_chat_evaluation_project_with_new_dataset, conversation_data_row,
-        rand_gen):
+        live_chat_evaluation_project_with_new_dataset,
+        offline_conversational_data_row, rand_gen):
     ontology = chat_evaluation_ontology
 
     # here we are essentially testing the ontology creation which is a fixture
@@ -35,8 +37,19 @@ def test_create_chat_evaluation_ontology_project(
                        match="No valid data rows to add to project"):
         project.create_batch(
             rand_gen(str),
-            [conversation_data_row.uid],  # sample of data row objects
+            [offline_conversational_data_row.uid],  # sample of data row objects
         )
+
+    with pytest.raises(MalformedQueryException,
+                       match="No valid data rows to add to project"):
+        with patch('labelbox.schema.project.MAX_SYNC_BATCH_ROW_COUNT',
+                   new=0):  # force to async
+
+            project.create_batch(
+                rand_gen(str),
+                [offline_conversational_data_row.uid
+                ],  # sample of data row objects
+            )
 
 
 def test_create_chat_evaluation_ontology_project_existing_dataset(


### PR DESCRIPTION
# Description

I have updated a test and added a new test to show that adding new batch to a live model chat evaluation project does not fail as expected

FYI the reason my initial test passed, i.e. project.create_batch() threw an exception, was because I used incorrect data row type for my test. So exception was for that reason, not because api explicitly disallowed created new batches for live model evaluation projects as it should.

FYI Project create_batch() uses two apis, depending whether we are adding less than or more than 1K rows:
- `createEmptyBatch` / `addDataRowsToBatchAsync` for async
- `createBatchV2` for sync

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
