### PR TITLE
[PLT-1581] Limiting labeling front end visibility and mentions of a custom editor

### DIFF
--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -425,17 +425,8 @@ class Client:
         """
         return self._get_all(Entity.Dataset, where)
 
-    def get_labeling_frontends(self, where=None) -> List[LabelingFrontend]:
-        """Fetches all the labeling frontends.
-
-        >>> frontend = client.get_labeling_frontends(where=LabelingFrontend.name == "Editor")
-
-        Args:
-            where (Comparison, LogicalOperation or None): The `where` clause
-                for filtering.
-        Returns:
-            An iterable of LabelingFrontends (typically a PaginatedCollection).
-        """
+    def _get_labeling_frontends(self, where=None) -> List[LabelingFrontend]:
+        """Private method to obtain labeling front ends"""
         return self._get_all(Entity.LabelingFrontend, where)
 
     def _create(self, db_object_type, data, extra_params={}):

--- a/libs/labelbox/src/labelbox/schema/labeling_frontend.py
+++ b/libs/labelbox/src/labelbox/schema/labeling_frontend.py
@@ -3,19 +3,7 @@ from labelbox.orm.model import Field, Relationship
 
 
 class LabelingFrontend(DbObject):
-    """Label editor.
-
-    Represents an HTML / JavaScript UI that is used to generate
-    labels. “Editor” is the default Labeling Frontend that comes in every
-    organization. You can create new labeling frontends for an organization.
-
-    Attributes:
-        name (str)
-        description (str)
-        iframe_url_path (str)
-
-        projects (Relationship): `ToMany` relationship to Project
-    """
+    """Private db object representing a projects label editor"""
 
     name = Field.String("name")
     description = Field.String("description")

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -692,7 +692,7 @@ class Project(DbObject, Updateable, Deletable):
         ):  # Chat evaluation projects are automatically set up via the same api that creates a project
             warnings.warn("Connecting default labeling editor for the project.")
             labeling_frontend = next(
-                self.client.get_labeling_frontends(
+                self.client._get_labeling_frontends(
                     where=Entity.LabelingFrontend.name == "Editor"
                 )
             )

--- a/libs/labelbox/tests/integration/test_labeling_frontend.py
+++ b/libs/labelbox/tests/integration/test_labeling_frontend.py
@@ -6,7 +6,7 @@ from labelbox import LabelingFrontend
 
 def test_get_labeling_frontends(client):
     filtered_frontends = list(
-        client.get_labeling_frontends(where=LabelingFrontend.name == "Editor")
+        client._get_labeling_frontends(where=LabelingFrontend.name == "Editor")
     )
     assert len(filtered_frontends)
 
@@ -14,7 +14,7 @@ def test_get_labeling_frontends(client):
 def test_labeling_frontend_connecting_to_project(project):
     client = project.client
     default_labeling_frontend = next(
-        client.get_labeling_frontends(where=LabelingFrontend.name == "Editor")
+        client._get_labeling_frontends(where=LabelingFrontend.name == "Editor")
     )
 
     assert project.labeling_frontend() is None


### PR DESCRIPTION
# Description

* This is something that was mention before but our SDK should not mention custom editor since it was removed. 
* This parameter has to stay since our API requires it be set on project creation or it will break backwards compat
* More of a document change, but I privatize `_get_labeling_frontend` since users should not use that function directly. 
