### PR TITLE
[PLT-1337] Added resource not found error handling to _create

### DIFF
--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -637,7 +637,7 @@ class Client:
 
         data = {**data, **extra_params}
         query_string, params = query.create(db_object_type, data)
-        res = self.execute(query_string, params)
+        res = self.execute(query_string, params, raise_return_resource_not_found=True)
 
         if not res:
             raise labelbox.exceptions.LabelboxError("Failed to create %s" %


### PR DESCRIPTION
# Description

* Adding this param to the execute makes it raise resource not found errors
* In the case were prompt creation and MMC projects are made with an invalid dataset_id this will give a better error
* This param was introduced very recently

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?
