### PR TITLE
Removed pydantic V2 protected messages to avoid unnecessary warnings to users

### DIFF
--- a/libs/labelbox/src/labelbox/data/annotation_types/data/raster.py
+++ b/libs/labelbox/src/labelbox/data/annotation_types/data/raster.py
@@ -24,7 +24,8 @@ class RasterData(BaseModel, ABC):
     uid: Optional[str] = None
     global_key: Optional[str] = None
     arr: Optional[TypedArray[Literal['uint8']]] = None
-    model_config = ConfigDict(extra="forbid", copy_on_model_validation="none")
+    
+    model_config = ConfigDict(extra="forbid")
 
     @classmethod
     def from_2D_arr(cls, arr: Union[TypedArray[Literal['uint8']],

--- a/libs/labelbox/src/labelbox/data/annotation_types/mmc.py
+++ b/libs/labelbox/src/labelbox/data/annotation_types/mmc.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import ClassVar, List, Union
 
-from pydantic import field_validator
+from pydantic import ConfigDict, field_validator
 
 from labelbox.utils import _CamelCaseMixin
 from labelbox.data.annotation_types.annotation import BaseAnnotation
@@ -10,6 +10,8 @@ from labelbox.data.annotation_types.annotation import BaseAnnotation
 class MessageInfo(_CamelCaseMixin):
     message_id: str
     model_config_name: str
+    
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class OrderedMessageInfo(MessageInfo):
@@ -19,6 +21,8 @@ class OrderedMessageInfo(MessageInfo):
 class _BaseMessageEvaluationTask(_CamelCaseMixin, ABC):
     format: ClassVar[str]
     parent_message_id: str
+    
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class MessageSingleSelectionTask(_BaseMessageEvaluationTask, MessageInfo):

--- a/libs/labelbox/src/labelbox/schema/foundry/app.py
+++ b/libs/labelbox/src/labelbox/schema/foundry/app.py
@@ -13,6 +13,8 @@ class App(_CamelCaseMixin):
     class_to_schema_id: Dict[str, str]
     ontology_id: str
     created_by: Optional[str] = None
+    
+    model_config = ConfigDict(protected_namespaces=())
 
     @classmethod
     def type_name(cls):


### PR DESCRIPTION
# Description

* If a Pydantic model has an attribute beginning with `model_`, it will spam the user with a protected message. You can avoid this message by inside the config dict https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.protected_namespaces
* Also copy_on_model_validation is removed as a option entirely in Pydantic V2 so removed this to avoid unnecessary warnings https://docs.pydantic.dev/latest/migration/#changes-to-config

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

