### PR TITLE
Fix test_get_slice

### DIFF
--- a/libs/labelbox/tests/integration/test_slice.py
+++ b/libs/labelbox/tests/integration/test_slice.py
@@ -85,7 +85,7 @@ def test_get_slice(client):
         if s.name in ["Test Slice 1", "Test Slice 2"]
     )
     for slice in slices:
-        _delete_catalog_slice(client, slice.id)
+        _delete_catalog_slice(client, slice.uid)
 
     # Create slices
     slice_id_1 = _create_catalog_slice(


### PR DESCRIPTION
# Description

This PR fixes a typo in `test_get_slice`

Before:
```python
    for slice in slices:
        _delete_catalog_slice(client, slice.id)
```

After:
```python
    for slice in slices:
        _delete_catalog_slice(client, slice.uid)
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
