### PR TITLE
Fix get_roles return type: Dict[str, Role] (instead of List[Role])

### DIFF
--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -860,7 +860,7 @@ class Client:
         extra_params = {k: v for k, v in extra_params.items() if v is not None}
         return self._create(Entity.Project, params, extra_params)
 
-    def get_roles(self) -> List[Role]:
+    def get_roles(self) -> Dict[str, Role]:
         """
         Returns:
             Roles: Provides information on available roles within an organization.


### PR DESCRIPTION
# Description

The get_roles method in the Client class (in the libs/labelbox/src/labelbox/client.py file) returns the roles from the get_roles function in the libs/labelbox/src/labelbox/schema/role.py file. This function has return type Dict[str, "Role"], while the method in the Client class has return type List[Role]. This pull request proposes to change the return type of the Client.get_roles method to Dict[str, Role].

## Type of change

Bug fix (non-breaking change which fixes an issue).