### PR TITLE
[PLT-0] Fix flaky test_get_user_groups_with_creation_deletion

### DIFF
--- a/libs/labelbox/tests/integration/schema/test_user_group.py
+++ b/libs/labelbox/tests/integration/schema/test_user_group.py
@@ -194,33 +194,40 @@ def test_update_user_group(user_group):
 
 def test_get_user_groups_with_creation_deletion(client):
     """Test user group creation, retrieval, and deletion."""
-    # Get initial count
-    initial_groups = list(UserGroup.get_user_groups(client))
-    initial_count = len(initial_groups)
-
-    # Create a new group
     group_name = f"{data.name()}_{int(time.time())}"
     user_group = UserGroup(client)
     user_group.name = group_name
     user_group.color = UserGroupColor.CYAN
     user_group.create()
 
-    # Verify the group was created
-    updated_groups = list(UserGroup.get_user_groups(client))
-    assert len(updated_groups) == initial_count + 1
-
-    # Find our group
-    our_group = next((g for g in updated_groups if g.name == group_name), None)
-    assert our_group is not None
-    assert our_group.id == user_group.id
+    # Verify the created group appears in the listing (retry for eventual
+    # consistency; count-based checks are racy with parallel test workers).
+    our_group = None
+    for _ in range(5):
+        updated_groups = list(UserGroup.get_user_groups(client))
+        our_group = next(
+            (g for g in updated_groups if g.id == user_group.id), None
+        )
+        if our_group is not None:
+            break
+        time.sleep(2)
+    assert (
+        our_group is not None
+    ), f"Created group {user_group.id} not found in group listing"
+    assert our_group.name == group_name
 
     # Delete the group
     user_group.delete()
 
-    # Verify the group was deleted
-    final_groups = list(UserGroup.get_user_groups(client))
-    assert len(final_groups) == initial_count
-    assert len(user_group.members) == 0  # V3 uses members
+    # Verify the deleted group no longer appears in the listing
+    gone = False
+    for _ in range(5):
+        final_groups = list(UserGroup.get_user_groups(client))
+        if not any(g.id == user_group.id for g in final_groups):
+            gone = True
+            break
+        time.sleep(2)
+    assert gone, f"Deleted group {user_group.id} still appears in group listing"
 
 
 def test_update_user_group_members_projects(user_group, client, project_pack):


### PR DESCRIPTION
# Description

Replace count-based assertions with ID-membership checks and add retry loops for eventual consistency. Count comparisons are unreliable when parallel test workers concurrently modify user groups.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to an integration test, replacing racy count-based assertions with ID-based membership checks and small retry loops for eventual consistency.
> 
> **Overview**
> Fixes flakiness in `test_get_user_groups_with_creation_deletion` by removing list-size assertions that break under parallel test runs.
> 
> The test now retries `UserGroup.get_user_groups` and asserts **presence/absence by group `id`**, waiting briefly for eventual consistency after create/delete.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f39274c3cd08839637629aa6e69e9e88bafd940c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->