### PR TITLE
Vb/fix create ontology for project setup

### DIFF
--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -832,19 +832,19 @@ class Project(DbObject, Updateable, Deletable):
             """)
             return
 
-        if self.labeling_frontend(
-        ) is None:  # Chat evaluation projects are automatically set up via the same api that creates a project
-            self._connect_default_labeling_front_end(labeling_frontend_options)
+        self._connect_default_labeling_front_end(labeling_frontend_options)
 
         timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         self.update(setup_complete=timestamp)
 
     def _connect_default_labeling_front_end(self, ontology_as_dict: dict):
-        warnings.warn("Connecting default labeling editor for the project.")
-        labeling_frontend = next(
-            self.client.get_labeling_frontends(
-                where=Entity.LabelingFrontend.name == "Editor"))
-        self.labeling_frontend.connect(labeling_frontend)
+        labeling_frontend = self.labeling_frontend()
+        if labeling_frontend is None:  # Chat evaluation projects are automatically set up via the same api that creates a project
+            warnings.warn("Connecting default labeling editor for the project.")
+            labeling_frontend = next(
+                self.client.get_labeling_frontends(
+                    where=Entity.LabelingFrontend.name == "Editor"))
+            self.labeling_frontend.connect(labeling_frontend)
 
         if not isinstance(ontology_as_dict, str):
             labeling_frontend_options_str = json.dumps(ontology_as_dict)

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -790,15 +790,15 @@ class Project(DbObject, Updateable, Deletable):
         Args:
             ontology (Ontology): The ontology to attach to the project
         """
+        if not self.is_empty_ontology():
+            raise ValueError("Ontology already connected to project.")
+
         if self.labeling_frontend(
         ) is None:  # Chat evaluation projects are automatically set up via the same api that creates a project
             self._connect_default_labeling_front_end(ontology_as_dict={
                 "tools": [],
                 "classifications": []
             })
-
-        if not self.is_empty_ontology():
-            raise ValueError("Ontology already connected to project.")
 
         query_str = """mutation ConnectOntologyPyApi($projectId: ID!, $ontologyId: ID!){
             project(where: {id: $projectId}) {connectOntology(ontologyId: $ontologyId) {id}}}"""

--- a/libs/labelbox/tests/data/annotation_import/conftest.py
+++ b/libs/labelbox/tests/data/annotation_import/conftest.py
@@ -619,7 +619,6 @@ def configured_project(client, initial_dataset, ontology, rand_gen, image_url):
         client.get_labeling_frontends(
             where=LabelingFrontend.name == "editor"))[0]
     project.setup(editor, ontology)
-
     data_row_ids = []
 
     ontologies = ontology["tools"] + ontology["classifications"]


### PR DESCRIPTION
# Description

This PR addresses a recent bug introduced after removing labeling front-end creation from the SDK.
The Project.setup now 
- Connects a default labeling front-end if one isn't already specified.
- Creates an ontology for the project.

If a labeling front-end already existed for the project, the ontology creation step was inadvertently skipped. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [x] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
