### PR TITLE
Support for project ontology change

### DIFF
--- a/libs/labelbox/src/labelbox/schema/ontology.py
+++ b/libs/labelbox/src/labelbox/schema/ontology.py
@@ -30,6 +30,7 @@ from labelbox.schema.tool_building.types import (
     FeatureSchemaAttributes,
 )
 import warnings
+from labelbox.schema.project import MediaType
 
 
 class DeleteFeatureFromOntologyResult:
@@ -195,6 +196,7 @@ class Ontology(DbObject):
     normalized = Field.Json("normalized")
     object_schema_count = Field.Int("object_schema_count")
     classification_schema_count = Field.Int("classification_schema_count")
+    media_type = Field.Enum(MediaType, "media_type", "mediaType")
 
     projects = Relationship.ToMany("Project", True)
     created_by = Relationship.ToOne("User", False, "created_by")

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -666,14 +666,30 @@ class Project(DbObject, Updateable, Deletable):
     def connect_ontology(self, ontology) -> None:
         """
         Connects the ontology to the project. If an editor is not setup, it will be connected as well.
+        This method can be used to change the project's ontology.
 
         Note: For live chat model evaluation projects, the editor setup is skipped because it is automatically setup when the project is created.
 
         Args:
             ontology (Ontology): The ontology to attach to the project
+
+        Raises:
+            ValueError: If ontology and project have different media types and ontology has a media type set
         """
-        if not self.is_empty_ontology():
-            raise ValueError("Ontology already connected to project.")
+        # Check media type compatibility
+        if (
+            self.media_type != ontology.media_type
+            and not ontology.media_type == MediaType.Unknown
+        ):
+            raise ValueError(
+                "Ontology and project must share the same type, unless the ontology has no type."
+            )
+
+        # Check if project has labels and warn user
+        if self.get_label_count() > 0:
+            warnings.warn(
+                "Project has labels. The new ontology must contain all annotation types."
+            )
 
         if (
             self.labeling_frontend() is None

--- a/libs/labelbox/tests/integration/test_project_setup.py
+++ b/libs/labelbox/tests/integration/test_project_setup.py
@@ -2,6 +2,7 @@ import time
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from labelbox.schema.media_type import MediaType
 
 
 def simple_ontology():
@@ -38,11 +39,69 @@ def test_project_editor_setup(client, project, rand_gen):
     ] == [ontology_name]
 
 
-def test_project_connect_ontology_cant_call_multiple_times(
-    client, project, rand_gen
-):
-    ontology_name = f"test_project_editor_setup_ontology_name-{rand_gen(str)}"
-    ontology = client.create_ontology(ontology_name, simple_ontology())
-    project.connect_ontology(ontology)
-    with pytest.raises(ValueError):
-        project.connect_ontology(ontology)
+def test_project_connect_ontology_multiple_times(client, project, rand_gen):
+    """Test that we can connect multiple ontologies in sequence."""
+    # Connect first ontology
+    ontology_name_1 = (
+        f"test_project_connect_ontology_multiple_times_1-{rand_gen(str)}"
+    )
+    ontology_1 = client.create_ontology(ontology_name_1, simple_ontology())
+    project.connect_ontology(ontology_1)
+    assert project.ontology().name == ontology_name_1
+
+    # Connect second ontology
+    ontology_name_2 = (
+        f"test_project_connect_ontology_multiple_times_2-{rand_gen(str)}"
+    )
+    ontology_2 = client.create_ontology(ontology_name_2, simple_ontology())
+    project.connect_ontology(ontology_2)
+    assert project.ontology().name == ontology_name_2
+
+
+def test_project_connect_ontology_with_different_media_types(client, rand_gen):
+    """Test connecting ontologies with different media types to a project"""
+    # Create a new project with Image media type
+    project_name = f"test_project_media_type_{rand_gen(str)}"
+    project = client.create_project(
+        name=project_name, media_type=MediaType.Image
+    )
+
+    try:
+        # Create ontologies with different media types
+        ontology_1 = client.create_ontology(
+            f"test_ontology_1_{rand_gen(str)}",
+            simple_ontology(),
+            media_type=MediaType.Image,  # Same media type as project
+        )
+
+        ontology_2 = client.create_ontology(
+            f"test_ontology_2_{rand_gen(str)}",
+            simple_ontology(),
+            media_type=MediaType.Video,  # Different media type
+        )
+
+        # Test connecting ontology with same media type
+        project.connect_ontology(ontology_1)
+        assert project.ontology().uid == ontology_1.uid
+
+        # Test connecting ontology with different media type
+        with pytest.raises(ValueError) as exc_info:
+            project.connect_ontology(ontology_2)
+        assert "Ontology and project must share the same type" in str(
+            exc_info.value
+        )
+    finally:
+        # Clean up
+        project.delete()
+
+
+def test_project_connect_ontology_with_unknown_type(client, project, rand_gen):
+    """Test connecting ontology with unknown media type to a project"""
+    # Create ontology with unknown media type
+    unknown_type_ontology = client.create_ontology(
+        f"test_unknown_type_{rand_gen(str)}", simple_ontology()
+    )
+
+    # Test connecting ontology with unknown type
+    project.connect_ontology(unknown_type_ontology)
+    assert project.ontology().uid == unknown_type_ontology.uid


### PR DESCRIPTION
# Description

Elevenlabs requested this change. It reverts a restriction so users can change a project's ontology.

## Changes
- The `MediaType` of an ontology is now accessible: `Ontology.media_type`

## Example
Common
```python
def simple_ontology():
    classifications = [
        {
            "name": "test_ontology",
            "instructions": "Which class is this?",
            "type": "radio",
            "options": [
                {"value": c, "label": c} for c in ["one", "two", "three"]
            ],
            "required": True,
        }
    ]

    return {"tools": [], "classifications": classifications}
```

1. Working case - same media type for project and ontology
```python
# Create a project with Image media type
project = client.create_project(
    name="my_image_project",
    media_type=MediaType.Image
)

# Create and connect first ontology
first_ontology = client.create_ontology(
    "first_ontology",
    simple_ontology(),
    media_type=MediaType.Image
)
project.connect_ontology(first_ontology)

# Create and connect second ontology with same media type
second_ontology = client.create_ontology(
    "second_ontology",
    simple_ontology(),
    media_type=MediaType.Image
)
project.connect_ontology(second_ontology)  # This works because media types match
```

1. Working case - media type unknown for the ontology
```python
# Create a project with Image media type
project = client.create_project(
    name="my_image_project",
    media_type=MediaType.Image
)

# Create and connect first ontology
first_ontology = client.create_ontology(
    "first_ontology",
    simple_ontology(),
    media_type=MediaType.Image
)
project.connect_ontology(first_ontology)

# Create and connect second ontology with same media type
second_ontology = client.create_ontology(
    "second_ontology",
    simple_ontology()
)
project.connect_ontology(second_ontology)  # This works because media types match
```

2. Non-working case - different media type for project and ontology
```python
# Create a project with Image media type
project = client.create_project(
    name="my_image_project",
    media_type=MediaType.Image
)

# Create and connect first ontology
first_ontology = client.create_ontology(
    "first_ontology",
    simple_ontology(),
    media_type=MediaType.Image
)
project.connect_ontology(first_ontology)

# Create and connect second ontology with different media type
second_ontology = client.create_ontology(
    "second_ontology",
    simple_ontology(),
    media_type=MediaType.Video
)
project.connect_ontology(second_ontology)  # ValueError: Ontology and project must share the same type, unless the ontology has no type
```


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
