### PR TITLE
[PTDT-3744]: Removes sdk max_length validation of the content of custom data row metadata

### DIFF
--- a/libs/labelbox/src/labelbox/schema/data_row_metadata.py
+++ b/libs/labelbox/src/labelbox/schema/data_row_metadata.py
@@ -65,7 +65,7 @@ class DataRowMetadataSchema(BaseModel):
 DataRowMetadataSchema.model_rebuild()
 
 Embedding: Type[List[float]] = conlist(float, min_length=128, max_length=128)
-String: Type[str] = Field(max_length=65000)
+String: Type[str] = Field()
 
 
 # Metadata base class

--- a/libs/labelbox/src/labelbox/schema/data_row_metadata.py
+++ b/libs/labelbox/src/labelbox/schema/data_row_metadata.py
@@ -65,7 +65,7 @@ class DataRowMetadataSchema(BaseModel):
 DataRowMetadataSchema.model_rebuild()
 
 Embedding: Type[List[float]] = conlist(float, min_length=128, max_length=128)
-String: Type[str] = Field(max_length=4096)
+String: Type[str] = Field(max_length=65000)
 
 
 # Metadata base class


### PR DESCRIPTION
# Description

Removes max_length character validation for data row metadata in the sdk. For context, we're doing this because we're now storing `turnInstructions` in data row metadata. These turn instructions are a json stringified object that contains per turn instructions for labelers to read and follow per turn in a conversation in the mmc editor.

See this [thread](https://labelbox.slack.com/archives/CPVQE6T2T/p1756311939061049) for more context.

Fixes # (issue)

## Type of change

Validation change

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?
