### PR TITLE
Make role name check case insensitive

### DIFF
--- a/libs/labelbox/src/labelbox/schema/api_key.py
+++ b/libs/labelbox/src/labelbox/schema/api_key.py
@@ -324,7 +324,9 @@ class ApiKey(DbObject):
             raise ValueError("role must be a Role object or a valid role name")
 
         allowed_roles = ApiKey._get_available_api_key_roles(client)
-        if role_name not in allowed_roles:
+        # Normalize the allowed roles to lowercase for case-insensitive comparison
+        normalized_allowed_roles = [r.lower() for r in allowed_roles]
+        if role_name.lower() not in normalized_allowed_roles:
             raise ValueError(
                 f"Invalid role specified. Allowed roles are: {allowed_roles}"
             )


### PR DESCRIPTION
# Description

Make role name check insensitive: `client.get_roles()` return upper case names and GraphQL call returns Pascal case names.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
