### PR TITLE
Add submit_external_metrics

### DIFF
--- a/libs/labelbox/src/labelbox/__init__.py
+++ b/libs/labelbox/src/labelbox/__init__.py
@@ -22,6 +22,18 @@ from labelbox.schema.data_row_metadata import (
 )
 from labelbox.schema.dataset import Dataset
 from labelbox.schema.enums import AnnotationImportState
+from labelbox.schema.project_sync import (
+    AutoQA,
+    AutoQaStatus,
+    CustomScore,
+    GranularRating,
+    ProjectSyncEntry,
+    ProjectSyncLabel,
+    ProjectSyncResult,
+    ProjectSyncReview,
+    ReviewedBy,
+    SubmittedBy,
+)
 from labelbox.schema.export_task import (
     BufferedJsonConverterOutput,
     ExportTask,

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -37,6 +37,11 @@ from labelbox.schema.export_filters import (
     ProjectExportFilters,
     build_filters,
 )
+from labelbox.schema.project_sync import (
+    ProjectSyncEntry,
+    ProjectSyncResult,
+    _to_gql_input,
+)
 from labelbox.schema.export_params import ProjectExportParams
 from labelbox.schema.export_task import ExportTask
 from labelbox.schema.identifiable import DataRowIdentifier
@@ -1000,6 +1005,39 @@ class Project(DbObject, Updateable, Deletable):
         task_ids = [task["taskId"] for task in tasks]
 
         return CreateBatchesTask(self.client, self.uid, batch_ids, task_ids)
+
+    def sync_external_project(
+        self,
+        entries: List[ProjectSyncEntry],
+    ) -> ProjectSyncResult:
+        """Syncs external project data — labels, metrics, and workflow state.
+
+        Processing is asynchronous. The returned submission ID can be used
+        to track the progress of the sync operation.
+
+        Args:
+            entries: A list of ProjectSyncEntry objects.
+
+        Returns:
+            A ProjectSyncResult containing the submission ID.
+        """
+        mutation_str = """mutation syncExternalProjectPyApi($input: SyncExternalProjectInput!) {
+            syncExternalProject(input: $input) {
+                submissionId
+            }
+        }"""
+
+        params = {
+            "input": {
+                "projectId": self.uid,
+                "entries": [_to_gql_input(e) for e in entries],
+            }
+        }
+
+        response = self.client.execute(mutation_str, params)
+        payload = response["syncExternalProject"]
+
+        return ProjectSyncResult(submission_id=payload["submissionId"])
 
     def create_batches_from_dataset(
         self,

--- a/libs/labelbox/src/labelbox/schema/project_sync.py
+++ b/libs/labelbox/src/labelbox/schema/project_sync.py
@@ -1,0 +1,121 @@
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class AutoQaStatus(str, Enum):
+    Approve = "Approve"
+    Reject = "Reject"
+    Neutral = "Neutral"
+
+
+class SubmittedBy(BaseModel):
+    email: str
+
+
+class CustomScore(BaseModel):
+    name: str
+    value: float
+
+
+class AutoQA(BaseModel):
+    status: AutoQaStatus
+    score: Optional[float] = None
+    feedback: Optional[str] = None
+    custom_scores: Optional[List[CustomScore]] = None
+
+
+class ProjectSyncLabel(BaseModel):
+    submitted_by: SubmittedBy
+    auto_qa: Optional[AutoQA] = None
+    seconds_to_completion: Optional[float] = None
+    submitted_on: Optional[str] = None
+
+
+class ReviewedBy(BaseModel):
+    email: str
+
+
+class GranularRating(BaseModel):
+    score: int
+    comment: Optional[str] = None
+
+
+class ProjectSyncReview(BaseModel):
+    reviewed_by: ReviewedBy
+    rating: Optional[GranularRating] = None
+    custom_scores: Optional[List[CustomScore]] = None
+
+
+class ProjectSyncEntry(BaseModel):
+    task_id: str
+    content_url: Optional[str] = None
+    label: Optional[ProjectSyncLabel] = None
+    review: Optional[ProjectSyncReview] = None
+    queue_type: Optional[str] = None
+
+
+class ProjectSyncResult(BaseModel):
+    submission_id: str
+
+
+def _to_gql_input(entry: ProjectSyncEntry) -> Dict[str, Any]:
+    """Convert a ProjectSyncEntry to a camelCase dict matching the GQL schema."""
+    result: Dict[str, Any] = {"taskId": entry.task_id}
+
+    if entry.content_url is not None:
+        result["contentUrl"] = entry.content_url
+
+    if entry.label is not None:
+        label: Dict[str, Any] = {
+            "submittedBy": {"email": entry.label.submitted_by.email},
+        }
+
+        if entry.label.auto_qa is not None:
+            auto_qa: Dict[str, Any] = {
+                "status": entry.label.auto_qa.status.value,
+            }
+            if entry.label.auto_qa.score is not None:
+                auto_qa["score"] = entry.label.auto_qa.score
+            if entry.label.auto_qa.feedback is not None:
+                auto_qa["feedback"] = entry.label.auto_qa.feedback
+            if entry.label.auto_qa.custom_scores is not None:
+                auto_qa["customScores"] = [
+                    {"name": cs.name, "value": cs.value}
+                    for cs in entry.label.auto_qa.custom_scores
+                ]
+            label["autoQA"] = auto_qa
+
+        if entry.label.seconds_to_completion is not None:
+            label["secondsToCompletion"] = entry.label.seconds_to_completion
+
+        if entry.label.submitted_on is not None:
+            label["submittedOn"] = entry.label.submitted_on
+
+        result["label"] = label
+    elif "label" in entry.model_fields_set:
+        result["label"] = None
+
+    if entry.review is not None:
+        review: Dict[str, Any] = {
+            "reviewedBy": {"email": entry.review.reviewed_by.email},
+        }
+        if entry.review.rating is not None:
+            rating: Dict[str, Any] = {"score": entry.review.rating.score}
+            if entry.review.rating.comment is not None:
+                rating["comment"] = entry.review.rating.comment
+            review["rating"] = rating
+        if entry.review.custom_scores is not None:
+            review["customScores"] = [
+                {"name": cs.name, "value": cs.value}
+                for cs in entry.review.custom_scores
+            ]
+        result["review"] = review
+
+    if entry.queue_type is not None:
+        result["queueType"] = entry.queue_type
+    elif "queue_type" in entry.model_fields_set:
+        result["queueType"] = None
+
+    return result


### PR DESCRIPTION
# Description

Allow syncing external metrics to projects

Example usage:
```
project = client.get_project(PROJECT_ID)

# Build entries using the new schema# Build entries using the new schema
entries = [
    # Entry 1: full label + review with rating, done queue
    lb.ProjectSyncEntry(
        task_id="test-task-031",
        content_url="https://storage.example.com/data/test-task-031.json",
        label=lb.ProjectSyncLabel(
            submitted_by=lb.SubmittedBy(email="user@email.com"),
            auto_qa=lb.AutoQA(
                status=lb.AutoQaStatus.Approve,
                score=0.92,
                feedback="Looks good",
                custom_scores=[
                    lb.CustomScore(name="accuracy", value=0.95),
                    lb.CustomScore(name="relevance", value=0.88),
                ],
            ),
            seconds_to_completion=45.0,
            submitted_on="2025-06-15T12:00:00.000Z",
        ),
        review=lb.ProjectSyncReview(
            reviewed_by=lb.ReviewedBy(email="user@email.com"),
            rating=lb.GranularRating(score=5, comment="Excellent work"),
        ),
        queue_type="DONE_QUEUE",
    ),
    # Entry 2: label + review without rating, done queue
    lb.ProjectSyncEntry(
        task_id="test-task-032",
        label=lb.ProjectSyncLabel(
            submitted_by=lb.SubmittedBy(email="user@email.com"),
            seconds_to_completion=30.0,
        ),
        review=lb.ProjectSyncReview(
            reviewed_by=lb.ReviewedBy(email="user@email.com"),
        ),
        queue_type="DONE_QUEUE",
    ),
    # Entry 3: label with rejected autoQA, no review, no content_url
    lb.ProjectSyncEntry(
        task_id="test-task-033",
        label=lb.ProjectSyncLabel(
            submitted_by=lb.SubmittedBy(email="user@email.com"),
            auto_qa=lb.AutoQA(
                status=lb.AutoQaStatus.Reject,
                score=0.3,
                feedback="Multiple errors found",
            ),
            seconds_to_completion=120.5,
        ),
    ),
]

print(f"Syncing {len(entries)} entries...")
result = project.sync_external_project(entries)
print(f"  submissionId={result.submission_id}")
print("Done!")
```



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new GraphQL mutation path and input serialization for project data sync; risk is mainly schema mismatch/serialization edge cases (e.g., optional vs explicit null) causing failed or incorrect syncs.
> 
> **Overview**
> Adds a new `Project.sync_external_project()` method that calls a `syncExternalProject` GraphQL mutation to asynchronously push external label/review metadata (including AutoQA status/scores and queue state) into a project and returns a `submission_id` for tracking.
> 
> Introduces a new `project_sync` pydantic schema (`ProjectSyncEntry`, `ProjectSyncLabel/Review`, `AutoQA`, etc.) plus a `_to_gql_input` serializer (including explicit `null` support), and re-exports these types from `labelbox.__init__` for SDK users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0b166db84349e2b65093d23ab0570c70d30192d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->