### PR TITLE
API key creation: fix support of role with a space in the name

### DIFF
--- a/libs/labelbox/src/labelbox/schema/api_key.py
+++ b/libs/labelbox/src/labelbox/schema/api_key.py
@@ -8,7 +8,7 @@ from labelbox.schema.timeunit import TimeUnit
 from lbox.exceptions import LabelboxError
 
 from labelbox.schema.user import User
-from labelbox.schema.role import Role
+from labelbox.schema.role import Role, format_role
 
 if TYPE_CHECKING:
     from labelbox import Client
@@ -258,7 +258,7 @@ class ApiKey(DbObject):
             if role["name"] in ["None", "Tenant Admin"]:
                 continue
             if all(perm in current_permissions for perm in role["permissions"]):
-                available_roles.append(role["name"])
+                available_roles.append(format_role(role["name"]))
         client._cached_available_api_key_roles = available_roles
         return available_roles
 
@@ -332,9 +332,9 @@ class ApiKey(DbObject):
             raise ValueError("role must be a Role object or a valid role name")
 
         allowed_roles = ApiKey._get_available_api_key_roles(client)
-        # Normalize the allowed roles to lowercase for case-insensitive comparison
-        normalized_allowed_roles = [r.lower() for r in allowed_roles]
-        if role_name.lower() not in normalized_allowed_roles:
+        # Format the input role name consistently with available roles
+        formatted_role_name = format_role(role_name)
+        if formatted_role_name not in allowed_roles:
             raise ValueError(
                 f"Invalid role specified. Allowed roles are: {allowed_roles}"
             )

--- a/libs/labelbox/src/labelbox/schema/api_key.py
+++ b/libs/labelbox/src/labelbox/schema/api_key.py
@@ -333,7 +333,9 @@ class ApiKey(DbObject):
 
         allowed_roles = ApiKey._get_available_api_key_roles(client)
         # Normalize the allowed roles to lowercase for case-insensitive comparison
-        normalized_allowed_roles = [r.lower() for r in allowed_roles]
+        normalized_allowed_roles = [
+            r.lower().replace(" ", "_") for r in allowed_roles
+        ]
         if role_name.lower() not in normalized_allowed_roles:
             raise ValueError(
                 f"Invalid role specified. Allowed roles are: {allowed_roles}"

--- a/libs/labelbox/src/labelbox/schema/api_key.py
+++ b/libs/labelbox/src/labelbox/schema/api_key.py
@@ -333,9 +333,7 @@ class ApiKey(DbObject):
 
         allowed_roles = ApiKey._get_available_api_key_roles(client)
         # Normalize the allowed roles to lowercase for case-insensitive comparison
-        normalized_allowed_roles = [
-            r.lower().replace(" ", "_") for r in allowed_roles
-        ]
+        normalized_allowed_roles = [r.lower() for r in allowed_roles]
         if role_name.lower() not in normalized_allowed_roles:
             raise ValueError(
                 f"Invalid role specified. Allowed roles are: {allowed_roles}"


### PR DESCRIPTION
# Description

This PR fixes a bug missed during testing.
During the creation of API keys with the SDK, roles with a space in their name are not detected correctly.

Fixes [PLT-2822](https://labelbox.atlassian.net/browse/PLT-2822)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?


[PLT-2822]: https://labelbox.atlassian.net/browse/PLT-2822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ