### PR TITLE
[PLT-1691] Simplify get_label_filter_order test

### DIFF
--- a/libs/labelbox/tests/integration/test_label.py
+++ b/libs/labelbox/tests/integration/test_label.py
@@ -44,16 +44,12 @@ def test_label_update(configured_project_with_label):
 def test_label_filter_order(configured_project_with_label, label_helpers):
     project, _, _, label = configured_project_with_label
 
-    l1 = label
     project.create_label()
     label_helpers.wait_for_labels(project, 2)
 
-    l2 = next(project.labels())
-
-    assert set(project.labels()) == {l1, l2}
-
-    assert list(project.labels(order_by=Label.created_at.asc)) == [l1, l2]
-    assert list(project.labels(order_by=Label.created_at.desc)) == [l2, l1]
+    list_asc = list(project.labels(order_by=Label.created_at.asc))
+    list_desc = list(project.labels(order_by=Label.created_at.desc))
+    assert list_asc == list_desc[::-1]
 
 
 def test_label_bulk_deletion(configured_project_with_label):


### PR DESCRIPTION
# Description

The `test_label_filter_order` test fails consistently on prod for some but not all runs. See [here](https://github.com/Labelbox/labelbox-python/actions/runs/11600088220) as an example. I have simplified the test to make sure it will be less subjected to timing / concurrency

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
