### PR TITLE
[PLT-1584] Removed remaining deprecated messages from tests

### DIFF
--- a/libs/labelbox/tests/data/test_data_row_metadata.py
+++ b/libs/labelbox/tests/data/test_data_row_metadata.py
@@ -79,7 +79,7 @@ def make_metadata(dr_id: str = None, gk: str = None) -> DataRowMetadata:
 
 def make_named_metadata(dr_id) -> DataRowMetadata:
     msg = "A message"
-    time = datetime.utcnow()
+    time = datetime.now(timezone.utc)
 
     metadata = DataRowMetadata(
         data_row_id=dr_id,

--- a/libs/labelbox/tests/integration/test_dates.py
+++ b/libs/labelbox/tests/integration/test_dates.py
@@ -22,6 +22,8 @@ def test_utc_conversion(project):
 
     # Update with a datetime with TZ info
     tz = timezone(timedelta(hours=6))  # +6 timezone
-    project.update(setup_complete=datetime.utcnow().replace(tzinfo=tz))
-    diff = datetime.utcnow() - project.setup_complete.replace(tzinfo=None)
+    project.update(setup_complete=datetime.now(timezone.utc).replace(tzinfo=tz))
+    diff = datetime.now(timezone.utc) - project.setup_complete.replace(
+        tzinfo=None
+    )
     assert diff > timedelta(hours=5, minutes=58)


### PR DESCRIPTION
# Description

Remove remaining deprecated methods shown in tests i.e. datetime.utcnow
