### PR TITLE
Add sleep to be able to test labeling service dashboard

### DIFF
--- a/libs/labelbox/tests/integration/test_labeling_dashboard.py
+++ b/libs/labelbox/tests/integration/test_labeling_dashboard.py
@@ -1,8 +1,11 @@
 from datetime import datetime, timedelta
+from time import sleep
 from labelbox.schema.labeling_service import LabelingServiceStatus
 from labelbox.schema.ontology_kind import EditorTaskType
 from labelbox.schema.media_type import MediaType
 from labelbox.schema.search_filters import IntegerValue, RangeDateTimeOperatorWithSingleValue, RangeOperatorWithSingleValue, DateRange, RangeOperatorWithValue, DateRangeValue, DateValue, IdOperator, OperationType, OrganizationFilter, TaskCompletedCountFilter, WorkforceRequestedDateFilter, WorkforceRequestedDateRangeFilter, WorkspaceFilter, TaskRemainingCountFilter
+
+ALLOW_TIME_TO_CREATE_DASHBOARD = 5  ## seconds
 
 
 def test_request_labeling_service_dashboard(requested_labeling_service):
@@ -10,12 +13,13 @@ def test_request_labeling_service_dashboard(requested_labeling_service):
 
     labeling_service_dashboard = project.get_labeling_service_dashboard()
     assert labeling_service_dashboard.status == LabelingServiceStatus.Requested
-    assert labeling_service_dashboard.tasks_completed == 0
-    assert labeling_service_dashboard.tasks_remaining == 0
+    assert labeling_service_dashboard.tasks_completed_count == 0
+    assert labeling_service_dashboard.tasks_remaining_count == 0
     assert labeling_service_dashboard.media_type == MediaType.Conversational
     assert labeling_service_dashboard.editor_task_type == EditorTaskType.ModelChatEvaluation
     assert labeling_service_dashboard.service_type == "Live chat evaluation"
 
+    sleep(ALLOW_TIME_TO_CREATE_DASHBOARD)
     labeling_service_dashboard = project.client.get_labeling_service_dashboards(
     ).get_one()
     assert labeling_service_dashboard
@@ -29,6 +33,7 @@ def test_request_labeling_service_dashboard_filters(requested_labeling_service):
                                     operator=IdOperator.Is,
                                     values=[organization.uid])
 
+    sleep(ALLOW_TIME_TO_CREATE_DASHBOARD)
     labeling_service_dashboard = project.client.get_labeling_service_dashboards(
         search_query=[org_filter]).get_one()
     assert labeling_service_dashboard is not None


### PR DESCRIPTION
# Description

Since creation of labeling dashboard in ES is totally asynch, the only way to test it at all is to add some sleep time 

In my observation 5s is enough for a labeling service to be created in ES and failure of this test would indicate either a coding or an environment or a performance issue

PS Did not see any other way to keep this test and prevent it from being 'flaky'

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [x] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
