### PR TITLE
[PLT-3337] SDK - Workflow Management allow multiple inputs

### DIFF
--- a/libs/labelbox/src/labelbox/schema/workflow/workflow_utils.py
+++ b/libs/labelbox/src/labelbox/schema/workflow/workflow_utils.py
@@ -117,31 +117,6 @@ class WorkflowValidator:
                             "node_type": node_type,
                         }
                     )
-                elif len(predecessors) > 1:
-                    # Check if all predecessors are initial nodes
-                    node_map = {n.id: n for n in nodes}
-                    predecessor_nodes = [
-                        node_map.get(pred_id) for pred_id in predecessors
-                    ]
-                    all_initial = all(
-                        pred_node
-                        and pred_node.definition_id in initial_node_types
-                        for pred_node in predecessor_nodes
-                        if pred_node is not None
-                    )
-
-                    if not all_initial:
-                        preds_info = ", ".join(
-                            [p[:8] + "..." for p in predecessors]
-                        )
-                        errors.append(
-                            {
-                                "reason": f"has multiple incoming connections ({len(predecessors)}) but not all are from initial nodes",
-                                "node_id": node.id,
-                                "node_type": node_type,
-                                "details": f"Connected from: {preds_info}",
-                            }
-                        )
 
             # Check outgoing connections (except terminal nodes)
             if node.definition_id not in terminal_node_types:

--- a/libs/labelbox/tests/integration/test_workflow.py
+++ b/libs/labelbox/tests/integration/test_workflow.py
@@ -96,6 +96,40 @@ def test_workflow_creation(client, test_projects):
     assert WorkflowDefinitionId.Done in node_types
 
 
+def test_workflow_allows_multiple_incoming_from_non_initial_nodes(
+    client, test_projects
+):
+    """
+    Nodes may have multiple incoming connections from any nodes (not only initial nodes).
+
+    This used to fail validation when a node had >1 predecessor and at least one
+    predecessor was not an initial node.
+    """
+    source_project, _ = test_projects
+
+    workflow = source_project.get_workflow()
+    initial_nodes = workflow.reset_to_initial_nodes(
+        labeling_config=LabelingConfig(instructions="Start labeling here")
+    )
+
+    logic = workflow.add_node(
+        type=NodeType.Logic,
+        name="Gate",
+        filters=ProjectWorkflowFilter([labeled_by.is_one_of(["test-user"])]),
+    )
+    review = workflow.add_node(type=NodeType.Review, name="Review Task")
+    done = workflow.add_node(type=NodeType.Done, name="Done")
+
+    # Multiple incoming connections to review, including from a non-initial node (logic)
+    workflow.add_edge(initial_nodes.labeling, logic)
+    workflow.add_edge(logic, review, NodeOutput.If)
+    workflow.add_edge(initial_nodes.rework, review)
+    workflow.add_edge(review, done, NodeOutput.Approved)
+
+    # Should validate and update successfully
+    workflow.update_config(reposition=False)
+
+
 def test_workflow_creation_simple(client):
     """Test creating a simple workflow with the working pattern."""
     # Create a new project for this test

--- a/libs/labelbox/tests/unit/test_workflow_utils_validation.py
+++ b/libs/labelbox/tests/unit/test_workflow_utils_validation.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+
+from labelbox.schema.workflow.enums import WorkflowDefinitionId
+from labelbox.schema.workflow.graph import ProjectWorkflowGraph
+from labelbox.schema.workflow.workflow_utils import WorkflowValidator
+
+
+@dataclass(frozen=True)
+class _Node:
+    id: str
+    definition_id: WorkflowDefinitionId
+
+
+def test_validate_node_connections_allows_multiple_incoming_from_non_initial_nodes():
+    """
+    Regression test: nodes may have multiple incoming connections from any nodes.
+
+    Historically validation required that if a node had >1 predecessors, they all had
+    to be initial nodes. Workflow Management now allows multi-input nodes from any
+    nodes, so this must not error.
+    """
+    initial_labeling = _Node(
+        id="initial_labeling",
+        definition_id=WorkflowDefinitionId.InitialLabelingTask,
+    )
+    initial_rework = _Node(
+        id="initial_rework",
+        definition_id=WorkflowDefinitionId.InitialReworkTask,
+    )
+    logic = _Node(id="logic", definition_id=WorkflowDefinitionId.Logic)
+    review = _Node(id="review", definition_id=WorkflowDefinitionId.ReviewTask)
+    done = _Node(id="done", definition_id=WorkflowDefinitionId.Done)
+
+    nodes = [initial_labeling, initial_rework, logic, review, done]
+
+    graph = ProjectWorkflowGraph()
+    graph.add_edge(initial_labeling.id, logic.id)
+    graph.add_edge(logic.id, review.id)
+    graph.add_edge(initial_rework.id, review.id)
+    graph.add_edge(review.id, done.id)
+
+    errors = WorkflowValidator.validate_node_connections(nodes, graph)
+    assert errors == []
+
+
+def test_validate_node_connections_still_flags_missing_incoming_connections():
+    """Non-initial nodes must still have at least one incoming connection."""
+    initial_labeling = _Node(
+        id="initial_labeling",
+        definition_id=WorkflowDefinitionId.InitialLabelingTask,
+    )
+    review = _Node(id="review", definition_id=WorkflowDefinitionId.ReviewTask)
+    done = _Node(id="done", definition_id=WorkflowDefinitionId.Done)
+
+    nodes = [initial_labeling, review, done]
+    graph = ProjectWorkflowGraph()
+    graph.add_edge(initial_labeling.id, done.id)
+
+    errors = WorkflowValidator.validate_node_connections(nodes, graph)
+    assert any(
+        e.get("node_id") == review.id
+        and e.get("reason") == "has no incoming connections"
+        for e in errors
+    )


### PR DESCRIPTION
Format updated by linter

# Description

In the SDK, remove a limitation in workflow management so nodes can accept multiple inputs from different nodes, and not just from initial nodes.

<img width="1176" height="356" alt="image" src="https://github.com/user-attachments/assets/4b31fd11-129f-4938-bf1f-3b2a843c1881" />


### Tests:
1. In the Labelbox platform, create a new project
2. For 1. change the workflow like the following:

   <img width="1176" height="356" alt="image" src="https://github.com/user-attachments/assets/a04f3602-e9b6-4c17-af99-3f8c2dee842e" />

3. Create a second project
4. From the SDK, update the values and run the following scripts:

   ```python
   import labelbox as lb

   # Values to update
   API_KEY = "<your API KEY>"
   SOURCE_PROJECT_ID = "<project ID from 1.>"
   TARGET_PROJECT_ID = "<project ID from 2.>"

   client = lb.Client(API_KEY)
   target_project = client.get_project(TARGET_PROJECT_ID)

   # The following must be successful if SOURCE_PROJECT_ID is a project with a valid workflow
   target_project.clone_from_project(SOURCE_PROJECT_ID)
   ```


Fixes [PLT-3337](https://labelbox.atlassian.net/browse/PLT-3337)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?


[PLT-3337]: https://labelbox.atlassian.net/browse/PLT-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables multi-input nodes from any predecessors by relaxing validation rules.
> 
> - Updates `WorkflowValidator.validate_node_connections` to remove the check that all predecessors must be initial nodes; still enforces at least one incoming for non-initial and at least one outgoing for non-terminal nodes
> - Adds integration test `test_workflow_allows_multiple_incoming_from_non_initial_nodes` in `tests/integration/test_workflow.py`
> - Adds unit tests in `tests/unit/test_workflow_utils_validation.py` to verify multiple incoming from non-initial nodes is allowed and that missing incoming connections are still flagged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb13a5f552f08576094a8dd7f099232fc8f941e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->