### PR TITLE
Docker container test run proceed even if a pipeline fails

### DIFF
--- a/libs/labelbox/Dockerfile
+++ b/libs/labelbox/Dockerfile
@@ -41,4 +41,4 @@ RUN rye config --set-bool behavior.global-python=true && \
     rye pin 3.8 && \
     rye sync
 
-CMD cd libs/labelbox && rye run integration && rye sync -f --features labelbox/data && rye run unit && rye run data
+    CMD cd libs/labelbox && rye run integration || true && rye sync -f --features labelbox/data && rye run unit || true && rye run data


### PR DESCRIPTION
# Description

For our codefresh tests, we now use sdk container based on the last sdk release. It runs 4 sets of test separately. Rarely, but it may happen, a new version of api on stage is incompatible with the last sdk release.  If this happens, and an sdk test fails, we do not proceed to run the rest of test sets

This PR makes it such that even if 1 test set fails, another still runs

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
