### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Rye conversion
+d9d54d002885b9f64160a9da70b1af2e05915bd3


### PR DESCRIPTION
# Description

* The rye conversion commit we did messes with the blame history since it touched every file.
* I added a .git-blame-ignore-revs file to clean this up 
* Review this page for more details https://github.com/orgs/community/discussions/5033

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

