### PR TITLE
[PLT-1201] Deprecate Project setup_editor and add Project connect_ontology

### DIFF
--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -772,35 +772,24 @@ class Project(DbObject, Updateable, Deletable):
         Args:
             ontology (Ontology): The ontology to attach to the project
         """
+        warnings.warn("This method is deprecated use connect_ontology instead.")
+        self.connect_ontology(ontology)
 
-        if self.labeling_frontend() is not None and not self.is_chat_evaluation(
-        ):  # Chat evaluation projects are automatically set up via the same api that creates a project
-            raise ResourceConflict("Editor is already set up.")
+    def connect_ontology(self, ontology) -> None:
+        """
+        Connects the ontology to the project. If an editor is not setup, it will be connected as well.
 
-        if not self.is_chat_evaluation():
-            labeling_frontend = next(
-                self.client.get_labeling_frontends(
-                    where=Entity.LabelingFrontend.name == "Editor"))
-            self.labeling_frontend.connect(labeling_frontend)
+        Note: For live chat model evaluation projects, the editor setup is skipped becase it is automatically setup when the project is created.
 
-            LFO = Entity.LabelingFrontendOptions
-            self.client._create(
-                LFO, {
-                    LFO.project:
-                        self,
-                    LFO.labeling_frontend:
-                        labeling_frontend,
-                    LFO.customization_options:
-                        json.dumps({
-                            "tools": [],
-                            "classifications": []
-                        })
-                })
-        else:
-            warnings.warn("""
-            Skipping editor setup for a chat evaluation project.
-            Editor was setup automatically.
-            """)
+        Args:
+            ontology (Ontology): The ontology to attach to the project
+        """
+        if self.labeling_frontend(
+        ) is None:  # Chat evaluation projects are automatically set up via the same api that creates a project
+            self._connect_default_labeling_front_end(ontology_as_dict={
+                "tools": [],
+                "classifications": []
+            })
 
         query_str = """mutation ConnectOntologyPyApi($projectId: ID!, $ontologyId: ID!){
             project(where: {id: $projectId}) {connectOntology(ontologyId: $ontologyId) {id}}}"""
@@ -812,42 +801,54 @@ class Project(DbObject, Updateable, Deletable):
         self.update(setup_complete=timestamp)
 
     def setup(self, labeling_frontend, labeling_frontend_options) -> None:
-        """ Finalizes the Project setup.
+        """ This method will associate default labeling frontend with the project and create an ontology based on labeling_frontend_options.
 
         Args:
-            labeling_frontend (LabelingFrontend): Which UI to use to label the
-                data.
+            labeling_frontend (LabelingFrontend): Do not use, this parameter is deprecated. We now associate the default labeling frontend with the project.
             labeling_frontend_options (dict or str): Labeling frontend options,
                 a.k.a. project ontology. If given a `dict` it will be converted
                 to `str` using `json.dumps`.
         """
 
+        warnings.warn("This method is deprecated use connect_ontology instead.")
+        if labeling_frontend is not None:
+            warnings.warn(
+                "labeling_frontend parameter will not be used to create a new labeling frontend."
+            )
+
         if self.is_chat_evaluation():
             warnings.warn("""
-            This project is a chat evaluation project.
+            This project is a live chat evaluation project.
             Editor was setup automatically.
-            No need to call this method.
             """)
             return
 
-        if self.labeling_frontend() is not None:
-            raise ResourceConflict("Editor is already set up.")
+        if self.labeling_frontend(
+        ) is None:  # Chat evaluation projects are automatically set up via the same api that creates a project
+            self._connect_default_labeling_front_end(labeling_frontend_options)
 
-        if not isinstance(labeling_frontend_options, str):
-            labeling_frontend_options = json.dumps(labeling_frontend_options)
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        self.update(setup_complete=timestamp)
 
+    def _connect_default_labeling_front_end(self, ontology_as_dict: dict):
+        warnings.warn("Connecting default labeling editor for the project.")
+        labeling_frontend = next(
+            self.client.get_labeling_frontends(
+                where=Entity.LabelingFrontend.name == "Editor"))
         self.labeling_frontend.connect(labeling_frontend)
+
+        if not isinstance(ontology_as_dict, str):
+            labeling_frontend_options_str = json.dumps(ontology_as_dict)
+        else:
+            labeling_frontend_options_str = ontology_as_dict
 
         LFO = Entity.LabelingFrontendOptions
         self.client._create(
             LFO, {
                 LFO.project: self,
                 LFO.labeling_frontend: labeling_frontend,
-                LFO.customization_options: labeling_frontend_options
+                LFO.customization_options: labeling_frontend_options_str
             })
-
-        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        self.update(setup_complete=timestamp)
 
     def create_batch(
         self,

--- a/libs/labelbox/tests/data/annotation_import/conftest.py
+++ b/libs/labelbox/tests/data/annotation_import/conftest.py
@@ -608,7 +608,8 @@ def configured_project_one_datarow_id(configured_project_with_one_data_row):
 
     yield get_data_row_id
 
-#TODO: Switch to setup_editor, setup might get removed in later releases
+
+#TODO: Switch to connect_ontology, setup might get removed in later releases
 @pytest.fixture
 def configured_project(client, initial_dataset, ontology, rand_gen, image_url):
     dataset = initial_dataset
@@ -645,7 +646,8 @@ def configured_project(client, initial_dataset, ontology, rand_gen, image_url):
 
     project.delete()
 
-#TODO: Switch to setup_editor, setup might get removed in later releases
+
+#TODO: Switch to connect_ontology, setup might get removed in later releases
 @pytest.fixture
 def project_with_ontology(client, configured_project, ontology, rand_gen):
     project = client.create_project(name=rand_gen(str),
@@ -660,7 +662,8 @@ def project_with_ontology(client, configured_project, ontology, rand_gen):
 
     project.delete()
 
-#TODO: Switch to setup_editor, setup might get removed in later releases
+
+#TODO: Switch to connect_ontology, setup might get removed in later releases
 @pytest.fixture
 def configured_project_pdf(client, ontology, rand_gen, pdf_url):
     project = client.create_project(name=rand_gen(str),

--- a/libs/labelbox/tests/data/annotation_import/test_send_to_annotate_mea.py
+++ b/libs/labelbox/tests/data/annotation_import/test_send_to_annotate_mea.py
@@ -14,7 +14,7 @@ def test_send_to_annotate_from_model(client, configured_project,
     destination_project = project
     model = client.get_model(model_run.model_id)
     ontology = client.get_ontology(model.ontology_id)
-    destination_project.setup_editor(ontology)
+    destination_project.connect_ontology(ontology)
 
     queues = destination_project.task_queues()
     initial_review_task = next(
@@ -55,13 +55,13 @@ def test_send_to_annotate_from_model(client, configured_project,
     # Check that the data row was sent to the new project
     destination_batches = list(destination_project.batches())
     assert len(destination_batches) == 1
-    
+
     export_task = destination_project.export()
     export_task.wait_till_done()
     stream = export_task.get_buffered_stream()
-    
+
     destination_data_rows = [dr.json["data_row"]["id"] for dr in stream]
-    
+
     assert len(destination_data_rows) == len(data_row_ids)
     assert all([dr in data_row_ids for dr in destination_data_rows])
 

--- a/libs/labelbox/tests/integration/test_chat_evaluation_ontology_project.py
+++ b/libs/labelbox/tests/integration/test_chat_evaluation_ontology_project.py
@@ -28,7 +28,7 @@ def test_create_chat_evaluation_ontology_project(
     project = live_chat_evaluation_project_with_new_dataset
     assert project.model_setup_complete is None
 
-    project.setup_editor(ontology)
+    project.connect_ontology(ontology)
 
     assert project.labeling_frontend().name == "Editor"
     assert project.ontology().name == ontology.name
@@ -61,7 +61,7 @@ def test_create_chat_evaluation_ontology_project_existing_dataset(
 
     project = chat_evaluation_project_append_to_dataset
     assert project
-    project.setup_editor(ontology)
+    project.connect_ontology(ontology)
 
     assert project.labeling_frontend().name == "Editor"
     assert project.ontology().name == ontology.name

--- a/libs/labelbox/tests/integration/test_offline_chat_evaluation_project.py
+++ b/libs/labelbox/tests/integration/test_offline_chat_evaluation_project.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 def test_create_offline_chat_evaluation_project(client, rand_gen,
                                                 offline_chat_evaluation_project,
                                                 chat_evaluation_ontology,
@@ -9,7 +10,7 @@ def test_create_offline_chat_evaluation_project(client, rand_gen,
     assert project
 
     ontology = chat_evaluation_ontology
-    project.setup_editor(ontology)
+    project.connect_ontology(ontology)
 
     assert project.labeling_frontend().name == "Editor"
     assert project.ontology().name == ontology.name

--- a/libs/labelbox/tests/integration/test_ontology.py
+++ b/libs/labelbox/tests/integration/test_ontology.py
@@ -95,7 +95,7 @@ def test_cant_delete_an_ontology_with_project(client):
         name='ontology name',
         feature_schema_ids=[feature_schema_id],
         media_type=MediaType.Image)
-    project.setup_editor(ontology)
+    project.connect_ontology(ontology)
 
     with pytest.raises(
             Exception,
@@ -160,7 +160,7 @@ def test_does_not_include_used_ontologies(client):
     project = client.create_project(name="test project",
                                     queue_mode=QueueMode.Batch,
                                     media_type=MediaType.Image)
-    project.setup_editor(ontology_with_project)
+    project.connect_ontology(ontology_with_project)
     unused_ontologies = client.get_unused_ontologies()
 
     assert ontology_with_project.uid not in unused_ontologies

--- a/libs/labelbox/tests/integration/test_project_setup.py
+++ b/libs/labelbox/tests/integration/test_project_setup.py
@@ -55,7 +55,7 @@ def test_project_editor_setup(client, project, rand_gen):
     ontology_name = f"test_project_editor_setup_ontology_name-{rand_gen(str)}"
     ontology = client.create_ontology(ontology_name, simple_ontology())
     now = datetime.now().astimezone(timezone.utc)
-    project.setup_editor(ontology)
+    project.connect_ontology(ontology)
     assert now - project.setup_complete <= timedelta(seconds=3)
     assert now - project.last_activity_time <= timedelta(seconds=3)
     assert project.labeling_frontend().name == "Editor"
@@ -72,6 +72,6 @@ def test_project_editor_setup_cant_call_multiple_times(client, project,
                                                        rand_gen):
     ontology_name = f"test_project_editor_setup_ontology_name-{rand_gen(str)}"
     ontology = client.create_ontology(ontology_name, simple_ontology())
-    project.setup_editor(ontology)
+    project.connect_ontology(ontology)
     with pytest.raises(ResourceConflict):
-        project.setup_editor(ontology)
+        project.connect_ontology(ontology)

--- a/libs/labelbox/tests/integration/test_project_setup.py
+++ b/libs/labelbox/tests/integration/test_project_setup.py
@@ -68,10 +68,10 @@ def test_project_editor_setup(client, project, rand_gen):
            ] == [ontology_name]
 
 
-def test_project_editor_setup_cant_call_multiple_times(client, project,
-                                                       rand_gen):
+def test_project_connect_ontology_cant_call_multiple_times(
+        client, project, rand_gen):
     ontology_name = f"test_project_editor_setup_ontology_name-{rand_gen(str)}"
     ontology = client.create_ontology(ontology_name, simple_ontology())
     project.connect_ontology(ontology)
-    with pytest.raises(ResourceConflict):
+    with pytest.raises(ValueError):
         project.connect_ontology(ontology)

--- a/libs/labelbox/tests/integration/test_send_to_annotate.py
+++ b/libs/labelbox/tests/integration/test_send_to_annotate.py
@@ -4,12 +4,13 @@ from typing import List
 
 
 def test_send_to_annotate_include_annotations(
-        client: Client, configured_batch_project_with_label: Project, project_pack: List[Project], ontology: Ontology):
+        client: Client, configured_batch_project_with_label: Project,
+        project_pack: List[Project], ontology: Ontology):
     [source_project, _, data_row, _] = configured_batch_project_with_label
     destination_project: Project = project_pack[0]
 
     src_ontology = source_project.ontology()
-    destination_project.setup_editor(ontology)
+    destination_project.connect_ontology(ontology)
 
     # build an ontology mapping using the top level tools
     src_feature_schema_ids = list(
@@ -46,11 +47,11 @@ def test_send_to_annotate_include_annotations(
         # Check that the data row was sent to the new project
         destination_batches = list(destination_project.batches())
         assert len(destination_batches) == 1
-        
+
         export_task = destination_project.export()
         export_task.wait_till_done()
         stream = export_task.get_buffered_stream()
-        
+
         destination_data_rows = [dr.json["data_row"]["id"] for dr in stream]
         assert len(destination_data_rows) == 1
         assert destination_data_rows[0] == data_row.uid

--- a/libs/labelbox/tests/unit/test_project.py
+++ b/libs/labelbox/tests/unit/test_project.py
@@ -1,8 +1,30 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from labelbox.schema.project import Project
 from labelbox.schema.ontology_kind import EditorTaskType
+
+
+@pytest.fixture
+def project_entity():
+    return Project(
+        MagicMock(), {
+            "id": "test",
+            "name": "test",
+            "createdAt": "2021-06-01T00:00:00.000Z",
+            "updatedAt": "2021-06-01T00:00:00.000Z",
+            "autoAuditNumberOfLabels": 1,
+            "autoAuditPercentage": 100,
+            "dataRowCount": 1,
+            "description": "test",
+            "editorTaskType": "MODEL_CHAT_EVALUATION",
+            "lastActivityTime": "2021-06-01T00:00:00.000Z",
+            "allowedMediaType": "IMAGE",
+            "queueMode": "BATCH",
+            "setupComplete": "2021-06-01T00:00:00.000Z",
+            "modelSetupComplete": None,
+            "uploadType": "Auto",
+        })
 
 
 @pytest.mark.parametrize(
@@ -14,7 +36,7 @@ from labelbox.schema.ontology_kind import EditorTaskType
       EditorTaskType.OfflineModelChatEvaluation),
      ('NEW_TYPE', EditorTaskType.Missing)])
 def test_project_editor_task_type(api_editor_task_type,
-                                  expected_editor_task_type):
+                                  expected_editor_task_type, project_entity):
     client = MagicMock()
     project = Project(
         client, {
@@ -36,3 +58,13 @@ def test_project_editor_task_type(api_editor_task_type,
         })
 
     assert project.editor_task_type == expected_editor_task_type
+
+
+def test_setup_editor_using_connect_ontology(project_entity):
+    project = project_entity
+    ontology = MagicMock()
+    project.connect_ontology = MagicMock()
+    with patch("warnings.warn") as warn:
+        project.setup_editor(ontology)
+        warn.assert_called_once()
+        project.connect_ontology.assert_called_once_with(ontology)


### PR DESCRIPTION
Deprecate Project setup

# Description

This story is part of the project sunset-custom-editor. It refactors Project `setup` and `setup_editor` methods to prevent users from injecting their own custom editors. Instead we will use or connect a default editor for all projects


- `setup_editor` now has a deprecated note, we replace it with `connect_ontology` which is essentially what this method will be doing now
- `setup`  will only allow to create ontology, but instead of adding a labeling front end, it will create a default labeling front end if one is missing

This is inline with https://docs.google.com/document/d/1ME1EzyyMtX0viTr4F8LGA_hnAAPu7oZK1qCT3Q7RljA - the Python SDK section

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
- [x] Have you updated any code comments, as applicable?
