### PR TITLE
[PLT-0] Fix VideoClassificationText

### DIFF
--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/classification.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/classification.py
@@ -223,9 +223,27 @@ class NDVideoText(BaseModel):
       {"name": "...", "answer": [{"value": "text", "frames": [{"start": 1, "end": 5}]}], ...}
     """
 
-    name: str
+    name: Optional[str] = None
+    schema_id: Optional[str] = Field(default=None, alias="schemaId")
     answer: List[NDVideoTextAnswer]
-    dataRow: Dict[str, str]
+    data_row: DataRow = Field(alias="dataRow")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="after")
+    def must_set_one(self):
+        if not self.name and not self.schema_id:
+            raise ValueError("Schema id or name are not set. Set either one.")
+        return self
+
+    @model_serializer(mode="wrap")
+    def serialize_model(self, handler):
+        res = handler(self)
+        if "name" in res and res["name"] is None:
+            res.pop("name")
+        if "schemaId" in res and res["schemaId"] is None:
+            res.pop("schemaId")
+        return res
 
     @classmethod
     def from_video_text_group(
@@ -235,14 +253,10 @@ class NDVideoText(BaseModel):
         data: "GenericDataRowData",
     ) -> "NDVideoText":
         first = annotation_group[0]
-        data_row = {}
-        if data.global_key:
-            data_row["globalKey"] = data.global_key
-        elif data.uid:
-            data_row["id"] = data.uid
         return cls(
             name=first.name,
-            dataRow=data_row,
+            schema_id=first.feature_schema_id,
+            data_row=DataRow(id=data.uid, global_key=data.global_key),
             answer=[
                 NDVideoTextAnswer(value=text_val, frames=ranges)
                 for text_val, ranges in frame_ranges_by_text.items()

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/classification.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/classification.py
@@ -209,6 +209,47 @@ class NDRadioSubclass(NDAnswer):
         )
 
 
+class NDVideoTextAnswer(BaseModel):
+    value: str
+    frames: List[Dict[str, int]]
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class NDVideoText(BaseModel):
+    """Video text classification with per-segment text values and frame ranges.
+
+    Produces NDJSON like:
+      {"name": "...", "answer": [{"value": "text", "frames": [{"start": 1, "end": 5}]}], ...}
+    """
+
+    name: str
+    answer: List[NDVideoTextAnswer]
+    dataRow: Dict[str, str]
+
+    @classmethod
+    def from_video_text_group(
+        cls,
+        annotation_group: List["VideoClassificationAnnotation"],
+        frame_ranges_by_text: Dict[str, List[Dict[str, int]]],
+        data: "GenericDataRowData",
+    ) -> "NDVideoText":
+        first = annotation_group[0]
+        data_row = {}
+        if data.global_key:
+            data_row["globalKey"] = data.global_key
+        elif data.uid:
+            data_row["id"] = data.uid
+        return cls(
+            name=first.name,
+            dataRow=data_row,
+            answer=[
+                NDVideoTextAnswer(value=text_val, frames=ranges)
+                for text_val, ranges in frame_ranges_by_text.items()
+            ],
+        )
+
+
 class NDPromptTextSubclass(NDAnswer):
     answer: str
 
@@ -517,6 +558,7 @@ NDChecklist.model_rebuild()
 NDRadioSubclass.model_rebuild()
 NDRadio.model_rebuild()
 NDText.model_rebuild()
+NDVideoText.model_rebuild()
 NDPromptText.model_rebuild()
 NDTextSubclass.model_rebuild()
 

--- a/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
+++ b/libs/labelbox/src/labelbox/data/serialization/ndjson/label.py
@@ -31,6 +31,7 @@ from ...annotation_types.temporal import (
 )
 from .temporal import create_temporal_ndjson_classifications
 from labelbox.types import DocumentRectangle, DocumentEntity
+from ...annotation_types.classification.classification import Text
 from .classification import (
     NDChecklistSubclass,
     NDClassification,
@@ -39,6 +40,7 @@ from .classification import (
     NDPromptClassificationType,
     NDPromptText,
     NDRadioSubclass,
+    NDVideoText,
 )
 from .metric import NDConfusionMatrixMetric, NDMetricAnnotation, NDScalarMetric
 from .mmc import NDMessageTask
@@ -61,6 +63,7 @@ AnnotationType = Union[
     NDRelationship,
     NDPromptText,
     NDMessageTask,
+    NDVideoText,
 ]
 
 
@@ -142,11 +145,33 @@ class NDLabel(BaseModel):
                 yield NDObject.from_common(annotation=annot, data=label.data)
 
         for annotation_group in video_annotations.values():
-            segment_frame_ranges = cls._get_segment_frame_ranges(
-                annotation_group
-            )
             if isinstance(annotation_group[0], VideoClassificationAnnotation):
                 annotation = annotation_group[0]
+
+                if isinstance(annotation.value, Text):
+                    by_text = defaultdict(list)
+                    for ann in annotation_group:
+                        by_text[ann.value.answer].append(ann)
+
+                    frame_ranges_by_text = {}
+                    for text_val, anns in sorted(
+                        by_text.items(),
+                        key=lambda x: min(a.frame for a in x[1]),
+                    ):
+                        ranges = [
+                            {"start": s, "end": e}
+                            for s, e in cls._get_segment_frame_ranges(anns)
+                        ]
+                        frame_ranges_by_text[text_val] = ranges
+
+                    yield NDVideoText.from_video_text_group(
+                        annotation_group, frame_ranges_by_text, label.data
+                    )
+                    continue
+
+                segment_frame_ranges = cls._get_segment_frame_ranges(
+                    annotation_group
+                )
                 frames_data = []
                 for frames in segment_frame_ranges:
                     frames_data.append({"start": frames[0], "end": frames[-1]})
@@ -154,6 +179,9 @@ class NDLabel(BaseModel):
                 yield NDClassification.from_common(annotation, label.data)
 
             elif isinstance(annotation_group[0], VideoObjectAnnotation):
+                segment_frame_ranges = cls._get_segment_frame_ranges(
+                    annotation_group
+                )
                 segments = []
                 for start_frame, end_frame in segment_frame_ranges:
                     segment = []

--- a/libs/labelbox/tests/data/serialization/ndjson/test_video.py
+++ b/libs/labelbox/tests/data/serialization/ndjson/test_video.py
@@ -635,6 +635,93 @@ def test_video_classification_global_subclassifications():
     assert res == [expected_first_annotation, expected_second_annotation]
 
 
+def test_video_classification_text_produces_ndjson_with_frames():
+    """VideoClassificationAnnotation + Text serializes with answer as a list of {value, frames}."""
+    label = Label(
+        data=GenericDataRowData(global_key="sample-video-text"),
+        annotations=[
+            VideoClassificationAnnotation(
+                name="free_text",
+                frame=9,
+                segment_index=0,
+                value=Text(answer="Looks like a hungry big cat"),
+            ),
+            VideoClassificationAnnotation(
+                name="free_text",
+                frame=15,
+                segment_index=0,
+                value=Text(answer="Looks like a hungry big cat"),
+            ),
+            VideoClassificationAnnotation(
+                name="free_text",
+                frame=40,
+                segment_index=1,
+                value=Text(answer="It's getting closer!"),
+            ),
+            VideoClassificationAnnotation(
+                name="free_text",
+                frame=50,
+                segment_index=1,
+                value=Text(answer="It's getting closer!"),
+            ),
+        ],
+    )
+    serialized = list(NDJsonConverter.serialize([label]))
+    free_text_rows = [r for r in serialized if r.get("name") == "free_text"]
+    assert len(free_text_rows) == 1
+
+    row = free_text_rows[0]
+    assert row["dataRow"] == {"globalKey": "sample-video-text"}
+    assert "answer" in row
+    answer = row["answer"]
+    assert isinstance(answer, list)
+    assert len(answer) == 2
+
+    by_value = {a["value"]: a for a in answer}
+    assert "Looks like a hungry big cat" in by_value
+    assert "It's getting closer!" in by_value
+    assert by_value["Looks like a hungry big cat"]["frames"] == [
+        {"start": 9, "end": 15}
+    ]
+    assert by_value["It's getting closer!"]["frames"] == [
+        {"start": 40, "end": 50}
+    ]
+
+
+def test_video_classification_text_single_text_across_frames():
+    """VideoClassificationAnnotation + Text with same text across all frames."""
+    label = Label(
+        data=GenericDataRowData(global_key="sample-video-single-text"),
+        annotations=[
+            VideoClassificationAnnotation(
+                name="free_text_per_frame",
+                frame=9,
+                segment_index=0,
+                value=Text(answer="sample text"),
+            ),
+            VideoClassificationAnnotation(
+                name="free_text_per_frame",
+                frame=15,
+                segment_index=0,
+                value=Text(answer="sample text"),
+            ),
+        ],
+    )
+    serialized = list(NDJsonConverter.serialize([label]))
+    free_text_rows = [
+        r for r in serialized if r.get("name") == "free_text_per_frame"
+    ]
+    assert len(free_text_rows) == 1
+
+    row = free_text_rows[0]
+    assert row["dataRow"] == {"globalKey": "sample-video-single-text"}
+    answer = row["answer"]
+    assert isinstance(answer, list)
+    assert len(answer) == 1
+    assert answer[0]["value"] == "sample text"
+    assert answer[0]["frames"] == [{"start": 9, "end": 15}]
+
+
 def test_video_classification_nesting_bbox():
     bbox_annotation = [
         VideoObjectAnnotation(


### PR DESCRIPTION
# Description

## Summary

Fixes NDJSON serialization for `VideoClassificationAnnotation` with `Text` values. Previously, frame information and secondary text segments were silently dropped -- only the first annotation's text was emitted as a plain string with no frames. After this fix, the output includes per-segment text values with their frame ranges, matching the format produced by `TemporalClassificationText`.

## Problem

```python
annotations = [
    lb_types.VideoClassificationAnnotation(
        name="free_text_per_frame", frame=9, segment_index=0,
        value=lb_types.Text(answer="sample text 1"),
    ),
    lb_types.VideoClassificationAnnotation(
        name="free_text_per_frame", frame=15, segment_index=0,
        value=lb_types.Text(answer="sample text 1"),
    ),
    lb_types.VideoClassificationAnnotation(
        name="free_text_per_frame", frame=40, segment_index=0,
        value=lb_types.Text(answer="sample text 2"),
    ),
    lb_types.VideoClassificationAnnotation(
        name="free_text_per_frame", frame=50, segment_index=0,
        value=lb_types.Text(answer="sample text 2"),
    ),
]
```

**Before** -- frames lost, second text segment dropped:
```json
{
  "name": "free_text_per_frame",
  "answer": "sample text 1",
  "uuid": "73a61cfa-...",
  "dataRow": {"globalKey": "my-video-global-key"}
}
```

**After** -- all segments and frame ranges preserved:
```json
{
  "name": "free_text_per_frame",
  "answer": [
    {"value": "sample text 1", "frames": [{"start": 9, "end": 15}]},
    {"value": "sample text 2", "frames": [{"start": 40, "end": 50}]}
  ],
  "dataRow": {"globalKey": "my-video-global-key"}
}
```

## Changes

- **`classification.py`**: Added `NDVideoText` and `NDVideoTextAnswer` classes (standalone `BaseModel`, no dependency on temporal pipeline).
- **`label.py`**: Added a `Text` branch in `_create_video_annotations` that groups annotations by text value, computes segment-aware frame ranges, and yields `NDVideoText`.
- **`test_video.py`**: Added two tests covering multi-text and single-text scenarios.

## Scope

- Only affects `VideoClassificationAnnotation` + `Text`. Video Radio, Checklist, and object annotations are unchanged.
- Non-video text annotations are unchanged.
- No breaking changes to the Python API -- users keep using `VideoClassificationAnnotation(value=Text(...))`.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the emitted NDJSON shape for video `Text` classifications from a single string to a structured list with frame ranges, which may impact downstream parsers expecting the old format. Scope is limited to `VideoClassificationAnnotation` + `Text` and is covered by new tests.
> 
> **Overview**
> Fixes video free-text classification export so NDJSON no longer drops frame information or later text segments.
> 
> `VideoClassificationAnnotation` with `Text` is now serialized as a single row whose `answer` is a list of `{value, frames}` entries (computed by grouping annotations by text value and segment-aware frame ranges) via a new `NDVideoText` model, with tests added for multi-text and single-text cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcc1107d5b1c2de5d5766610a844a1ca91233bb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->