### PR TITLE
[PTDT-2854] MAL and GT support for pdf relationships

### DIFF
--- a/libs/labelbox/src/labelbox/data/annotation_types/relationship.py
+++ b/libs/labelbox/src/labelbox/data/annotation_types/relationship.py
@@ -1,8 +1,10 @@
+from typing import Union
 from pydantic import BaseModel
 from enum import Enum
 from labelbox.data.annotation_types.annotation import (
     BaseAnnotation,
     ObjectAnnotation,
+    ClassificationAnnotation,
 )
 
 
@@ -11,7 +13,7 @@ class Relationship(BaseModel):
         UNIDIRECTIONAL = "unidirectional"
         BIDIRECTIONAL = "bidirectional"
 
-    source: ObjectAnnotation
+    source: Union[ObjectAnnotation, ClassificationAnnotation]
     target: ObjectAnnotation
     type: Type = Type.UNIDIRECTIONAL
 

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
@@ -194,7 +194,7 @@ class NDLabel(BaseModel):
     def _create_relationship_annotations(
         cls, label: Label
     ) -> Generator[NDRelationship, None, None]:
-        """Creates relationship annotations following validation rules for source and target types.
+        """Creates relationship annotations.
 
         Args:
             label: Label containing relationship annotations to be processed

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
@@ -188,6 +188,20 @@ class NDLabel(BaseModel):
     def _create_relationship_annotations(
         cls, label: Label
     ) -> Generator[NDRelationship, None, None]:
+        """Creates relationship annotations following validation rules for source and target types.
+
+        Args:
+            label: Label containing relationship annotations to be processed
+
+        Yields:
+            NDRelationship: Validated relationship annotations in NDJSON format
+
+        Raises:
+            TypeError: If source/target types violate the validation rules:
+                - Invalid source type for PDF target
+                - Non-ObjectAnnotation source for non-PDF target
+                - Non-ObjectAnnotation target
+        """
         for annotation in label.annotations:
             if isinstance(annotation, RelationshipAnnotation):
                 uuid1 = uuid4()

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
@@ -233,6 +233,7 @@ class NDLabel(BaseModel):
                         f"Unable to create relationship with non ObjectAnnotation source: {type(source)}"
                     )
 
+                # Check if target type is valid
                 if not isinstance(target, ObjectAnnotation):
                     raise TypeError(
                         f"Unable to create relationship with non ObjectAnnotation target: {type(target)}"

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
@@ -62,7 +62,9 @@ class NDLabel(BaseModel):
     annotations: AnnotationType
 
     @classmethod
-    def from_common(cls, data: LabelCollection) -> Generator["NDLabel", None, None]:
+    def from_common(
+        cls, data: LabelCollection
+    ) -> Generator["NDLabel", None, None]:
         for label in data:
             yield from cls._create_relationship_annotations(label)
             yield from cls._create_non_video_annotations(label)
@@ -126,12 +128,16 @@ class NDLabel(BaseModel):
             if isinstance(
                 annot, (VideoClassificationAnnotation, VideoObjectAnnotation)
             ):
-                video_annotations[annot.feature_schema_id or annot.name].append(annot)
+                video_annotations[annot.feature_schema_id or annot.name].append(
+                    annot
+                )
             elif isinstance(annot, VideoMaskAnnotation):
                 yield NDObject.from_common(annotation=annot, data=label.data)
 
         for annotation_group in video_annotations.values():
-            segment_frame_ranges = cls._get_segment_frame_ranges(annotation_group)
+            segment_frame_ranges = cls._get_segment_frame_ranges(
+                annotation_group
+            )
             if isinstance(annotation_group[0], VideoClassificationAnnotation):
                 annotation = annotation_group[0]
                 frames_data = []
@@ -197,10 +203,12 @@ class NDLabel(BaseModel):
             NDRelationship: Validated relationship annotations in NDJSON format
 
         Raises:
-            TypeError: If source/target types violate the validation rules:
-                - Invalid source type for PDF target
-                - Non-ObjectAnnotation source for non-PDF target
-                - Non-ObjectAnnotation target
+            TypeError: If source/target types are invalid:
+                - Source:
+                    - For PDF target annotations (DocumentRectangle, DocumentEntity): source must be ObjectAnnotation or ClassificationAnnotation
+                    - For other target annotations: source must be ObjectAnnotation
+                - Target:
+                    - Target must always be ObjectAnnotation
         """
         for annotation in label.annotations:
             if isinstance(annotation, RelationshipAnnotation):
@@ -210,7 +218,9 @@ class NDLabel(BaseModel):
                 target = copy.copy(annotation.value.target)
 
                 # Check if source type is valid based on target type
-                if isinstance(target.value, (DocumentRectangle, DocumentEntity)):
+                if isinstance(
+                    target.value, (DocumentRectangle, DocumentEntity)
+                ):
                     if not isinstance(
                         source, (ObjectAnnotation, ClassificationAnnotation)
                     ):

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 import copy
 from itertools import groupby
 from operator import itemgetter
-from typing import Generator, List, Tuple, Union
+from typing import Generator, List, Tuple, Union, Iterator, Dict
 from uuid import uuid4
 
 from pydantic import BaseModel
@@ -24,6 +24,7 @@ from ...annotation_types.video import (
     VideoMaskAnnotation,
     VideoObjectAnnotation,
 )
+from labelbox.types import DocumentRectangle, DocumentEntity
 from .classification import (
     NDChecklistSubclass,
     NDClassification,
@@ -61,9 +62,7 @@ class NDLabel(BaseModel):
     annotations: AnnotationType
 
     @classmethod
-    def from_common(
-        cls, data: LabelCollection
-    ) -> Generator["NDLabel", None, None]:
+    def from_common(cls, data: LabelCollection) -> Generator["NDLabel", None, None]:
         for label in data:
             yield from cls._create_relationship_annotations(label)
             yield from cls._create_non_video_annotations(label)
@@ -127,16 +126,12 @@ class NDLabel(BaseModel):
             if isinstance(
                 annot, (VideoClassificationAnnotation, VideoObjectAnnotation)
             ):
-                video_annotations[annot.feature_schema_id or annot.name].append(
-                    annot
-                )
+                video_annotations[annot.feature_schema_id or annot.name].append(annot)
             elif isinstance(annot, VideoMaskAnnotation):
                 yield NDObject.from_common(annotation=annot, data=label.data)
 
         for annotation_group in video_annotations.values():
-            segment_frame_ranges = cls._get_segment_frame_ranges(
-                annotation_group
-            )
+            segment_frame_ranges = cls._get_segment_frame_ranges(annotation_group)
             if isinstance(annotation_group[0], VideoClassificationAnnotation):
                 annotation = annotation_group[0]
                 frames_data = []
@@ -169,6 +164,7 @@ class NDLabel(BaseModel):
                     VideoClassificationAnnotation,
                     VideoObjectAnnotation,
                     VideoMaskAnnotation,
+                    RelationshipAnnotation,
                 ),
             )
         ]
@@ -179,8 +175,6 @@ class NDLabel(BaseModel):
                 yield NDObject.from_common(annotation, label.data)
             elif isinstance(annotation, (ScalarMetric, ConfusionMatrixMetric)):
                 yield NDMetricAnnotation.from_common(annotation, label.data)
-            elif isinstance(annotation, RelationshipAnnotation):
-                yield NDRelationship.from_common(annotation, label.data)
             elif isinstance(annotation, PromptClassificationAnnotation):
                 yield NDPromptClassification.from_common(annotation, label.data)
             elif isinstance(annotation, MessageEvaluationTaskAnnotation):
@@ -191,19 +185,35 @@ class NDLabel(BaseModel):
                 )
 
     @classmethod
-    def _create_relationship_annotations(cls, label: Label):
+    def _create_relationship_annotations(
+        cls, label: Label
+    ) -> Generator[NDRelationship, None, None]:
         for annotation in label.annotations:
             if isinstance(annotation, RelationshipAnnotation):
                 uuid1 = uuid4()
                 uuid2 = uuid4()
                 source = copy.copy(annotation.value.source)
                 target = copy.copy(annotation.value.target)
-                if not isinstance(source, ObjectAnnotation) or not isinstance(
-                    target, ObjectAnnotation
-                ):
+
+                # Check if source type is valid based on target type
+                if isinstance(target.value, (DocumentRectangle, DocumentEntity)):
+                    if not isinstance(
+                        source, (ObjectAnnotation, ClassificationAnnotation)
+                    ):
+                        raise TypeError(
+                            f"Unable to create relationship with invalid source. For PDF targets, "
+                            f"source must be ObjectAnnotation or ClassificationAnnotation. Got: {type(source)}"
+                        )
+                elif not isinstance(source, ObjectAnnotation):
                     raise TypeError(
-                        f"Unable to create relationship with non ObjectAnnotations. `Source: {type(source)} Target: {type(target)}`"
+                        f"Unable to create relationship with non ObjectAnnotation source: {type(source)}"
                     )
+
+                if not isinstance(target, ObjectAnnotation):
+                    raise TypeError(
+                        f"Unable to create relationship with non ObjectAnnotation target: {type(target)}"
+                    )
+
                 if not source._uuid:
                     source._uuid = uuid1
                 if not target._uuid:

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 import copy
 from itertools import groupby
 from operator import itemgetter
-from typing import Generator, List, Tuple, Union, Iterator, Dict
+from typing import Generator, List, Tuple, Union
 from uuid import uuid4
 
 from pydantic import BaseModel

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
@@ -194,7 +194,7 @@ class NDLabel(BaseModel):
     def _create_relationship_annotations(
         cls, label: Label
     ) -> Generator[NDRelationship, None, None]:
-        """Creates relationship annotations.
+        """Processes relationship annotations from a label, converting them to NDJSON format.
 
         Args:
             label: Label containing relationship annotations to be processed

--- a/libs/labelbox/tests/data/annotation_import/conftest.py
+++ b/libs/labelbox/tests/data/annotation_import/conftest.py
@@ -2210,21 +2210,21 @@ def expected_export_v2_video():
                 "classifications": [
                     {
                         "name": "checklist_index",
-                        "value": "checklist_index", 
+                        "value": "checklist_index",
                         "checklist_answers": [
                             {
                                 "name": "first_checklist_answer",
                                 "value": "first_checklist_answer",
-                                "classifications": []
+                                "classifications": [],
                             },
                             {
-                                "name": "second_checklist_answer", 
+                                "name": "second_checklist_answer",
                                 "value": "second_checklist_answer",
-                                "classifications": []
-                            }
-                        ]
+                                "classifications": [],
+                            },
+                        ],
                     }
-                ]
+                ],
             },
             "13": {
                 "objects": {},
@@ -2235,17 +2235,17 @@ def expected_export_v2_video():
                         "checklist_answers": [
                             {
                                 "name": "first_checklist_answer",
-                                "value": "first_checklist_answer", 
-                                "classifications": []
+                                "value": "first_checklist_answer",
+                                "classifications": [],
                             },
                             {
                                 "name": "second_checklist_answer",
                                 "value": "second_checklist_answer",
-                                "classifications": []
-                            }
-                        ]
+                                "classifications": [],
+                            },
+                        ],
                     }
-                ]
+                ],
             },
             "18": {
                 "objects": {},
@@ -2257,16 +2257,16 @@ def expected_export_v2_video():
                             {
                                 "name": "first_checklist_answer",
                                 "value": "first_checklist_answer",
-                                "classifications": []
+                                "classifications": [],
                             },
                             {
                                 "name": "second_checklist_answer",
                                 "value": "second_checklist_answer",
-                                "classifications": []
-                            }
-                        ]
+                                "classifications": [],
+                            },
+                        ],
                     }
-                ]
+                ],
             },
             "19": {
                 "objects": {},
@@ -2278,17 +2278,17 @@ def expected_export_v2_video():
                             {
                                 "name": "first_checklist_answer",
                                 "value": "first_checklist_answer",
-                                "classifications": []
+                                "classifications": [],
                             },
                             {
                                 "name": "second_checklist_answer",
                                 "value": "second_checklist_answer",
-                                "classifications": []
-                            }
-                        ]
+                                "classifications": [],
+                            },
+                        ],
                     }
-                ]
-            }
+                ],
+            },
         },
         "segments": {
             "<cuid>": [[7, 13], [18, 19]],

--- a/libs/labelbox/tests/data/annotation_import/test_relationships.py
+++ b/libs/labelbox/tests/data/annotation_import/test_relationships.py
@@ -179,7 +179,9 @@ def configured_project(
     data_row_data = []
 
     for _ in range(3):
-        data_row_data.append(data_row_json_by_media_type[media_type](rand_gen(str)))
+        data_row_data.append(
+            data_row_json_by_media_type[media_type](rand_gen(str))
+        )
 
     task = dataset.create_data_rows(data_row_data)
     task.wait_till_done()
@@ -254,7 +256,9 @@ def test_valid_classification_relationships():
             )
         raise ValueError(f"Unknown target type: {target_type}")
 
-    def verify_relationship(source: ClassificationAnnotation, target: ObjectAnnotation):
+    def verify_relationship(
+        source: ClassificationAnnotation, target: ObjectAnnotation
+    ):
         relationship = RelationshipAnnotation(
             name="relationship",
             value=Relationship(
@@ -263,12 +267,16 @@ def test_valid_classification_relationships():
                 type=Relationship.Type.UNIDIRECTIONAL,
             ),
         )
-        label = Label(data={"global_key": "global_key"}, annotations=[relationship])
+        label = Label(
+            data={"global_key": "global_key"}, annotations=[relationship]
+        )
         result = list(NDJsonConverter.serialize([label]))
         assert len(result) == 1
 
     # Test case 1: Text Classification -> DocumentRectangle
-    text_source = ClassificationAnnotation(name="text", value=Text(answer="test"))
+    text_source = ClassificationAnnotation(
+        name="text", value=Text(answer="test")
+    )
     verify_relationship(text_source, create_pdf_annotation("bbox"))
 
     # Test case 2: Text Classification -> DocumentEntity
@@ -284,7 +292,9 @@ def test_valid_classification_relationships():
                     ClassificationAnnotation(
                         name="second_sub_radio_question",
                         value=Radio(
-                            answer=ClassificationAnswer(name="second_sub_radio_answer")
+                            answer=ClassificationAnswer(
+                                name="second_sub_radio_answer"
+                            )
                         ),
                     )
                 ],
@@ -323,5 +333,7 @@ def test_classification_relationship_restrictions():
         TypeError,
         match="Unable to create relationship with non ObjectAnnotation source: .*",
     ):
-        label = Label(data={"global_key": "test_key"}, annotations=[relationship])
+        label = Label(
+            data={"global_key": "test_key"}, annotations=[relationship]
+        )
         list(NDJsonConverter.serialize([label]))

--- a/libs/labelbox/tests/data/annotation_import/test_relationships.py
+++ b/libs/labelbox/tests/data/annotation_import/test_relationships.py
@@ -10,7 +10,17 @@ from labelbox.types import (
     RelationshipAnnotation,
     Relationship,
     TextEntity,
+    DocumentRectangle,
+    DocumentEntity,
+    Point,
+    Text,
+    ClassificationAnnotation,
+    DocumentTextSelection,
+    Radio,
+    ClassificationAnswer,
+    Checklist,
 )
+from labelbox.data.serialization.ndjson import NDJsonConverter
 import pytest
 
 
@@ -169,9 +179,7 @@ def configured_project(
     data_row_data = []
 
     for _ in range(3):
-        data_row_data.append(
-            data_row_json_by_media_type[media_type](rand_gen(str))
-        )
+        data_row_data.append(data_row_json_by_media_type[media_type](rand_gen(str)))
 
     task = dataset.create_data_rows(data_row_data)
     task.wait_till_done()
@@ -220,3 +228,100 @@ def test_import_media_types(
 
     assert label_import.state == AnnotationImportState.FINISHED
     assert len(label_import.errors) == 0
+
+
+def test_valid_classification_relationships():
+    def create_pdf_annotation(target_type: str) -> ObjectAnnotation:
+        if target_type == "bbox":
+            return ObjectAnnotation(
+                name="bbox",
+                value=DocumentRectangle(
+                    start=Point(x=0, y=0),
+                    end=Point(x=0.5, y=0.5),
+                    page=1,
+                    unit="PERCENT",
+                ),
+            )
+        elif target_type == "entity":
+            return ObjectAnnotation(
+                name="entity",
+                value=DocumentEntity(
+                    page=1,
+                    textSelections=[
+                        DocumentTextSelection(token_ids=[], group_id="", page=1)
+                    ],
+                ),
+            )
+        raise ValueError(f"Unknown target type: {target_type}")
+
+    def verify_relationship(source: ClassificationAnnotation, target: ObjectAnnotation):
+        relationship = RelationshipAnnotation(
+            name="relationship",
+            value=Relationship(
+                source=source,
+                target=target,
+                type=Relationship.Type.UNIDIRECTIONAL,
+            ),
+        )
+        label = Label(data={"global_key": "global_key"}, annotations=[relationship])
+        result = list(NDJsonConverter.serialize([label]))
+        assert len(result) == 1
+
+    # Test case 1: Text Classification -> DocumentRectangle
+    text_source = ClassificationAnnotation(name="text", value=Text(answer="test"))
+    verify_relationship(text_source, create_pdf_annotation("bbox"))
+
+    # Test case 2: Text Classification -> DocumentEntity
+    verify_relationship(text_source, create_pdf_annotation("entity"))
+
+    # Test case 3: Radio Classification -> DocumentRectangle
+    radio_source = ClassificationAnnotation(
+        name="sub_radio_question",
+        value=Radio(
+            answer=ClassificationAnswer(
+                name="first_sub_radio_answer",
+                classifications=[
+                    ClassificationAnnotation(
+                        name="second_sub_radio_question",
+                        value=Radio(
+                            answer=ClassificationAnswer(name="second_sub_radio_answer")
+                        ),
+                    )
+                ],
+            )
+        ),
+    )
+    verify_relationship(radio_source, create_pdf_annotation("bbox"))
+
+    # Test case 4: Checklist Classification -> DocumentEntity
+    checklist_source = ClassificationAnnotation(
+        name="sub_checklist_question",
+        value=Checklist(
+            answer=[ClassificationAnswer(name="first_sub_checklist_answer")]
+        ),
+    )
+    verify_relationship(checklist_source, create_pdf_annotation("entity"))
+
+
+def test_classification_relationship_restrictions():
+    """Test all relationship validation error messages."""
+    text = ClassificationAnnotation(name="text", value=Text(answer="test"))
+    point = ObjectAnnotation(name="point", value=Point(x=1, y=1))
+
+    # Test case: Classification -> Point (invalid)
+    # Should fail because classifications can only connect to PDF targets
+    relationship = RelationshipAnnotation(
+        name="relationship",
+        value=Relationship(
+            source=text,
+            target=point,
+            type=Relationship.Type.UNIDIRECTIONAL,
+        ),
+    )
+
+    with pytest.raises(
+        TypeError,
+        match="Unable to create relationship with non ObjectAnnotation source: .*",
+    ):
+        label = Label(data={"global_key": "test_key"}, annotations=[relationship])
+        list(NDJsonConverter.serialize([label]))


### PR DESCRIPTION
# Description

Added MAL and GT support for connecting classifications to PDF annotations (DocumentRectangle and DocumentEntity) using relationships.

# How to test

- MAL and GT import work for relationships connecting classifications and bounding boxes/named entities
```
import labelbox as lb
import uuid
import labelbox.types as lb_types
from labelbox.data.annotation_types import RectangleUnit

client = lb.Client(
    api_key="",
    endpoint="https://app.lb-stage.xyz/api/_gql",
    rest_endpoint="https://app.lb-stage.xyz/api/api/v1",
)

radio_annotation = lb_types.ClassificationAnnotation(
    name="radio_pdf",
    value=lb_types.Radio(
        answer=lb_types.ClassificationAnswer(name="second_radio_answer")
    ),
)

checklist_annotation = lb_types.ClassificationAnnotation(
    name="checklist_pdf",  # must match your ontology feature's name
    value=lb_types.Checklist(
        answer=[
            lb_types.ClassificationAnswer(name="first_checklist_answer"),
            lb_types.ClassificationAnswer(name="second_checklist_answer"),
        ]
    ),
)

text_annotation = lb_types.ClassificationAnnotation(
    name="text_pdf", value=lb_types.Text(answer="sample text")
)

bbox_annotation = lb_types.ObjectAnnotation(
    name="bounding_box",
    value=lb_types.DocumentRectangle(
        start=lb_types.Point(x=0.5, y=0.5),  #  x = left, y = top
        end=lb_types.Point(x=0.7, y=0.7),  # x= left + width , y = top + height
        page=1,
        unit=RectangleUnit.PERCENT,
    ),
)

bbox_annotation_2 = lb_types.ObjectAnnotation(
    name="bounding_box",
    value=lb_types.DocumentRectangle(
        start=lb_types.Point(x=0.5, y=0.5),
        end=lb_types.Point(x=0.7, y=0.7),
        page=2,
        unit=RectangleUnit.PERCENT,
    ),
)

entity_annotation = lb_types.ObjectAnnotation(
    name="named_entity",
    value=lb_types.DocumentEntity(
        name="named_entity",
        textSelections=[
            lb_types.DocumentTextSelection(
                token_ids=["9763b68b-9ea7-472d-af40-20ab69fbee71"],
                group_id="ee108a07-059a-4302-910f-b16eb148f123",
                page=1,
            )
        ],
    ),
)

text_bbox_relationship = lb_types.RelationshipAnnotation(
    name="relationship",
    value=lb_types.Relationship(
        source=text_annotation,
        target=bbox_annotation,
        type=lb_types.Relationship.Type.UNIDIRECTIONAL,
    ),
)

radio_bbox_relationship = lb_types.RelationshipAnnotation(
    name="relationship",
    value=lb_types.Relationship(
        source=radio_annotation,
        target=bbox_annotation,
        type=lb_types.Relationship.Type.UNIDIRECTIONAL,
    ),
)

checklist_bbox_relationship = lb_types.RelationshipAnnotation(
    name="relationship",
    value=lb_types.Relationship(
        source=checklist_annotation,
        target=bbox_annotation,
        type=lb_types.Relationship.Type.UNIDIRECTIONAL,
    ),
)


text_entity_relationship = lb_types.RelationshipAnnotation(
    name="relationship",
    value=lb_types.Relationship(
        source=text_annotation,
        target=entity_annotation,
        type=lb_types.Relationship.Type.UNIDIRECTIONAL,
    ),
)

bbox_bbox2_relationship = lb_types.RelationshipAnnotation(
    name="relationship",
    value=lb_types.Relationship(
        source=bbox_annotation,
        target=bbox_annotation_2,
        type=lb_types.Relationship.Type.UNIDIRECTIONAL,
    ),
)

global_key = f"pdf_{uuid.uuid4()}"

test_img_url = {
    "row_data": {
        "pdf_url": "https://storage.googleapis.com/labelbox-developer-testing-assets/pdf-with-percents.pdf",
        "text_layer_url": "https://storage.googleapis.com/labelbox-developer-testing-assets/text-layer-percent-unit.json",
    },
    "global_key": global_key,
}

dataset = client.create_dataset(name="demo_dataset_pdf")
task = dataset.create_data_rows([test_img_url])
task.wait_till_done()
print("Errors:", task.errors)
print("Failed data rows:", task.failed_data_rows)
ontology_builder = lb.OntologyBuilder(
    classifications=[
        lb.Classification(class_type=lb.Classification.Type.TEXT, name="text_pdf"),
        lb.Classification(
            class_type=lb.Classification.Type.CHECKLIST,
            name="checklist_pdf",
            options=[
                lb.Option(value="first_checklist_answer"),
                lb.Option(value="second_checklist_answer"),
            ],
        ),
        lb.Classification(
            class_type=lb.Classification.Type.RADIO,
            name="radio_pdf",
            options=[
                lb.Option(value="first_radio_answer"),
                lb.Option(value="second_radio_answer"),
            ],
        ),
    ],
    tools=[  # List of tools
        lb.Tool(tool=lb.Tool.Type.BBOX, name="bounding_box"),
        lb.Tool(tool=lb.Tool.Type.RELATIONSHIP, name="relationship"),
        lb.Tool(tool=lb.Tool.Type.NER, name="named_entity"),
    ],
)

ontology = client.create_ontology(
    "Ontology PDF Annotations", ontology_builder.asdict(), media_type=lb.MediaType.Pdf
)
project = client.create_project(name="pdf_project 2", media_type=lb.MediaType.Pdf)

# Setup your ontology
project.connect_ontology(ontology)
batch = project.create_batch(
    "first-batch-pdf-demo",  # Each batch in a project must have a unique name
    global_keys=[
        global_key
    ],  # Paginated collection of data row objects, list of data row ids or global keys
    priority=5,  # priority between 1(highest) - 5(lowest)
)

print("Batch: ", batch)
label = []
label.append(
    lb_types.Label(
        data={"global_key": global_key},
        annotations=[
            text_annotation,
            checklist_annotation,
            radio_annotation,
            bbox_annotation,
            bbox_annotation_2,
            entity_annotation,
            text_bbox_relationship,
            radio_bbox_relationship,
            checklist_bbox_relationship,
            text_entity_relationship,
            bbox_bbox2_relationship,
        ],
    )
)
# MAL
upload_job = lb.MALPredictionImport.create_from_objects(
    client=client,
    project_id=project.uid,
    name=f"mal_job-{str(uuid.uuid4())}",
    predictions=label,
)

# GT
# upload_job = lb.LabelImport.create_from_objects(
#     client=client,
#     project_id=project.uid,
#     name="label_import_job" + str(uuid.uuid4()),
#     labels=label,
# )

upload_job.wait_until_done()
print("Errors:", upload_job.errors)
print("Status of uploads: ", upload_job.statuses)
```

- MAL and GT import of relationships works in image

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

## New Feature Submissions

- [x] Does your submission pass tests?
- [x] Have you added thorough tests for your new feature?
- [x] Have you commented your code, particularly in hard-to-understand areas?
- [x] Have you added a Docstring?

## Changes to Core Features

- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
- [x] Have you updated any code comments, as applicable?
