### PR TITLE
Set up test embeddings to be reusable

### DIFF
--- a/libs/labelbox/tests/conftest.py
+++ b/libs/labelbox/tests/conftest.py
@@ -1063,7 +1063,7 @@ def configured_project_with_complex_ontology(client, initial_dataset, rand_gen,
     project.delete()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def embedding(client: Client):
     uuid_str = uuid.uuid4().hex
     embedding = client.create_embedding(f"sdk-int-{uuid_str}", 8)

--- a/libs/labelbox/tests/conftest.py
+++ b/libs/labelbox/tests/conftest.py
@@ -35,6 +35,8 @@ from labelbox.schema.invite import Invite
 from labelbox.schema.quality_mode import QualityMode
 from labelbox.schema.queue_mode import QueueMode
 from labelbox.schema.user import User
+from labelbox.exceptions import LabelboxError
+from contextlib import suppress
 from labelbox import Client
 
 IMG_URL = "https://picsum.photos/200/300.jpg"
@@ -1064,7 +1066,15 @@ def configured_project_with_complex_ontology(client, initial_dataset, rand_gen,
 
 
 @pytest.fixture(scope="session")
-def embedding(client: Client):
+def embedding(client: Client, environ):
+    
+    # Remove all embeddings on staging
+    if environ == Environ.STAGING:
+        embeddings = client.get_embeddings()
+        for embedding in embeddings:
+            with suppress(LabelboxError):
+                embedding.delete()
+
     uuid_str = uuid.uuid4().hex
     embedding = client.create_embedding(f"sdk-int-{uuid_str}", 8)
     yield embedding

--- a/libs/labelbox/tests/conftest.py
+++ b/libs/labelbox/tests/conftest.py
@@ -1067,18 +1067,18 @@ def configured_project_with_complex_ontology(client, initial_dataset, rand_gen,
 
 @pytest.fixture(scope="session")
 def embedding(client: Client, environ):
-    
+
+    uuid_str = uuid.uuid4().hex
+    embedding = client.create_embedding(f"sdk-int-{uuid_str}", 8)
+    yield embedding
     # Remove all embeddings on staging
     if environ == Environ.STAGING:
         embeddings = client.get_embeddings()
         for embedding in embeddings:
             with suppress(LabelboxError):
                 embedding.delete()
-
-    uuid_str = uuid.uuid4().hex
-    embedding = client.create_embedding(f"sdk-int-{uuid_str}", 8)
-    yield embedding
-    embedding.delete()
+    else:
+        embedding.delete()
 
 
 @pytest.fixture

--- a/libs/labelbox/tests/conftest.py
+++ b/libs/labelbox/tests/conftest.py
@@ -1063,7 +1063,7 @@ def configured_project_with_complex_ontology(client, initial_dataset, rand_gen,
     project.delete()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def embedding(client: Client):
     uuid_str = uuid.uuid4().hex
     embedding = client.create_embedding(f"sdk-int-{uuid_str}", 8)


### PR DESCRIPTION
# Description

Embedding fixtures keeps running into error were we hit max limit. Set up test to only use the same embedding instead of rapidly creating many

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

