### PR TITLE
[PLT-2769] remove project setup complete restriction

### DIFF
--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -564,15 +564,8 @@ class Project(DbObject, Updateable, Deletable):
 
         Raises:
             ValueError:
-                * project must be setup
                 * instructions file must have a ".pdf" or ".html" extension
         """
-
-        if self.setup_complete is None:
-            raise ValueError(
-                "Cannot attach instructions to a project that has not been set up."
-            )
-
         frontend = self.labeling_frontend()
 
         if frontend.name != "Editor":
@@ -705,7 +698,6 @@ class Project(DbObject, Updateable, Deletable):
             query_str, {"ontologyId": ontology.uid, "projectId": self.uid}
         )
         timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        self.update(setup_complete=timestamp)
 
     def _connect_default_labeling_front_end(self, ontology_as_dict: dict):
         labeling_frontend = self.labeling_frontend()

--- a/libs/labelbox/tests/integration/test_project.py
+++ b/libs/labelbox/tests/integration/test_project.py
@@ -140,12 +140,6 @@ def test_extend_reservations(project):
 
 
 def test_attach_instructions(client, project):
-    with pytest.raises(ValueError) as execinfo:
-        project.upsert_instructions("tests/integration/media/sample_pdf.pdf")
-    assert (
-        str(execinfo.value)
-        == "Cannot attach instructions to a project that has not been set up."
-    )
     ontology_builder = OntologyBuilder(
         tools=[
             Tool(tool=Tool.Type.BBOX, name="test-bbox-class"),


### PR DESCRIPTION
# Description

Remove project setup complete restriction when attaching instructions to a project - it's a deprecated feature.

Fixes # (issue)

https://labelbox.atlassian.net/browse/PLT-2769

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
