### PR TITLE
[PLT-1273] Removed setup_editor

### DIFF
--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -657,16 +657,6 @@ class Project(DbObject, Updateable, Deletable):
         res = self.client.execute(query_str, {id_param: self.uid})
         return res["project"]["reviewMetrics"]["labelAggregate"]["count"]
 
-    def setup_editor(self, ontology) -> None:
-        """
-        Sets up the project using the Pictor editor.
-
-        Args:
-            ontology (Ontology): The ontology to attach to the project
-        """
-        warnings.warn("This method is deprecated use connect_ontology instead.")
-        self.connect_ontology(ontology)
-
     def connect_ontology(self, ontology) -> None:
         """
         Connects the ontology to the project. If an editor is not setup, it will be connected as well.

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -661,7 +661,7 @@ class Project(DbObject, Updateable, Deletable):
         """
         Connects the ontology to the project. If an editor is not setup, it will be connected as well.
 
-        Note: For live chat model evaluation projects, the editor setup is skipped becase it is automatically setup when the project is created.
+        Note: For live chat model evaluation projects, the editor setup is skipped because it is automatically setup when the project is created.
 
         Args:
             ontology (Ontology): The ontology to attach to the project

--- a/libs/labelbox/tests/unit/test_project.py
+++ b/libs/labelbox/tests/unit/test_project.py
@@ -72,13 +72,3 @@ def test_project_editor_task_type(
     )
 
     assert project.editor_task_type == expected_editor_task_type
-
-
-def test_setup_editor_using_connect_ontology(project_entity):
-    project = project_entity
-    ontology = MagicMock()
-    project.connect_ontology = MagicMock()
-    with patch("warnings.warn") as warn:
-        project.setup_editor(ontology)
-        warn.assert_called_once()
-        project.connect_ontology.assert_called_once_with(ontology)


### PR DESCRIPTION
# Description

* No tests use `setup_editor` on a follow up ticket Ill remove `setup` which is way more indepth
