### PR TITLE
Fix ApiKey.created_by for old API keys

### DIFF
--- a/libs/labelbox/src/labelbox/schema/api_key.py
+++ b/libs/labelbox/src/labelbox/schema/api_key.py
@@ -45,14 +45,22 @@ class ApiKey(DbObject):
         """Gets the User who created this API key.
 
         Returns:
-            Optional[User]: The User who created this API key, or None if not available
+            Optional[User]: The User who created this API key, or None if not available.
         """
         if not hasattr(self, "_created_by"):
+            # Use created_by_user_id if present, otherwise fall back to user_id
+            # (typically needed for older API keys where created_by_user_id is NULL)
+            user_id_to_fetch = (
+                self.created_by_user_id
+                if self.created_by_user_id is not None
+                else self.user_id
+            )
             self._created_by = (
-                self.client._get_single(User, self.created_by_user_id)
-                if self.created_by_user_id
+                self.client._get_single(User, user_id_to_fetch)
+                if user_id_to_fetch
                 else None
             )
+
         return self._created_by
 
     @property


### PR DESCRIPTION
# Description

In the SDK, API keys created before the deployment of [PLT-2509](https://labelbox.atlassian.net/browse/PLT-2509) don’t have a value for the attribute created_by:

<img width="464" alt="image" src="https://github.com/user-attachments/assets/7e237121-955e-4230-955e-ed1e5c7df2b8" />


For keys with createdById null, the value of `userId` should be used instead.

<img width="464" alt="image" src="https://github.com/user-attachments/assets/4736aafd-6f64-4d70-a4ba-7feefcbb4376" />


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?


[PLT-2509]: https://labelbox.atlassian.net/browse/PLT-2509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ