### PR TITLE
[PLT-2228] Move to task queue task id to be optional with default as None for better type support

### DIFF
--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -1403,7 +1403,7 @@ class Project(DbObject, Updateable, Deletable):
         ]
 
     def move_data_rows_to_task_queue(
-        self, data_row_ids: DataRowIdentifiers, task_queue_id: str
+        self, data_row_ids: DataRowIdentifiers, task_queue_id: Optional[str] = None
     ):
         """
 

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -1405,7 +1405,7 @@ class Project(DbObject, Updateable, Deletable):
     def move_data_rows_to_task_queue(
         self,
         data_row_ids: DataRowIdentifiers,
-        task_queue_id: Union[str, None],
+        task_queue_id: Optional[str] = None,
     ):
         """
 
@@ -1414,7 +1414,7 @@ class Project(DbObject, Updateable, Deletable):
         Args:
             data_row_ids: a list of data row ids to be moved. This should be a DataRowIdentifiers object
                 DataRowIdentifier objects are lists of ids or global keys. A DataIdentifier object can be a UniqueIds or GlobalKeys class.
-            task_queue_id: the task queue id to be moved to, or None to specify the "Done" queue
+            task_queue_id: the task queue id to be moved to, or None to specify the "Done" queue. Defaults to None.
 
         Returns:
             None if successful, or a raised error on failure

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -1403,7 +1403,9 @@ class Project(DbObject, Updateable, Deletable):
         ]
 
     def move_data_rows_to_task_queue(
-        self, data_row_ids: DataRowIdentifiers, task_queue_id: Optional[str] = None
+        self,
+        data_row_ids: DataRowIdentifiers,
+        task_queue_id: Optional[str] = None,
     ):
         """
 

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -1405,7 +1405,7 @@ class Project(DbObject, Updateable, Deletable):
     def move_data_rows_to_task_queue(
         self,
         data_row_ids: DataRowIdentifiers,
-        task_queue_id: Optional[str] = None,
+        task_queue_id: Union[str, None],
     ):
         """
 


### PR DESCRIPTION
# Description

* Switched type of task_queu_id to be optional with default of None which is a valid value.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?