### PR TITLE
Vb/remove ontology disconnect plt 1308

### DIFF
--- a/libs/labelbox/src/labelbox/exceptions.py
+++ b/libs/labelbox/src/labelbox/exceptions.py
@@ -44,7 +44,7 @@ class ResourceNotFoundError(LabelboxError):
             super().__init__(message)
         else:
             super().__init__("Resource '%s' not found for params: %r" %
-                                (db_object_type.type_name(), params))
+                             (db_object_type.type_name(), params))
             self.db_object_type = db_object_type
             self.params = params
 
@@ -141,6 +141,11 @@ class MALValidationError(LabelboxError):
 
 class OperationNotAllowedException(Exception):
     """Raised when user does not have permissions to a resource or has exceeded usage limit"""
+    pass
+
+
+class OperationNotSupportedException(Exception):
+    """Raised when sdk does not support requested operation"""
     pass
 
 

--- a/libs/labelbox/src/labelbox/orm/db_object.py
+++ b/libs/labelbox/src/labelbox/orm/db_object.py
@@ -192,10 +192,10 @@ class RelationshipManager:
         self.source.client.execute(query_string, params)
 
     def disconnect(self, other):
+        """ Disconnects source object of this manager from the `other` object. """
         if not self.config.disconnect_supported:
             raise OperationNotSupportedException(
                 "Disconnect is not supported for this relationship")
-        """ Disconnects source object of this manager from the `other` object. """
 
         query_string, params = query.update_relationship(
             self.source, other, self.relationship, "disconnect")

--- a/libs/labelbox/src/labelbox/orm/db_object.py
+++ b/libs/labelbox/src/labelbox/orm/db_object.py
@@ -1,10 +1,11 @@
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import wraps
 import logging
 import json
 
 from labelbox import utils
-from labelbox.exceptions import InvalidQueryError, InvalidAttributeError
+from labelbox.exceptions import InvalidQueryError, InvalidAttributeError, OperationNotSupportedException
 from labelbox.orm import query
 from labelbox.orm.model import Field, Relationship, Entity
 from labelbox.pagination import PaginatedCollection
@@ -123,6 +124,7 @@ class RelationshipManager:
         self.supports_sorting = True
         self.filter_on_id = True
         self.value = value
+        self.config = relationship.config
 
     def __call__(self, *args, **kwargs):
         """ Forwards the call to either `_to_many` or `_to_one` methods,
@@ -190,7 +192,11 @@ class RelationshipManager:
         self.source.client.execute(query_string, params)
 
     def disconnect(self, other):
+        if not self.config.disconnect_supported:
+            raise OperationNotSupportedException(
+                "Disconnect is not supported for this relationship")
         """ Disconnects source object of this manager from the `other` object. """
+
         query_string, params = query.update_relationship(
             self.source, other, self.relationship, "disconnect")
         self.source.client.execute(query_string, params)

--- a/libs/labelbox/src/labelbox/orm/model.py
+++ b/libs/labelbox/src/labelbox/orm/model.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Dict, List, Union, Any, Type, TYPE_CHECKING
 
@@ -219,6 +220,10 @@ class Relationship:
 
     """
 
+    @dataclass
+    class Config:
+        disconnect_supported: bool = True
+
     class Type(Enum):
         ToOne = auto()
         ToMany = auto()
@@ -238,12 +243,14 @@ class Relationship:
                  name=None,
                  graphql_name=None,
                  cache=False,
-                 deprecation_warning=None):
+                 deprecation_warning=None,
+                 config=Config()):
         self.relationship_type = relationship_type
         self.destination_type_name = destination_type_name
         self.filter_deleted = filter_deleted
         self.cache = cache
         self.deprecation_warning = deprecation_warning
+        self.config = config
 
         if name is None:
             name = utils.snake_case(destination_type_name) + (

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -132,7 +132,9 @@ class Project(DbObject, Updateable, Deletable):
     # Relationships
     created_by = Relationship.ToOne("User", False, "created_by")
     organization = Relationship.ToOne("Organization", False)
-    labeling_frontend = Relationship.ToOne("LabelingFrontend")
+    labeling_frontend = Relationship.ToOne(
+        "LabelingFrontend",
+        config=Relationship.Config(disconnect_supported=False))
     labeling_frontend_options = Relationship.ToMany(
         "LabelingFrontendOptions", False, "labeling_frontend_options")
     labeling_parameter_overrides = Relationship.ToMany(

--- a/libs/labelbox/tests/integration/test_labeling_frontend.py
+++ b/libs/labelbox/tests/integration/test_labeling_frontend.py
@@ -1,5 +1,7 @@
-from labelbox import LabelingFrontend
 import pytest
+
+from labelbox import LabelingFrontend
+from labelbox.exceptions import OperationNotSupportedException
 
 
 def test_get_labeling_frontends(client):
@@ -18,5 +20,5 @@ def test_labeling_frontend_connecting_to_project(project):
     project.labeling_frontend.connect(default_labeling_frontend)
     assert project.labeling_frontend() == default_labeling_frontend
 
-    project.labeling_frontend.disconnect(default_labeling_frontend)
-    assert project.labeling_frontend() == None
+    with pytest.raises(OperationNotSupportedException):
+        project.labeling_frontend.disconnect(default_labeling_frontend)


### PR DESCRIPTION
# Description

We now have only 1 labeling front end and an sdk user should not be allowed to disconnect from it, it will create issues for the project

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [x] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
