### PR TITLE
[PTDT-2410] Prevent adding batches to live chat evaluation projects

### DIFF
--- a/libs/labelbox/tests/integration/test_chat_evaluation_ontology_project.py
+++ b/libs/labelbox/tests/integration/test_chat_evaluation_ontology_project.py
@@ -33,15 +33,17 @@ def test_create_chat_evaluation_ontology_project(
     assert project.labeling_frontend().name == "Editor"
     assert project.ontology().name == ontology.name
 
-    with pytest.raises(MalformedQueryException,
-                       match="No valid data rows to add to project"):
+    with pytest.raises(
+            ValueError,
+            match="Cannot create batches for auto data generation projects"):
         project.create_batch(
             rand_gen(str),
             [offline_conversational_data_row.uid],  # sample of data row objects
         )
 
-    with pytest.raises(MalformedQueryException,
-                       match="No valid data rows to add to project"):
+    with pytest.raises(
+            ValueError,
+            match="Cannot create batches for auto data generation projects"):
         with patch('labelbox.schema.project.MAX_SYNC_BATCH_ROW_COUNT',
                    new=0):  # force to async
 


### PR DESCRIPTION
# Description

Prevent adding data rows to live chat evaluation projects

PS testing in `tests/integration/test_chat_evaluation_ontology_project.py::test_create_chat_evaluation_ontology_project`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
- [x] Have you updated any code comments, as applicable?
