### PR TITLE
[PLT-1347] Vb/request labelin service

### DIFF
--- a/libs/labelbox/src/labelbox/schema/labeling_service.py
+++ b/libs/labelbox/src/labelbox/schema/labeling_service.py
@@ -77,7 +77,8 @@ class LabelingService(BaseModel):
             }
         }
         """
-        result = self.client.execute(query_str, {"projectId": self.project_id})
+        result = self.client.execute(query_str, {"projectId": self.project_id},
+                                     raise_return_resource_not_found=True)
         success = result["validateAndRequestProjectBoostWorkforce"]["success"]
         if not success:
             raise Exception("Failed to start labeling service")

--- a/libs/labelbox/src/labelbox/schema/labeling_service.py
+++ b/libs/labelbox/src/labelbox/schema/labeling_service.py
@@ -61,12 +61,15 @@ class LabelingService(BaseModel):
 
     def request(self) -> 'LabelingService':
         """
-        Starts the labeling service for the project. This is equivalent to a UI action to Request Specialized Labelers
+        Creates a request to labeling service to start labeling for the project. 
+        Our back end will validate that the project is ready for labeling and then request the labeling service.
 
         Returns:
             LabelingService: The labeling service for the project.
         Raises:
-            Exception: If the service fails to start.
+            ResourceNotFoundError: If ontology is not associated with the project
+                or if any projects required prerequisites are missing.
+
         """
 
         query_str = """mutation ValidateAndRequestProjectBoostWorkforcePyApi($projectId: ID!) {

--- a/libs/labelbox/src/labelbox/schema/labeling_service.py
+++ b/libs/labelbox/src/labelbox/schema/labeling_service.py
@@ -10,12 +10,13 @@ from labelbox.utils import _CamelCaseMixin
 
 Cuid = Annotated[str, Field(min_length=25, max_length=25)]
 
+
 class LabelingServiceStatus(Enum):
-    Accepted = 'ACCEPTED',
-    Calibration = 'CALIBRATION',
-    Complete = 'COMPLETE',
-    Production = 'PRODUCTION',
-    Requested = 'REQUESTED',
+    Accepted = 'ACCEPTED'
+    Calibration = 'CALIBRATION'
+    Complete = 'COMPLETE'
+    Production = 'PRODUCTION'
+    Requested = 'REQUESTED'
     SetUp = 'SET_UP'
 
 
@@ -40,7 +41,7 @@ class LabelingService(BaseModel):
     @classmethod
     def start(cls, client, project_id: Cuid) -> 'LabelingService':
         """
-        Starts the labeling service for the project. This is equivalent to a UI acction to Request Specialized Labelers
+        Starts the labeling service for the project. This is equivalent to a UI action to Request Specialized Labelers
 
         Returns:
             LabelingService: The labeling service for the project.
@@ -57,6 +58,30 @@ class LabelingService(BaseModel):
         if not success:
             raise Exception("Failed to start labeling service")
         return cls.get(client, project_id)
+
+    def request(self) -> 'LabelingService':
+        """
+        Starts the labeling service for the project. This is equivalent to a UI action to Request Specialized Labelers
+
+        Returns:
+            LabelingService: The labeling service for the project.
+        Raises:
+            Exception: If the service fails to start.
+        """
+
+        query_str = """mutation ValidateAndRequestProjectBoostWorkforcePyApi($projectId: ID!) {
+            validateAndRequestProjectBoostWorkforce(
+                data: { projectId: $projectId }
+            ) {
+                success
+            }
+        }
+        """
+        result = self.client.execute(query_str, {"projectId": self.project_id})
+        success = result["validateAndRequestProjectBoostWorkforce"]["success"]
+        if not success:
+            raise Exception("Failed to start labeling service")
+        return LabelingService.get(self.client, self.project_id)
 
     @classmethod
     def get(cls, client, project_id: Cuid) -> 'LabelingService':

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -1949,15 +1949,6 @@ class Project(DbObject, Updateable, Deletable):
         """
         return LabelingService.start(self.client, self.uid)  # type: ignore
 
-    @experimental
-    def start_labeling_service(self) -> LabelingService:
-        """Submit a request to start the labeling service for this project.
-
-        Returns:
-            LabelingService: The labeling service for this project.
-        """
-        return LabelingService.start(self.client, self.uid)  # type: ignore
-
 
 class ProjectMember(DbObject):
     user = Relationship.ToOne("User", cache=True)

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -1949,6 +1949,15 @@ class Project(DbObject, Updateable, Deletable):
         """
         return LabelingService.start(self.client, self.uid)  # type: ignore
 
+    @experimental
+    def start_labeling_service(self) -> LabelingService:
+        """Submit a request to start the labeling service for this project.
+
+        Returns:
+            LabelingService: The labeling service for this project.
+        """
+        return LabelingService.start(self.client, self.uid)  # type: ignore
+
 
 class ProjectMember(DbObject):
     user = Relationship.ToOne("User", cache=True)

--- a/libs/labelbox/tests/conftest.py
+++ b/libs/labelbox/tests/conftest.py
@@ -130,8 +130,7 @@ def rest_url(environ: str) -> str:
 def testing_api_key(environ: Environ) -> str:
     keys = [
         f"LABELBOX_TEST_API_KEY_{environ.value.upper()}",
-        "LABELBOX_TEST_API_KEY",
-        "LABELBOX_API_KEY"
+        "LABELBOX_TEST_API_KEY", "LABELBOX_API_KEY"
     ]
     for key in keys:
         value = os.environ.get(key)
@@ -318,11 +317,7 @@ def environ() -> Environ:
     'prod' or 'staging'
     Make sure to set LABELBOX_TEST_ENVIRON in .github/workflows/python-package.yaml
     """
-    keys = [
-        "LABELBOX_TEST_ENV",
-        "LABELBOX_TEST_ENVIRON",
-        "LABELBOX_ENV"
-    ]
+    keys = ["LABELBOX_TEST_ENV", "LABELBOX_TEST_ENVIRON", "LABELBOX_ENV"]
     for key in keys:
         value = os.environ.get(key)
         if value is not None:
@@ -740,6 +735,23 @@ def configured_batch_project_with_multiple_datarows(project, dataset, data_rows,
 
     for label in project.labels():
         label.delete()
+
+
+@pytest.fixture
+def configured_batch_project_for_labeling_service(project,
+                                                  data_row_and_global_key):
+    """Project with a batch having multiple datarows
+    Project contains an ontology with 1 bbox tool
+    Additionally includes a create_label method for any needed extra labels
+    """
+    global_keys = [data_row_and_global_key[1]]
+
+    batch_name = f'batch {uuid.uuid4()}'
+    project.create_batch(batch_name, global_keys=global_keys)
+
+    _setup_ontology(project)
+
+    yield project
 
 
 # NOTE this is nice heuristics, also there is this logic _wait_until_data_rows_are_processed in Project

--- a/libs/labelbox/tests/integration/test_labeling_service.py
+++ b/libs/labelbox/tests/integration/test_labeling_service.py
@@ -1,6 +1,6 @@
 import pytest
 
-from labelbox.exceptions import ResourceNotFoundError
+from labelbox.exceptions import LabelboxError, ResourceNotFoundError
 from labelbox.schema.labeling_service import LabelingServiceStatus
 
 
@@ -23,3 +23,70 @@ def test_start_labeling_service(project):
 
     labeling_service_status = project.get_labeling_service_status()
     assert labeling_service_status == LabelingServiceStatus.SetUp
+
+
+def test_request_labeling_service(
+        configured_batch_project_for_labeling_service):
+    project = configured_batch_project_for_labeling_service
+
+    project.upsert_instructions('tests/integration/media/sample_pdf.pdf')
+
+    labeling_service = project.request_labeling_service(
+    )  # project fixture is an Image type project
+    labeling_service.request()
+    assert project.get_labeling_service_status(
+    ) == LabelingServiceStatus.Requested
+
+
+def test_request_labeling_service_moe_offline_project(
+        rand_gen, offline_chat_evaluation_project, chat_evaluation_ontology,
+        offline_conversational_data_row, model_config):
+    project = offline_chat_evaluation_project
+    project.connect_ontology(chat_evaluation_ontology)
+
+    project.create_batch(
+        rand_gen(str),
+        [offline_conversational_data_row.uid],  # sample of data row objects
+    )
+
+    project.upsert_instructions('tests/integration/media/sample_pdf.pdf')
+
+    labeling_service = project.request_labeling_service()
+    labeling_service.request()
+    assert project.get_labeling_service_status(
+    ) == LabelingServiceStatus.Requested
+
+
+def test_request_labeling_service_moe_project(
+        rand_gen, live_chat_evaluation_project_with_new_dataset,
+        chat_evaluation_ontology, model_config):
+    project = live_chat_evaluation_project_with_new_dataset
+    project.connect_ontology(chat_evaluation_ontology)
+
+    project.upsert_instructions('tests/integration/media/sample_pdf.pdf')
+
+    labeling_service = project.request_labeling_service()
+    with pytest.raises(
+            LabelboxError,
+            match=
+            '[{"errorType":"PROJECT_MODEL_CONFIG","errorMessage":"Project model config is not completed"}]'
+    ):
+        labeling_service.request()
+    project.add_model_config(model_config.uid)
+    project.set_project_model_setup_complete()
+
+    labeling_service.request()
+    assert project.get_labeling_service_status(
+    ) == LabelingServiceStatus.Requested
+
+
+def test_request_labeling_service_incomplete_requirements(project, ontology):
+    labeling_service = project.request_labeling_service(
+    )  # project fixture is an Image type project
+    with pytest.raises(ResourceNotFoundError,
+                       match="Associated ontology id could not be found"
+                      ):  # No labeling service by default
+        labeling_service.request()
+    project.connect_ontology(ontology)
+    with pytest.raises(LabelboxError):
+        labeling_service.request()


### PR DESCRIPTION
# Description

Provides an sdk method to request labeling service. This will match the UI transition when all project prerequisites are completed.

For sdk, we have built a new api on the backend to verify the project and transition labeling service to Requested

Sample code - live chat model evaluation project
```
client.create_model_evaluation_project(...)
project.connect_ontology(chat_evaluation_ontology)
project.upsert_instructions(...)

# if not live MOE, also need to add a batch of data rows

# Only for live MOE
project.add_model_config(...)
project.set_project_model_setup_complete()

labeling_service = project.request_labeling_service()
labeling_service.request()

assert project.get_labeling_service_status() == LabelingServiceStatus.Requested
```

NOTE

All integration tests for the new api `ValidateAndRequestProjectBoostWorkforcePyApi` will fail till we merge and deploy the api to stage (tonight or tomorrow)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [x] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [x] Have you added a Docstring?

## Changes to Core Features

- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
