### PR TITLE
Improved test where

### DIFF
--- a/libs/labelbox/tests/integration/test_filtering.py
+++ b/libs/labelbox/tests/integration/test_filtering.py
@@ -21,12 +21,16 @@ def project_to_test_where(client, rand_gen):
     
     while (num_retries > 0):
         projects = client.get_projects()
-        if projects is None or len(list(projects)) != 3:
+        try:
+            if len(list(projects)) >= 3:
+                break
+        except TypeError:
             num_retries -= 1
             time.sleep(5)
-        else:
-            break
 
+    if num_retries == 0:
+        raise TimeoutError("Hit max number of retries getting projects")
+    
     yield p_a, p_b, p_c
 
     p_a.delete()

--- a/libs/labelbox/tests/integration/test_filtering.py
+++ b/libs/labelbox/tests/integration/test_filtering.py
@@ -4,6 +4,7 @@ from labelbox import Project
 from labelbox.exceptions import InvalidQueryError
 from labelbox import MediaType
 import time
+import logging
 
 
 @pytest.fixture
@@ -21,11 +22,12 @@ def project_to_test_where(client, rand_gen):
     while (num_retries > 0):
         projects = client.get_projects()
         try:
+            logging.log(level=2, msg=f"{len(list(projects))}")
             if len(list(projects)) >= 3:
                 break
             else:
                 raise TypeError()
-        except TypeError:
+        except:
             num_retries -= 1
             time.sleep(5)
 

--- a/libs/labelbox/tests/integration/test_filtering.py
+++ b/libs/labelbox/tests/integration/test_filtering.py
@@ -2,7 +2,6 @@ import pytest
 
 from labelbox import Project
 from labelbox.exceptions import InvalidQueryError
-from labelbox.schema.queue_mode import QueueMode
 from labelbox import MediaType
 import time
 
@@ -24,6 +23,8 @@ def project_to_test_where(client, rand_gen):
         try:
             if len(list(projects)) >= 3:
                 break
+            else:
+                raise TypeError()
         except TypeError:
             num_retries -= 1
             time.sleep(5)

--- a/libs/labelbox/tests/integration/test_filtering.py
+++ b/libs/labelbox/tests/integration/test_filtering.py
@@ -3,17 +3,29 @@ import pytest
 from labelbox import Project
 from labelbox.exceptions import InvalidQueryError
 from labelbox.schema.queue_mode import QueueMode
+from labelbox import MediaType
+import time
 
 
 @pytest.fixture
 def project_to_test_where(client, rand_gen):
+    num_retries = 5
+    
     p_a_name = f"a-{rand_gen(str)}"
     p_b_name = f"b-{rand_gen(str)}"
     p_c_name = f"c-{rand_gen(str)}"
-
-    p_a = client.create_project(name=p_a_name, queue_mode=QueueMode.Batch)
-    p_b = client.create_project(name=p_b_name, queue_mode=QueueMode.Batch)
-    p_c = client.create_project(name=p_c_name, queue_mode=QueueMode.Batch)
+    
+    p_a = client.create_project(name=p_a_name, media_type=MediaType.Image)
+    p_b = client.create_project(name=p_b_name, media_type=MediaType.Image)
+    p_c = client.create_project(name=p_c_name, media_type=MediaType.Image)
+    
+    while (num_retries > 0):
+        projects = client.get_projects()
+        if projects is None or len(list(projects)) != 3:
+            num_retries -= 1
+            time.sleep(5)
+        else:
+            break
 
     yield p_a, p_b, p_c
 


### PR DESCRIPTION
# Description

* test_where is finicky, and the main problem is due to projects not being ready yet
* Added a retry loop This is similar logic to our export_v2 helper
* This won't slow down the test at all just introduce some retries if API is slow since we do not block on on project creation and if multiple projects are created at a time their can be a very slight slow down

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

