### PR TITLE
[PLT-1580] Cleaned up typed array

### DIFF
--- a/libs/labelbox/pyproject.toml
+++ b/libs/labelbox/pyproject.toml
@@ -46,7 +46,6 @@ Changelog = "https://github.com/Labelbox/labelbox-python/blob/develop/libs/label
 [project.optional-dependencies]
 data = [
     "shapely>=2.0.3",
-    # numpy v2 breaks package since it only supports python >3.9
     "numpy>=1.25.0",
     "pillow>=10.2.0",
     "typeguard>=4.1.5",

--- a/libs/labelbox/pyproject.toml
+++ b/libs/labelbox/pyproject.toml
@@ -47,7 +47,7 @@ Changelog = "https://github.com/Labelbox/labelbox-python/blob/develop/libs/label
 data = [
     "shapely>=2.0.3",
     # numpy v2 breaks package since it only supports python >3.9
-    "numpy>=1.24.4, <2.0.0",
+    "numpy>=1.25.0",
     "pillow>=10.2.0",
     "typeguard>=4.1.5",
     "imagesize>=1.4.1",
@@ -95,7 +95,7 @@ integration = { cmd = "pytest tests/integration" }
 data = { cmd = "pytest tests/data" }
 rye-lint = "rye lint"
 rye-fmt-check = "rye fmt --check"
-MYPYPATH="../lbox-clients/src/"
+MYPYPATH = "../lbox-clients/src/"
 mypy-lint = "mypy src --pretty --show-error-codes --non-interactive --install-types"
 lint = { chain = ["rye-fmt-check", "mypy-lint", "rye-lint"] }
 test = { chain = ["lint", "unit", "integration"] }

--- a/libs/labelbox/src/labelbox/data/annotation_types/types.py
+++ b/libs/labelbox/src/labelbox/data/annotation_types/types.py
@@ -1,16 +1,12 @@
-import sys
-from typing import Annotated, Any, Generic, TypeVar
-
+from typing import Generic, TypeVar
 import numpy as np
-from packaging import version
-from pydantic import ConfigDict, Field, StringConstraints
 from pydantic_core import core_schema
 
 DType = TypeVar("DType")
 DShape = TypeVar("DShape")
 
 
-class _TypedArray(np.ndarray, Generic[DType, DShape]):
+class TypedArray(np.ndarray, Generic[DType, DShape]):
     @classmethod
     def __get_pydantic_core_schema__(
         cls, _source_type: type, _model: type
@@ -22,23 +18,3 @@ class _TypedArray(np.ndarray, Generic[DType, DShape]):
         if not isinstance(val, np.ndarray):
             raise TypeError(f"Expected numpy array. Found {type(val)}")
         return val
-
-
-if version.parse(np.__version__) >= version.parse("1.25.0"):
-    from typing import GenericAlias
-
-    TypedArray = GenericAlias(_TypedArray, (Any, DType))
-elif version.parse(np.__version__) >= version.parse("1.23.0"):
-    from numpy._typing import _GenericAlias
-
-    TypedArray = _GenericAlias(_TypedArray, (Any, DType))
-elif (
-    version.parse("1.22.0")
-    <= version.parse(np.__version__)
-    < version.parse("1.23.0")
-):
-    from numpy.typing import _GenericAlias
-
-    TypedArray = _GenericAlias(_TypedArray, (Any, DType))
-else:
-    TypedArray = _TypedArray[Any, DType]


### PR DESCRIPTION
# Description

* Support Numpy 2.0 now that we are not supporting 3.8
* limit Numpy to over 1.25, which came out over a year ago, and we only supported 1.24.4> anyways
* allows us to clean up a messy class that does not behave well with editors
