### PR TITLE
[PLT-0] Remove GCP integration tests

### DIFF
--- a/libs/labelbox/tests/integration/test_delegated_access.py
+++ b/libs/labelbox/tests/integration/test_delegated_access.py
@@ -8,7 +8,6 @@ import pytest
 from labelbox import Client
 from labelbox.schema.iam_integration import (
     AwsIamIntegrationSettings,
-    GcpIamIntegrationSettings,
     AzureIamIntegrationSettings,
 )
 from ..conftest import create_dataset_robust
@@ -37,23 +36,6 @@ def aws_integration(
     settings = AwsIamIntegrationSettings(
         role_arn="arn:aws:iam::000000000000:role/temporary",
         read_bucket="test-bucket",
-    )
-    integration = client.get_organization().create_iam_integration(
-        name=test_integration_name,
-        settings=settings,
-    )
-    yield integration
-    # Proper cleanup using delete mutation
-    delete_iam_integration(client, integration.uid)
-
-
-@pytest.fixture
-def gcp_integration(
-    client, test_integration_name
-) -> Optional["IAMIntegration"]:
-    """Creates a test GCP integration and cleans it up after the test."""
-    settings = GcpIamIntegrationSettings(
-        read_bucket="gs://test-bucket",
     )
     integration = client.get_organization().create_iam_integration(
         name=test_integration_name,
@@ -103,23 +85,6 @@ def test_create_aws_integration(client, test_integration_name):
         delete_iam_integration(client, integration.uid)
 
 
-def test_create_gcp_integration(client, test_integration_name):
-    """Test creating a GCP IAM integration."""
-    settings = GcpIamIntegrationSettings(read_bucket="gs://test-bucket")
-    integration = client.get_organization().create_iam_integration(
-        name=test_integration_name, settings=settings
-    )
-
-    try:
-        assert integration.name == test_integration_name
-        assert integration.provider == "GCP"
-        assert isinstance(integration.settings, GcpIamIntegrationSettings)
-        assert integration.settings.read_bucket == settings.read_bucket
-    finally:
-        # Ensure cleanup even if assertions fail
-        delete_iam_integration(client, integration.uid)
-
-
 def test_create_azure_integration(client, test_integration_name):
     """Test creating an Azure IAM integration."""
     settings = AzureIamIntegrationSettings(
@@ -160,38 +125,6 @@ def test_update_aws_integration(client, test_integration_name):
         new_settings = AwsIamIntegrationSettings(
             role_arn="arn:aws:iam::111111111111:role/updated",
             read_bucket="updated-bucket",
-        )
-        integration.update(
-            name=f"updated-{test_integration_name}", settings=new_settings
-        )
-
-        # Verify update - find the specific integration by ID
-        updated_integration = None
-        for iam_int in client.get_organization().get_iam_integrations():
-            if iam_int.uid == integration.uid:
-                updated_integration = iam_int
-                break
-
-        assert updated_integration is not None
-        assert updated_integration.name == f"updated-{test_integration_name}"
-        # Note: Settings may not be returned immediately after update
-    finally:
-        # Ensure cleanup even if assertions fail
-        delete_iam_integration(client, integration.uid)
-
-
-def test_update_gcp_integration(client, test_integration_name):
-    """Test updating a GCP IAM integration."""
-    # Create initial integration
-    settings = GcpIamIntegrationSettings(read_bucket="gs://test-bucket")
-    integration = client.get_organization().create_iam_integration(
-        name=test_integration_name, settings=settings
-    )
-
-    try:
-        # Update integration
-        new_settings = GcpIamIntegrationSettings(
-            read_bucket="gs://updated-bucket"
         )
         integration.update(
             name=f"updated-{test_integration_name}", settings=new_settings


### PR DESCRIPTION
# Description

- Remove `test_create_gcp_integration`, `test_update_gcp_integration`, and the unused `gcp_integration` fixture from `test_delegated_access.py`
- These tests create GCP service accounts via the backend on every CI run, but the accounts are never deleted from GCP (only the Labelbox integration record is removed), causing cumulative quota exhaustion (Service accounts per project)
- The equivalent AWS and Azure integration tests cover the same SDK code paths (create_iam_integration, update, response parsing, cleanup)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only deletes integration tests and related imports/fixtures, with no production code changes. Main impact is reduced automated coverage for the GCP IAM integration path.
> 
> **Overview**
> Removes GCP IAM integration coverage from `test_delegated_access.py` by deleting the `gcp_integration` fixture and the `test_create_gcp_integration`/`test_update_gcp_integration` tests, along with the `GcpIamIntegrationSettings` import.
> 
> AWS and Azure IAM integration tests remain unchanged, avoiding CI-side creation of GCP service accounts that weren’t being cleaned up.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cf577dac2ee5d65592c00881ee1301cbafe6f40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->