### PR TITLE
Correct Prompt Issue Tool Name

### DIFF
--- a/docs/labelbox/prompt-issue-tool.rst
+++ b/docs/labelbox/prompt-issue-tool.rst
@@ -1,4 +1,4 @@
-Step Reasoning Tool
+Prompt Issue Tool
 ===============================================================================================
 
 .. automodule:: labelbox.schema.tool_building.prompt_issue_tool


### PR DESCRIPTION
# Description

This PR corrects the _Prompt Issue Tool_ header, previously the title was _"Step Reasoning Tool"_.  The motivation behind this PR is both OpenAI Codex and Claude Code attempt to fix my local copy of the docs anytime they read them.  The correction is not a big deal, but it often distracts the agent and leads to attempts to install dependencies to test their fix.

This PR is not associated with an issue.

## Type of change

- [X] Document change (fix typo **OUTSIDE OF THE EXAMPLES FOLDER**)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the docs page title to match the `labelbox.schema.tool_building.prompt_issue_tool` module.
> 
> - Renames heading from "Step Reasoning Tool" to "Prompt Issue Tool" in `docs/labelbox/prompt-issue-tool.rst`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 950e81702ff524818ce95b940ba9c145a34e7987. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->