### PR TITLE
#nojira Add v6.8 as a heading in changelog

### DIFF
--- a/libs/labelbox/CHANGELOG.md
+++ b/libs/labelbox/CHANGELOG.md
@@ -4,8 +4,8 @@
 * Provide support to cancel tasks ([#1957](https://github.com/Labelbox/labelbox-python/pull/1957))
 * Added support for AUDIO attachment type ([#1956](https://github.com/Labelbox/labelbox-python/pull/1956))
 
-Version 6.8.0 (2025-02-20)
-### Added Support for Source Ontology Names in Relationships
+# Version 6.8.0 (2025-02-20)
+## Added Support for Source Ontology Names in Relationships
 
 Added the ability to specify relationships using `source_ontology_name` instead of a concrete source annotation. This enhancement is particularly useful for PDF document annotations where you can create relationships referencing ontology classes directly.
 
@@ -13,8 +13,8 @@ Key changes:
 - Added optional `source_ontology_name` field to `Relationship` class
 - Made `source` field optional
 - Added validation to ensure either `source` or `source_ontology_name` is provided, but not both
-### Added search by name for `get_catalog_slice`
-### Added `get_catalog_slices` to get all slices
+## Added search by name for `get_catalog_slice`
+## Added `get_catalog_slices` to get all slices
 
 # Version 6.7.0 (2025-02-06)
 ## Added


### PR DESCRIPTION
# Description

In the Changelog, v6.8 is currently formatted as a regular paragraph instead of a heading. This PR adds the H1 formatting to it to make it consistent with other versions.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
