### PR TITLE
[PLT-2290] Fix for mmc test global key

### DIFF
--- a/libs/labelbox/tests/integration/test_mmc_data_rows.py
+++ b/libs/labelbox/tests/integration/test_mmc_data_rows.py
@@ -23,10 +23,11 @@ def mmc_data_row(dataset):
 
 
 @pytest.fixture
-def mmc_data_row_all(dataset, make_metadata_fields, embedding):
+def mmc_data_row_all(dataset, make_metadata_fields, embedding, rand_gen):
     data = ModelEvaluationTemplate()
     data.row_data.rootMessageIds = ["root1"]
-    data.global_key = "global_key"
+    global_key = f"global_key_{rand_gen(str)}"
+    data.global_key = global_key
     vector = [random.uniform(1.0, 2.0) for _ in range(embedding.dims)]
     data.embeddings = [{"embedding_id": embedding.id, "vector": vector}]
     data.metadata_fields = make_metadata_fields
@@ -39,7 +40,7 @@ def mmc_data_row_all(dataset, make_metadata_fields, embedding):
 
     data_row = list(dataset.data_rows())[0]
 
-    yield data_row
+    yield data_row, global_key
 
     data_row.delete()
 
@@ -57,7 +58,7 @@ def test_mmc(mmc_data_row):
 
 
 def test_mmc_all(mmc_data_row_all, embedding, constants):
-    data_row = mmc_data_row_all
+    data_row, global_key = mmc_data_row_all
     assert json.loads(data_row.row_data) == {
         "type": "application/vnd.labelbox.conversational.model-chat-evaluation",
         "draft": True,
@@ -66,7 +67,7 @@ def test_mmc_all(mmc_data_row_all, embedding, constants):
         "messages": {},
         "version": 2,
     }
-    assert data_row.global_key == "global_key"
+    assert data_row.global_key == global_key
     metadata_fields = data_row.metadata_fields
     metadata = data_row.metadata
     assert len(metadata_fields) == 3


### PR DESCRIPTION
# Description

Cause of the failing test: using the same global key for each test. As a result when running with multiple pipelines we sometimes get a _Duplicate key error_ from ADV


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
