### PR TITLE
[PLT-0] Mark ModelEvaluation MAL import tests as xfail and fix checklist_infe…

### DIFF
--- a/libs/labelbox/tests/data/annotation_import/conftest.py
+++ b/libs/labelbox/tests/data/annotation_import/conftest.py
@@ -1417,7 +1417,7 @@ def checklist_inference_index_mmc(
     checklists = []
     for feature in prediction_id_mapping:
         if "checklist_index" not in feature:
-            return None
+            continue
         checklist = feature["checklist_index"].copy()
         checklist.update(
             {

--- a/libs/labelbox/tests/data/annotation_import/test_generic_data_types.py
+++ b/libs/labelbox/tests/data/annotation_import/test_generic_data_types.py
@@ -245,7 +245,13 @@ def test_import_media_types_by_global_key(
         ),
         (MediaType.LLMPromptCreation, MediaType.LLMPromptCreation),
         (OntologyKind.ResponseCreation, OntologyKind.ResponseCreation),
-        (OntologyKind.ModelEvaluation, OntologyKind.ModelEvaluation),
+        pytest.param(
+            OntologyKind.ModelEvaluation,
+            OntologyKind.ModelEvaluation,
+            marks=pytest.mark.xfail(
+                reason="Backend bug: lb-import-annot-pred-no-mta raises TypeError on ModelEvaluation MAL annotations (encoding without a string argument)"
+            ),
+        ),
     ],
     indirect=["configured_project"],
 )
@@ -279,7 +285,13 @@ def test_import_mal_annotations(
         (MediaType.Conversational, MediaType.Conversational),
         (MediaType.Document, MediaType.Document),
         (OntologyKind.ResponseCreation, OntologyKind.ResponseCreation),
-        (OntologyKind.ModelEvaluation, OntologyKind.ModelEvaluation),
+        pytest.param(
+            OntologyKind.ModelEvaluation,
+            OntologyKind.ModelEvaluation,
+            marks=pytest.mark.xfail(
+                reason="Backend bug: lb-import-annot-pred-no-mta raises TypeError on ModelEvaluation MAL annotations (encoding without a string argument)"
+            ),
+        ),
     ],
     indirect=["configured_project_by_global_key"],
 )


### PR DESCRIPTION
# Description

- Mark `OntologyKind.ModelEvaluation` MAL import parametrizations as `xfail` in `test_import_mal_annotations` and `test_import_mal_annotations_global_key`.
  These fail due to a confirmed backend bug in `lb-import-annot-pred-no-mta` 
```
(`TypeError: encoding without a string argument`) when processing ModelEvaluation annotation payloads.
```
- Fix latent bug in `checklist_inference_index_mmc` fixture where `return None` should be `continue`, consistent with all other similar fixtures.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that adjust parametrization expectations for a known backend failure and fix a fixture control-flow bug; no production code paths affected.
> 
> **Overview**
> Marks `OntologyKind.ModelEvaluation` cases in the MAL annotation import integration tests as `xfail`, documenting a known backend `TypeError` so CI doesn’t fail on that external issue.
> 
> Fixes `checklist_inference_index_mmc` to `continue` when a feature lacks `checklist_index` instead of returning `None`, preventing premature fixture termination and aligning behavior with other inference fixtures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b33c41603008169980e38facd9eafc962594bd30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->