### PR TITLE
[PLT-0] Fix flaky test_request_labeling_service_moe_project

### DIFF
--- a/libs/labelbox/tests/integration/conftest.py
+++ b/libs/labelbox/tests/integration/conftest.py
@@ -746,15 +746,25 @@ def live_chat_evaluation_project(client, rand_gen):
 def live_chat_evaluation_project_with_batch(
     client,
     rand_gen,
-    live_chat_evaluation_project,
     offline_conversational_data_row,
 ):
     project_name = f"test-model-evaluation-project-{rand_gen(str)}"
-    project = client.create_model_evaluation_project(name=project_name)
+
+    # Retry to handle transient ER_LOCK_DEADLOCK from the backend when
+    # multiple parallel workers create model-evaluation projects.
+    project = None
+    for attempt in range(3):
+        try:
+            project = client.create_model_evaluation_project(name=project_name)
+            break
+        except Exception:
+            if attempt == 2:
+                raise
+            time.sleep(2 * (attempt + 1))
 
     project.create_batch(
         rand_gen(str),
-        [offline_conversational_data_row.uid],  # sample of data row objects
+        [offline_conversational_data_row.uid],
     )
 
     yield project


### PR DESCRIPTION
# Description

Remove unused live_chat_evaluation_project dependency from `live_chat_evaluation_project_with_batch` fixture and add retry logic for transient ER_LOCK_DEADLOCK errors. The redundant dependency triggered an extra `create_model_evaluation_project` call that increased deadlock probability.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture changes add retry/backoff around project creation, which could slightly increase test runtime but doesn’t affect production code paths.
> 
> **Overview**
> Reduces flakiness in `test_request_labeling_service_moe_project` setup by removing the unused `live_chat_evaluation_project` dependency from `live_chat_evaluation_project_with_batch`, avoiding an extra `create_model_evaluation_project` call.
> 
> Adds a small retry-with-sleep loop around `client.create_model_evaluation_project` to handle transient `ER_LOCK_DEADLOCK` errors when tests run in parallel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ab3633dc6722ecf5c79f02b572935d75b4f65d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->