### PR TITLE
[PLT-1317] Add back support for project JSON type

### DIFF
--- a/libs/labelbox/src/labelbox/schema/media_type.py
+++ b/libs/labelbox/src/labelbox/schema/media_type.py
@@ -21,6 +21,7 @@ class MediaType(Enum):
     Video = "VIDEO"
     Point_Cloud = "POINT_CLOUD"
     LLM = "LLM"
+    Json = "JSON"
 
     @classmethod
     def _missing_(cls, name):


### PR DESCRIPTION
Story: https://labelbox.atlassian.net/browse/PLT-1317

# Description

We are making changes to the api to include back project with custom or no editors with Client `get_projects()` . This change is required to support projects with custom editors (media type = JSON)
But not 


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
