### PR TITLE
[PLT-1913] Deprecated get_data_row_ids

### DIFF
--- a/libs/labelbox/src/labelbox/schema/slice.py
+++ b/libs/labelbox/src/labelbox/schema/slice.py
@@ -258,6 +258,13 @@ class ModelSlice(Slice):
         Returns:
             A PaginatedCollection of data row ids
         """
+
+        warnings.warn(
+            "The method get_data_row_ids for ModelSlice is deprecated and will be removed in the next major release. Use the get_data_row_identifiers method instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         return PaginatedCollection(
             client=self.client,
             query=ModelSlice.query_str(),


### PR DESCRIPTION
# Description

* Deprecated get_data_row_ids users should use get_data_row_identifiers

## Type of change

Please delete options that are not relevant.

- [x] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?
