### PR TITLE
[PLT-0] remove build-lbox job from publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,19 +26,19 @@ permissions:
   id-token: write
 
 jobs:
-  build-lbox:
-    permissions:
-      actions: read
-      contents: write
-      id-token: write # Needed to access the workflow's OIDC identity.
-      packages: write
-    uses: ./.github/workflows/lbox-publish.yml
-    with:
-      tag: ${{ inputs.tag }}
-      prev_sdk_tag: ${{ inputs.prev_sdk_tag }}
-    secrets: inherit
+#  build-lbox:
+#    permissions:
+#      actions: read
+#      contents: write
+#      id-token: write # Needed to access the workflow's OIDC identity.
+#      packages: write
+#    uses: ./.github/workflows/lbox-publish.yml
+#    with:
+#      tag: ${{ inputs.tag }}
+#      prev_sdk_tag: ${{ inputs.prev_sdk_tag }}
+#    secrets: inherit
   build:
-    needs: ['build-lbox']
+#    needs: ['build-lbox']
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}


### PR DESCRIPTION
# Description

As a stop-gap, remove publishing `lbox` artifacts as part of the core Labelbox SDK - there are issues publishing to PyPi with reusable workflows - https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables publishing of `lbox` artifacts in the SDK release workflow.
> 
> - Comments out the `build-lbox` reusable workflow block in `publish.yml`
> - Removes the `build` job dependency on `build-lbox`
> - Minor formatting fix (newline)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db35caf0bc16ce0cd9276eb17b208cce36bea326. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->