### PR TITLE
Documentation Cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ As a note, the repository is organized as a monorepo, with each module residing 
 - [General Guidelines](#general-guidelines)
 - [Branches and Tags](#branches-and-tags)
 - [Release Steps](#release-steps)
-- [Github Workflows](#github-workflows)
+- [GitHub Workflows](#github-workflows)
 - [General Prerequisites](#general-prerequisites)
 - [Setup and Building](#setup-and-building)
 - [Testing](#testing)
@@ -17,10 +17,10 @@ As a note, the repository is organized as a monorepo, with each module residing 
 
 ## General Guidelines
 
-* For feature requests, we recommend consulting with [Labelbox Support](https://docs.labelbox.com/docs/contacting-customer-support) support or creating a [Github Issue](https://github.com/Labelbox/labelbox-python/issues).
+* For feature requests, we recommend consulting with [Labelbox Support](https://docs.labelbox.com/docs/contacting-customer-support) support or creating a [GitHub Issue](https://github.com/Labelbox/labelbox-python/issues).
 * Ensure that any new libraries added are compliant with the Apache license that governs the repository.
 * Ensure that you update any relevant docstrings and comments within the code you may add or change.
-* Ensure that any new Python components, such as classes, packages, or methods, that need to feature in the Labelbox documentation have entries in the file [index.rst](https://github.com/Labelbox/labelbox-python/blob/develop/docs/source/index.rst).
+* Ensure that any new Python components, such as classes, packages, or methods, that need to feature in the Labelbox documentation have entries in the file [index.rst](https://github.com/Labelbox/labelbox-python/blob/develop/docs/labelbox/index.rst).
 
 ## Branches and Tags
 
@@ -32,17 +32,17 @@ As a note, the repository is organized as a monorepo, with each module residing 
 
 Your contributions will be released as soon as it is approved and merged into the `develop` branch. Please consult the [Labelbox](https://docs.labelbox.com/docs/contacting-customer-support) team for if you need a more specific timeframe of when your contributions may be released.
 
-## Github Workflows
+## GitHub Workflows
 
 ![workflow](./docs/github-workflow.svg)
 
-The above shows the Github workflows that currently exist in the repository.
+The above shows the GitHub workflows that currently exist in the repository.
 
-* Github Branch Workflow
+* GitHub Branch Workflow
   * When you push to a branch, it will create a build of the SDK that runs tests against **staging**. It will publish the build to `test.pypi.org` which can be downloaded for testing. Also, a docker image is built which can be used for testing as it has the SDK installed.
-* Github Develop Workflow
+* GitHub Develop Workflow
   * When you push to a `develop` (main branch), it will create a build of the SDK that runs tests against **staging**. It will publish the build to `test.pypi.org` which can be downloaded for testing. Also, a docker image is built which can be used for testing as it has the SDK installed. This docker image is tagged with `develop`.
-* Github Publish Workflow
+* GitHub Publish Workflow
   * When you run the publish workflow, it will create a build of the SDK that runs tests against **production**. It will publish the build to `pypi.org` which is what consumers of the SDK will normally use. Also, a docker image is built which can be used for testing as it has the SDK installed. This docker image is tagged with `latest`.
 
 ## General Prerequisites

--- a/README.md
+++ b/README.md
@@ -9,30 +9,34 @@
 [![Open Issues](https://img.shields.io/github/issues-raw/labelbox/labelbox-python)](https://github.com/labelbox/labelbox-python/issues)
 [![Changelog](https://img.shields.io/badge/Changelog-Recent%20Updates-blue.svg)](https://docs.labelbox.com/changelog)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Twitter Follow](https://img.shields.io/twitter/follow/labelbox.svg?style=social&label=Follow)](https://twitter.com/labelbox)
+[![X Follow](https://img.shields.io/twitter/follow/labelbox.svg?style=social&label=Follow)](https://x.com/labelbox)
 [![LinkedIn Follow](https://img.shields.io/badge/Follow-LinkedIn-blue.svg?style=flat&logo=linkedin)](https://www.linkedin.com/company/labelbox/)
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/labelbox)](https://img.shields.io/pypi/pyversions/labelbox)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
 # Labelbox
+
 With Labelbox, enterprises can easily curate and annotate data, generate high-quality human feedback data for computer vision and language models, evaluate and improve model performance, and automate tasks by seamlessly combining AI and human-centric workflows. The academic and research community also relies on Labelbox for cutting-edge AI research and experimentation.
 
 Visit [Labelbox](http://labelbox.com/) for more information.
 
 ## Table of Contents
+
 - [Quick Start](#quick-start)
 - [Contribution Guidelines](#contribution-guidelines)
-- [Develop with AI Assistance](#develop-with-ai-assistance)
 - [Documentation](#documentation)
 - [Jupyter Notebooks](#jupyter-notebooks)
+- [Provenance](#provenance)
 
 ## Quick Start
    
 ### Sign Up
+
 If you haven't already, create a free account at [Labelbox](http://app.labelbox.com/).
 
 ### Generate an API key
-Log into Labelbox and navigate to [Account > API Keys](https://docs.labelbox.com/docs/create-an-api-key) to generate an API key. 
+
+Log into Labelbox and navigate to [Account > API Keys](https://docs.labelbox.com/reference/create-api-key) to generate an API key. 
 
 ### Install
 
@@ -64,12 +68,14 @@ task = dataset.create_data_rows(data_rows)
 task.wait_till_done()
 ```
 
-You should be set! Running the snippet above should create a dataset called `Test Dataset` with its content being `My First Data Row`. You can log into [Labelbox](http://labelbox.com/) to verify this. If you have any issues please file a Github Issue or contact [Labelbox Support](https://docs.labelbox.com/docs/contacting-customer-support) directly. For more advanced examples and information on the SDK, see [Documentation](#documentation) below.
+You should be set! Running the snippet above should create a dataset called `Test Dataset` with its content being `My First Data Row`. You can log into [Labelbox](http://labelbox.com/) to verify this. If you have any issues please file a GitHub Issue or contact [Labelbox Support](https://docs.labelbox.com/docs/contacting-customer-support) directly. For more advanced examples and information on the SDK, see [Documentation](#documentation) below.
 
 ## Contribution Guidelines
+
 We encourage anyone to contribute to this repository to help improve it. Please refer to [Contributing Guide](CONTRIBUTING.md) for detailed information on how to contribute. This guide also includes instructions for how to build and run the SDK locally.
 
 ## Documentation
+
 The SDK is well-documented to help developers get started quickly and use the SDK effectively. Here are links to that documentation:
 
 - [Labelbox Official Documentation](https://docs.labelbox.com/docs/overview)
@@ -77,13 +83,15 @@ The SDK is well-documented to help developers get started quickly and use the SD
 - [Python SDK Reference](https://labelbox-python.readthedocs.io/en/latest/)
 
 ## Jupyter Notebooks
+
 We have samples in the `examples` directory to help you get started with the SDK.
 
 Make sure your notebook will use your source code:
+
 1. `ipython profile create`
 2. `ipython locate` - will show where the config file is. This is the config file used by the Jupyter server, since it runs via ipython
 3. Open the file (this should be ipython_config.py and it is usually located in ~/.ipython/profile_default) and add the following line of code: 
-```
+```python
 c.InteractiveShellApp.exec_lines = [
   'import sys; sys.path.insert(0, "<labelbox-python root folder>")'
 ]
@@ -99,7 +107,7 @@ By using the [SLSA framework's official verifier](https://github.com/slsa-framew
 
 Example of usage for the v.3.72.2 release wheel:
 
-```
+```bash
 export VERSION=3.72.2 # sdk release version 
 export TAG=v.3.72.2 # github tag
 pip download --no-deps labelbox==${VERSION}

--- a/libs/labelbox/README.md
+++ b/libs/labelbox/README.md
@@ -48,7 +48,7 @@ rye run unit
 ```bash
 LABELBOX_TEST_API_KEY="YOUR_API_TEST_KEY" LABELBOX_TEST_ENVIRON="prod" rye run integration
 ```
-For more info on how to get a `LABELBOX_TEST_API_KEY` [Labelbox API key docs](https://labelbox.helpdocs.io/docs/api/getting-started). 
+For more info on how to get a `LABELBOX_TEST_API_KEY` [Labelbox API key docs](https://docs.labelbox.com/reference/create-api-key). 
 
 **Integration tests by default will run against your account that you provide an API Key from and modify its data. If you want to run integration tests, without it impacting your existing account, create an additional account using a secondary e-mail on [Labelbox](https://labelbox.com). Free accounts are sufficent for integration testing purposes.**
 

--- a/libs/lbox-clients/README.md
+++ b/libs/lbox-clients/README.md
@@ -4,6 +4,4 @@ This is an example module which can be cloned and reused to develop modules unde
 
 ## Module Status: Experimental
 
-**TLDR: This module may be removed or altered at any given time and there is no offical support.**
-
-Please see [here](https://docs.labelbox.com/docs/product-release-phases) for the formal definition of `Experimental`.
+<p>This module may be removed or altered at any given time and there is no offical support.</p>

--- a/libs/lbox-example/README.md
+++ b/libs/lbox-example/README.md
@@ -4,6 +4,4 @@ This is an example module which can be cloned and reused to develop modules unde
 
 ## Module Status: Experimental
 
-**TLDR: This module may be removed or altered at any given time and there is no offical support.**
-
-Please see [here](https://docs.labelbox.com/docs/product-release-phases) for the formal definition of `Experimental`.
+<p>This module may be removed or altered at any given time and there is no offical support.</p>


### PR DESCRIPTION
# Description

## Documentation Cleaning

I started this to fix a couple of dead links in the root `README.md` but figured I should go ahead and hit other documentation while I was at it.

### CONTRIBUTING.md

- Fix Capitalization "Github" -> "GitHub" in several places
- Contribution Guide
  - General Guidelines
    - Fixed Dead Link "index.rst"

### README.md

- Badges
  - Twitter -> X
- Labelbox
  - Table of Contents
    - Remove Deadlink "Develop with AI"
    - Add Missing Section "Provenance"
  - Quick Start
    - Generate an API key
      - Fixed Dead Link "Account > API Keys"
    - Validate Installation and API Key
      - Fix Capitalization "Github" -> "GitHub"
  - Jupyter Notebooks
    - Added python syntax highlighting to code block
  - Provenance
    - Added bash syntax highlighting to the code block

### Other

- Removed `README.md` links to definition of "Experimental Feature" in `libs/lbox-clients` and `libs/lbox-example` This redirected to the overview page and it appears that we no longer define what an experimental feature is in the docs.
- Fixed Dead Link to "Labelbox API key docs" in `libs/labelbox/README.md`.


## Type of change

- Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
  - No, there's no reason for me to install devdependencies or spin up a virtual environment for changes to markdown documentation
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only link, branding, and formatting fixes with no runtime, security, or dependency impact.
> 
> **Overview**
> This PR **updates repository markdown only**—no code or build behavior changes.
> 
> **CONTRIBUTING.md** standardizes **GitHub** capitalization (section title and workflow bullets) and points the `index.rst` doc entry link at **`docs/labelbox/index.rst`** instead of the old `docs/source/` path.
> 
> The root **README.md** switches the social badge from Twitter to **X** (`x.com`), adds **Provenance** to the table of contents and drops the dead “Develop with AI Assistance” entry, fixes the API key doc URL to **`docs.labelbox.com/reference/create-api-key`**, uses **GitHub** in support text, and adds **`python`** / **`bash`** fences on the Jupyter and provenance examples.
> 
> **`libs/labelbox/README.md`** uses the same API key reference link and closes the docs code block properly. **`libs/lbox-clients`** and **`libs/lbox-example`** shorten the experimental notice and remove the link to product-release phases that no longer documents “Experimental.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89d1236f41992248c4a8feaf83bc2599a9b7ed6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->