### PR TITLE
[PLT-1339] Fixed Cuid dependencies that crash if numpy was not installed

### DIFF
--- a/libs/labelbox/src/labelbox/annotated_types.py
+++ b/libs/labelbox/src/labelbox/annotated_types.py
@@ -1,0 +1,6 @@
+from typing_extensions import Annotated
+
+from pydantic import Field
+
+
+Cuid = Annotated[str, Field(min_length=25, max_length=25)]

--- a/libs/labelbox/src/labelbox/data/annotation_types/feature.py
+++ b/libs/labelbox/src/labelbox/data/annotation_types/feature.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from pydantic import BaseModel, model_validator, model_serializer
-from .types import Cuid
+
+from ...annotated_types import Cuid
 
 
 class FeatureSchema(BaseModel):

--- a/libs/labelbox/src/labelbox/data/annotation_types/label.py
+++ b/libs/labelbox/src/labelbox/data/annotation_types/label.py
@@ -6,6 +6,8 @@ import labelbox
 from labelbox.data.annotation_types.data.generic_data_row_data import GenericDataRowData
 from labelbox.data.annotation_types.data.tiled_image import TiledImageData
 from labelbox.schema import ontology
+
+from ...annotated_types import Cuid
 from .annotation import ClassificationAnnotation, ObjectAnnotation
 from .relationship import RelationshipAnnotation
 from .llm_prompt_response.prompt import PromptClassificationAnnotation
@@ -13,7 +15,6 @@ from .classification import ClassificationAnswer
 from .data import AudioData, ConversationData, DicomData, DocumentData, HTMLData, ImageData, TextData, VideoData, LlmPromptCreationData, LlmPromptResponseCreationData, LlmResponseCreationData
 from .geometry import Mask
 from .metrics import ScalarMetric, ConfusionMatrixMetric
-from .types import Cuid
 from .video import VideoClassificationAnnotation
 from .video import VideoObjectAnnotation, VideoMaskAnnotation
 from .mmc import MessageEvaluationTaskAnnotation

--- a/libs/labelbox/src/labelbox/data/annotation_types/types.py
+++ b/libs/labelbox/src/labelbox/data/annotation_types/types.py
@@ -7,8 +7,6 @@ import numpy as np
 
 from pydantic import StringConstraints, Field
 
-Cuid = Annotated[str, StringConstraints(min_length=25, max_length=25)]
-
 DType = TypeVar('DType')
 DShape = TypeVar('DShape')
 

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/base.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/base.py
@@ -2,10 +2,11 @@ from typing import Optional
 from uuid import uuid4
 
 from labelbox.utils import _CamelCaseMixin, is_exactly_one_set
-from ...annotation_types.types import Cuid
 from pydantic import model_validator, ConfigDict, BaseModel, Field
 from uuid import uuid4
 import threading
+
+from ....annotated_types import Cuid
 
 subclass_registry = {}
 

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/classification.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/classification.py
@@ -19,11 +19,12 @@ class NDAnswer(ConfidenceMixin, CustomMetricsMixin):
     name: Optional[str] = None
     schema_id: Optional[Cuid] = None
     classifications: Optional[List['NDSubclassificationType']] = None
-    model_config = ConfigDict(populate_by_name = True, alias_generator = to_camel)
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
 
     @model_validator(mode="after")
     def must_set_one(self):
-        if (not hasattr(self, "schema_id") or self.schema_id is None) and (not hasattr(self, "name") or self.name is None):
+        if (not hasattr(self, "schema_id") or self.schema_id
+                is None) and (not hasattr(self, "name") or self.name is None):
             raise ValueError("Schema id or name are not set. Set either one.")
         return self
 
@@ -103,7 +104,10 @@ class NDChecklistSubclass(NDAnswer):
             NDAnswer(name=answer.name,
                      schema_id=answer.feature_schema_id,
                      confidence=answer.confidence,
-                     classifications=[NDSubclassification.from_common(annot) for annot in answer.classifications] if answer.classifications else None,
+                     classifications=[
+                         NDSubclassification.from_common(annot)
+                         for annot in answer.classifications
+                     ] if answer.classifications else None,
                      custom_metrics=answer.custom_metrics)
             for answer in checklist.answer
         ],
@@ -153,8 +157,8 @@ class NDPromptTextSubclass(NDAnswer):
 
     def to_common(self) -> PromptText:
         return PromptText(answer=self.answer,
-                    confidence=self.confidence,
-                    custom_metrics=self.custom_metrics)
+                          confidence=self.confidence,
+                          custom_metrics=self.custom_metrics)
 
     @classmethod
     def from_common(cls, prompt_text: PromptText, name: str,
@@ -195,7 +199,8 @@ class NDText(NDAnnotation, NDTextSubclass, _SubclassRegistryBase):
         )
 
 
-class NDChecklist(NDAnnotation, NDChecklistSubclass, VideoSupported, _SubclassRegistryBase):
+class NDChecklist(NDAnnotation, NDChecklistSubclass, VideoSupported,
+                  _SubclassRegistryBase):
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
@@ -238,7 +243,8 @@ class NDChecklist(NDAnnotation, NDChecklistSubclass, VideoSupported, _SubclassRe
                    confidence=confidence)
 
 
-class NDRadio(NDAnnotation, NDRadioSubclass, VideoSupported, _SubclassRegistryBase):
+class NDRadio(NDAnnotation, NDRadioSubclass, VideoSupported,
+              _SubclassRegistryBase):
 
     @classmethod
     def from_common(
@@ -267,35 +273,32 @@ class NDRadio(NDAnnotation, NDRadioSubclass, VideoSupported, _SubclassRegistryBa
                    frames=extra.get('frames'),
                    message_id=message_id,
                    confidence=confidence)
-        
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
         res = handler(self)
         if "classifications" in res and res["classifications"] == []:
             del res["classifications"]
         return res
-        
-        
+
+
 class NDPromptText(NDAnnotation, NDPromptTextSubclass, _SubclassRegistryBase):
-    
+
     @classmethod
-    def from_common(
-        cls,
-        uuid: str,
-        text: PromptText,
-        name,
-        data: Dict,
-        feature_schema_id: Cuid,
-        confidence: Optional[float] = None
-    ) -> "NDPromptText":
-        return cls(
-            answer=text.answer,
-            data_row=DataRow(id=data.uid, global_key=data.global_key),
-            name=name,
-            schema_id=feature_schema_id,
-            uuid=uuid,
-            confidence=text.confidence,
-            custom_metrics=text.custom_metrics)
+    def from_common(cls,
+                    uuid: str,
+                    text: PromptText,
+                    name,
+                    data: Dict,
+                    feature_schema_id: Cuid,
+                    confidence: Optional[float] = None) -> "NDPromptText":
+        return cls(answer=text.answer,
+                   data_row=DataRow(id=data.uid, global_key=data.global_key),
+                   name=name,
+                   schema_id=feature_schema_id,
+                   uuid=uuid,
+                   confidence=text.confidence,
+                   custom_metrics=text.custom_metrics)
 
 
 class NDSubclassification:
@@ -351,7 +354,8 @@ class NDClassification:
         for frame in annotation.frames:
             for idx in range(frame.start, frame.end + 1, 1):
                 results.append(
-                    VideoClassificationAnnotation(frame=idx, **common.model_dump(exclude_none=True)))
+                    VideoClassificationAnnotation(
+                        frame=idx, **common.model_dump(exclude_none=True)))
         return results
 
     @classmethod
@@ -383,6 +387,7 @@ class NDClassification:
             Radio: NDRadio
         }.get(type(annotation.value))
 
+
 class NDPromptClassification:
 
     @staticmethod
@@ -405,8 +410,7 @@ class NDPromptClassification:
         data: Union[VideoData, TextData, ImageData]
     ) -> Union[NDTextSubclass, NDChecklistSubclass, NDRadioSubclass]:
         return NDPromptText.from_common(str(annotation._uuid), annotation.value,
-                                        annotation.name,
-                                        data,
+                                        annotation.name, data,
                                         annotation.feature_schema_id,
                                         annotation.confidence)
 

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/classification.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/classification.py
@@ -3,12 +3,12 @@ from typing import Any, Dict, List, Union, Optional
 from labelbox.data.mixins import ConfidenceMixin, CustomMetric, CustomMetricsMixin
 from labelbox.data.serialization.ndjson.base import DataRow, NDAnnotation
 
+from ....annotated_types import Cuid
+
 from ...annotation_types.annotation import ClassificationAnnotation
 from ...annotation_types.video import VideoClassificationAnnotation
 from ...annotation_types.llm_prompt_response.prompt import PromptClassificationAnnotation, PromptText
 from ...annotation_types.classification.classification import ClassificationAnswer, Text, Checklist, Radio
-from ...annotation_types.types import Cuid
-from ...annotation_types.data import TextData, VideoData, ImageData
 from pydantic import model_validator, Field, BaseModel, ConfigDict, model_serializer
 from pydantic.alias_generators import to_camel
 from .base import _SubclassRegistryBase

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/classification.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/classification.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Union, Optional
 
+from labelbox.data.annotation_types import ImageData, TextData, VideoData
 from labelbox.data.mixins import ConfidenceMixin, CustomMetric, CustomMetricsMixin
 from labelbox.data.serialization.ndjson.base import DataRow, NDAnnotation
 

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/mmc.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/mmc.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Optional, Union
 from labelbox.utils import _CamelCaseMixin
 
 from .base import _SubclassRegistryBase, DataRow, NDAnnotation
-from ...annotation_types.types import Cuid
 from ...annotation_types.mmc import MessageSingleSelectionTask, MessageMultiSelectionTask, MessageRankingTask, MessageEvaluationTaskAnnotation
 
 

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/objects.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/objects.py
@@ -5,6 +5,7 @@ import base64
 from labelbox.data.annotation_types.ner.conversation_entity import ConversationEntity
 from labelbox.data.annotation_types.video import VideoObjectAnnotation, DICOMObjectAnnotation
 from labelbox.data.mixins import ConfidenceMixin, CustomMetricsMixin, CustomMetric, CustomMetricsNotSupportedMixin
+from ....annotated_types import Cuid
 import numpy as np
 
 from PIL import Image
@@ -14,7 +15,6 @@ from labelbox.data.annotation_types.data.video import VideoData
 
 from ...annotation_types.data import ImageData, TextData, MaskData
 from ...annotation_types.ner import DocumentEntity, DocumentTextSelection, TextEntity
-from ...annotation_types.types import Cuid
 from ...annotation_types.geometry import DocumentRectangle, Rectangle, Polygon, Line, Point, Mask
 from ...annotation_types.annotation import ClassificationAnnotation, ObjectAnnotation
 from ...annotation_types.video import VideoMaskAnnotation, DICOMMaskAnnotation, MaskFrame, MaskInstance

--- a/libs/labelbox/src/labelbox/schema/labeling_service.py
+++ b/libs/labelbox/src/labelbox/schema/labeling_service.py
@@ -2,14 +2,14 @@ from datetime import datetime
 from typing import Any
 from typing_extensions import Annotated
 
-from labelbox.exceptions import ResourceNotFoundError
-
 from pydantic import BaseModel, Field
+
+from labelbox.exceptions import ResourceNotFoundError
 from labelbox.utils import _CamelCaseMixin
 from labelbox.schema.labeling_service_dashboard import LabelingServiceDashboard
 from labelbox.schema.labeling_service_status import LabelingServiceStatus
 
-Cuid = Annotated[str, Field(min_length=25, max_length=25)]
+from ..annotated_types import Cuid
 
 
 class LabelingService(_CamelCaseMixin):


### PR DESCRIPTION
# Description

This addresses the issue when a class importing a `Cuid` type ended up dragging other classes that used numpy that is an optional package

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
