### PR TITLE
[PTDT-0] Update tests to contain classifications field for TextAnswer

### DIFF
--- a/libs/labelbox/tests/data/annotation_import/conftest.py
+++ b/libs/labelbox/tests/data/annotation_import/conftest.py
@@ -2313,10 +2313,12 @@ def expected_export_v2_document():
                     "left": 58.0,
                     "height": 65.0,
                     "width": 12.0,
+                    "unit": "points",
                 },
                 "page_dimensions": {
                     "height": 792.0,
                     "width": 612.0,
+                    "unit": "points",
                 },
             },
         ],

--- a/libs/labelbox/tests/data/annotation_import/conftest.py
+++ b/libs/labelbox/tests/data/annotation_import/conftest.py
@@ -2073,7 +2073,7 @@ def expected_export_v2_image():
                 "value": "text",
                 "text_answer": {
                     "content": "free form text...",
-                    "classifications": []
+                    "classifications": [],
                 },
             },
         ],
@@ -2108,7 +2108,7 @@ def expected_export_v2_audio():
                 "value": "text",
                 "text_answer": {
                     "content": "free form text...",
-                    "classifications": []
+                    "classifications": [],
                 },
             },
         ],
@@ -2128,7 +2128,7 @@ def expected_export_v2_html():
                 "value": "text",
                 "text_answer": {
                     "content": "free form text...",
-                    "classifications": []
+                    "classifications": [],
                 },
             },
             {
@@ -2191,7 +2191,7 @@ def expected_export_v2_text():
                 "value": "text",
                 "text_answer": {
                     "content": "free form text...",
-                    "classifications": []
+                    "classifications": [],
                 },
             },
         ],
@@ -2344,37 +2344,7 @@ def expected_export_v2_document():
                 "value": "text",
                 "text_answer": {
                     "content": "free form text...",
-                    "classifications": []
-                },
-            },
-        ],
-        "relationships": [],
-    }
-    return expected_annotations
-
-
-@pytest.fixture()
-def expected_export_v2_llm_prompt_creation():
-    expected_annotations = {
-        "objects": [],
-        "classifications": [
-            {
-                "name":
-                    "checklist",
-                "value":
-                    "checklist",
-                "checklist_answers": [{
-                    "name": "option1",
-                    "value": "option1",
-                    "classifications": []
-                }],
-            },
-            {
-                "name": "text",
-                "value": "text",
-                "text_answer": {
-                    "content": "free form text...",
-                    "classifications": []
+                    "classifications": [],
                 },
             },
         ],
@@ -2393,14 +2363,14 @@ def expected_export_v2_llm_prompt_response_creation():
                 "value": "prompt-text",
                 "text_answer": {
                     "content": "free form text...",
-                    "classifications": []
+                    "classifications": [],
                 },
             },
             {
                 "name": "response-text",
                 "text_answer": {
                     "content": "free form text...",
-                    "classifications": []
+                    "classifications": [],
                 },
                 "value": "response-text",
             },
@@ -2445,7 +2415,7 @@ def expected_export_v2_llm_prompt_creation():
                 "value": "prompt-text",
                 "text_answer": {
                     "content": "free form text...",
-                    "classifications": []
+                    "classifications": [],
                 },
             },
         ],
@@ -2464,7 +2434,7 @@ def expected_export_v2_llm_response_creation():
                 "name": "response-text",
                 "text_answer": {
                     "content": "free form text...",
-                    "classifications": []
+                    "classifications": [],
                 },
                 "value": "response-text",
             },
@@ -2579,7 +2549,7 @@ def expected_exports_v2_mmc(mmc_example_data_row_message_ids):
                 "value": "text",
                 "text_answer": {
                     "content": "free form text...",
-                    "classifications": []
+                    "classifications": [],
                 },
             },
             {

--- a/libs/labelbox/tests/data/annotation_import/conftest.py
+++ b/libs/labelbox/tests/data/annotation_import/conftest.py
@@ -2071,7 +2071,10 @@ def expected_export_v2_image():
             {
                 "name": "text",
                 "value": "text",
-                "text_answer": {"content": "free form text..."},
+                "text_answer": {
+                    "content": "free form text...",
+                    "classifications": []
+                },
             },
         ],
         "relationships": [],
@@ -2103,7 +2106,10 @@ def expected_export_v2_audio():
             {
                 "name": "text",
                 "value": "text",
-                "text_answer": {"content": "free form text..."},
+                "text_answer": {
+                    "content": "free form text...",
+                    "classifications": []
+                },
             },
         ],
         "segments": {},
@@ -2120,7 +2126,10 @@ def expected_export_v2_html():
             {
                 "name": "text",
                 "value": "text",
-                "text_answer": {"content": "free form text..."},
+                "text_answer": {
+                    "content": "free form text...",
+                    "classifications": []
+                },
             },
             {
                 "name": "checklist",
@@ -2180,7 +2189,10 @@ def expected_export_v2_text():
             {
                 "name": "text",
                 "value": "text",
-                "text_answer": {"content": "free form text..."},
+                "text_answer": {
+                    "content": "free form text...",
+                    "classifications": []
+                },
             },
         ],
         "relationships": [],
@@ -2328,7 +2340,40 @@ def expected_export_v2_document():
             {
                 "name": "text",
                 "value": "text",
-                "text_answer": {"content": "free form text..."},
+                "text_answer": {
+                    "content": "free form text...",
+                    "classifications": []
+                },
+            },
+        ],
+        "relationships": [],
+    }
+    return expected_annotations
+
+
+@pytest.fixture()
+def expected_export_v2_llm_prompt_creation():
+    expected_annotations = {
+        "objects": [],
+        "classifications": [
+            {
+                "name":
+                    "checklist",
+                "value":
+                    "checklist",
+                "checklist_answers": [{
+                    "name": "option1",
+                    "value": "option1",
+                    "classifications": []
+                }],
+            },
+            {
+                "name": "text",
+                "value": "text",
+                "text_answer": {
+                    "content": "free form text...",
+                    "classifications": []
+                },
             },
         ],
         "relationships": [],
@@ -2344,11 +2389,17 @@ def expected_export_v2_llm_prompt_response_creation():
             {
                 "name": "prompt-text",
                 "value": "prompt-text",
-                "text_answer": {"content": "free form text..."},
+                "text_answer": {
+                    "content": "free form text...",
+                    "classifications": []
+                },
             },
             {
                 "name": "response-text",
-                "text_answer": {"content": "free form text..."},
+                "text_answer": {
+                    "content": "free form text...",
+                    "classifications": []
+                },
                 "value": "response-text",
             },
             {
@@ -2390,7 +2441,10 @@ def expected_export_v2_llm_prompt_creation():
             {
                 "name": "prompt-text",
                 "value": "prompt-text",
-                "text_answer": {"content": "free form text..."},
+                "text_answer": {
+                    "content": "free form text...",
+                    "classifications": []
+                },
             },
         ],
         "relationships": [],
@@ -2406,7 +2460,10 @@ def expected_export_v2_llm_response_creation():
         "classifications": [
             {
                 "name": "response-text",
-                "text_answer": {"content": "free form text..."},
+                "text_answer": {
+                    "content": "free form text...",
+                    "classifications": []
+                },
                 "value": "response-text",
             },
             {
@@ -2518,7 +2575,10 @@ def expected_exports_v2_mmc(mmc_example_data_row_message_ids):
             {
                 "name": "text",
                 "value": "text",
-                "text_answer": {"content": "free form text..."},
+                "text_answer": {
+                    "content": "free form text...",
+                    "classifications": []
+                },
             },
             {
                 "name": "radio_index",


### PR DESCRIPTION
# Description

Since new version of the exporter returns `classifications` field for the text classifications(in order to support subclassifications for text classification), tests needed to be updated accordingly.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
