### PR TITLE
[PLT-0] decouple the publish workflows for lbox and the sdk

### DIFF
--- a/.github/workflows/lbox-publish.yml
+++ b/.github/workflows/lbox-publish.yml
@@ -1,16 +1,14 @@
 name: LBox Publish
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       tag:
         description: 'Release Tag'
         required: true
-        type: string
       prev_sdk_tag:
-        description: 'Prev SDK Release Tag'
+        description: 'Prev SDK Release Tag, used to determine which lbox files have changed'
         required: true
-        type: string        
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,19 +26,19 @@ permissions:
   id-token: write
 
 jobs:
-  build-lbox:
-    permissions:
-      actions: read
-      contents: write
-      id-token: write # Needed to access the workflow's OIDC identity.
-      packages: write
-    uses: ./.github/workflows/lbox-publish.yml
-    with:
-      tag: ${{ inputs.tag }}
-      prev_sdk_tag: ${{ inputs.prev_sdk_tag }}
-    secrets: inherit
+#  build-lbox:
+#    permissions:
+#      actions: read
+#      contents: write
+#      id-token: write # Needed to access the workflow's OIDC identity.
+#      packages: write
+#    uses: ./.github/workflows/lbox-publish.yml
+#    with:
+#      tag: ${{ inputs.tag }}
+#      prev_sdk_tag: ${{ inputs.prev_sdk_tag }}
+#    secrets: inherit
   build:
-    needs: ['build-lbox']
+#    needs: ['build-lbox']
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}


### PR DESCRIPTION
# Description

PyPI does not support publishing from a reusable workflow - decouple the publishing workflows.

https://github.com/pypa/gh-action-pypi-publish/issues/166

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?
