### PR TITLE
Add support to assign multiple datarows to a user

### DIFF
--- a/.github/actions/lbox-matrix/index.js
+++ b/.github/actions/lbox-matrix/index.js
@@ -26814,27 +26814,27 @@ try {
     // To be updated with the new API keys
     {
       "python-version": "3.9",
-      "api-key": "STAGING_LABELBOX_API_KEY_ORG_CMH2FKAOZ032H0735C32V1U63",
+      "api-key": "STAGING_API_KEY_ORG_CMOI3PQ7801GM070D4TPG7FMH",
       "da-test-key": "DA_GCP_LABELBOX_API_KEY"
     },
     {
       "python-version": "3.10",
-      "api-key": "STAGING_LABELBOX_API_KEY_ORG_CMH2G1557037K0726H50N3JQK",
+      "api-key": "STAGING_API_KEY_ORG_CMOI3PQ7801GM070D4TPG7FMH",
       "da-test-key": "DA_GCP_LABELBOX_API_KEY"
     },
     {
       "python-version": "3.11",
-      "api-key": "STAGING_LABELBOX_API_KEY_ORG_CMH2G7STM04WC071F73LG8RSD",
+      "api-key": "STAGING_API_KEY_ORG_CMOI3PQ7801GM070D4TPG7FMH",
       "da-test-key": "DA_GCP_LABELBOX_API_KEY"
     },
     {
       "python-version": "3.12",
-      "api-key": "STAGING_LABELBOX_API_KEY_ORG_CMH2GEJW9033B07299RKLAOFM",
+      "api-key": "STAGING_API_KEY_ORG_CMOI3PQ7801GM070D4TPG7FMH",
       "da-test-key": "DA_GCP_LABELBOX_API_KEY"
     },
     {
       "python-version": "3.13",
-      "api-key": "STAGING_LABELBOX_API_KEY_ORG_CMH2GGV3X04QK071X1EJCH8W0",
+      "api-key": "STAGING_API_KEY_ORG_CMOI3PQ7801GM070D4TPG7FMH",
       "da-test-key": "DA_GCP_LABELBOX_API_KEY"
     },    
   ];

--- a/.github/workflows/python-package-develop.yml
+++ b/.github/workflows/python-package-develop.yml
@@ -59,19 +59,19 @@ jobs:
       matrix:
         include:
           - python-version: "3.9"
-            api-key: STAGING_LABELBOX_API_KEY_ORG_CMH2FKAOZ032H0735C32V1U63
+            api-key: STAGING_API_KEY_ORG_CMOI3PQ7801GM070D4TPG7FMH 
             da-test-key: DA_GCP_LABELBOX_API_KEY
           - python-version: "3.10"
-            api-key: STAGING_LABELBOX_API_KEY_ORG_CMH2G1557037K0726H50N3JQK
+            api-key: STAGING_API_KEY_ORG_CMOI3PQ7801GM070D4TPG7FMH
             da-test-key: DA_GCP_LABELBOX_API_KEY
           - python-version: "3.11"
-            api-key: STAGING_LABELBOX_API_KEY_ORG_CMH2G7STM04WC071F73LG8RSD
+            api-key: STAGING_API_KEY_ORG_CMOI3PQ7801GM070D4TPG7FMH
             da-test-key: DA_GCP_LABELBOX_API_KEY
           - python-version: "3.12"
-            api-key: STAGING_LABELBOX_API_KEY_ORG_CMH2GEJW9033B07299RKLAOFM
+            api-key: STAGING_API_KEY_ORG_CMOI3PQ7801GM070D4TPG7FMH
             da-test-key: DA_GCP_LABELBOX_API_KEY       
           - python-version: "3.13"
-            api-key: STAGING_LABELBOX_API_KEY_ORG_CMH2GGV3X04QK071X1EJCH8W0
+            api-key: STAGING_API_KEY_ORG_CMOI3PQ7801GM070D4TPG7FMH
             da-test-key: DA_GCP_LABELBOX_API_KEY
     uses: ./.github/workflows/python-package-shared.yml
     with:

--- a/libs/labelbox/src/labelbox/__init__.py
+++ b/libs/labelbox/src/labelbox/__init__.py
@@ -93,6 +93,7 @@ from labelbox.schema.project_model_config import ProjectModelConfig
 from labelbox.schema.project_resource_tag import ProjectResourceTag
 from labelbox.schema.media_type import MediaType
 from labelbox.schema.slice import Slice, CatalogSlice, ModelSlice
+from labelbox.schema.task_assignment_status import TaskAssignmentStatus
 from labelbox.schema.task_queue import TaskQueue
 from labelbox.schema.label_score import LabelScore
 from labelbox.schema.identifiables import UniqueIds, GlobalKeys, DataRowIds

--- a/libs/labelbox/src/labelbox/schema/api_key.py
+++ b/libs/labelbox/src/labelbox/schema/api_key.py
@@ -322,6 +322,27 @@ class ApiKey(DbObject):
         if not user_email or not isinstance(user_email, str):
             raise ValueError("user must be a User object or a valid email")
 
+        role_name = role.name if hasattr(role, "name") else role
+        if not role_name or not isinstance(role_name, str):
+            raise ValueError("role must be a Role object or a valid role name")
+
+        if not isinstance(time_unit, TimeUnit):
+            raise ValueError("time_unit must be a valid TimeUnit enum value")
+
+        if validity < 0:
+            raise ValueError("validity must be a positive integer")
+
+        validity_seconds = validity * time_unit.value
+
+        if validity_seconds < TimeUnit.MINUTE.value:
+            raise ValueError("Minimum validity period is 1 minute")
+
+        max_seconds = 25 * TimeUnit.WEEK.value
+        if validity_seconds > max_seconds:
+            raise ValueError(
+                "Maximum validity period is 6 months (or 25 weeks)"
+            )
+
         # Check if the user exists in the organization
         user_id = ApiKey._get_user(client, user_email)
         if not user_id:
@@ -329,20 +350,9 @@ class ApiKey(DbObject):
                 f"User with email '{user_email}' does not exist in the organization"
             )
 
-        role_name = role.name if hasattr(role, "name") else role
-        if not role_name or not isinstance(role_name, str):
-            raise ValueError("role must be a Role object or a valid role name")
-
         allowed_roles = ApiKey._get_available_api_key_roles(client)
-        # Determine the exact server role name to pass through.
-        #
-        # - If caller provides a string, require exact match (case-sensitive).
-        # - If caller provides a Role object (which may be normalized by the SDK),
-        #   map it back to the server role name.
         server_role_name: Optional[str] = None
         if hasattr(role, "name"):
-            # Role objects in the SDK are often normalized (e.g. "TENANT_ADMIN").
-            # Map normalized name back to the server-provided role display name.
             normalized_to_server = {format_role(r): r for r in allowed_roles}
             server_role_name = (
                 role_name
@@ -355,24 +365,6 @@ class ApiKey(DbObject):
         if server_role_name is None:
             raise ValueError(
                 f"Invalid role specified. Allowed roles are: {allowed_roles}"
-            )
-
-        validity_seconds = 0
-        if validity < 0:
-            raise ValueError("validity must be a positive integer")
-
-        if not isinstance(time_unit, TimeUnit):
-            raise ValueError("time_unit must be a valid TimeUnit enum value")
-
-        validity_seconds = validity * time_unit.value
-
-        if validity_seconds < TimeUnit.MINUTE.value:
-            raise ValueError("Minimum validity period is 1 minute")
-
-        max_seconds = 25 * TimeUnit.WEEK.value
-        if validity_seconds > max_seconds:
-            raise ValueError(
-                "Maximum validity period is 6 months (or 25 weeks)"
             )
 
         query_str = """

--- a/libs/labelbox/src/labelbox/schema/internal/data_row_upsert_item.py
+++ b/libs/labelbox/src/labelbox/schema/internal/data_row_upsert_item.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Union
 
 from labelbox.schema.identifiable import UniqueId, GlobalKey
 from labelbox.schema.data_row import DataRow
@@ -34,7 +34,8 @@ class DataRowItemBase(ABC, BaseModel):
             if not key:
                 key = {"type": "AUTO", "value": ""}
             elif isinstance(key, key_types):  # type: ignore
-                key = {"type": key.id_type.value, "value": key.key}
+                typed_key: Union[UniqueId, GlobalKey] = key  # type: ignore[assignment]
+                key = {"type": typed_key.id_type.value, "value": typed_key.key}
             else:
                 if not key_types:
                     raise ValueError(

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -48,6 +48,7 @@ from labelbox.schema.identifiable import DataRowIdentifier
 from labelbox.schema.identifiables import (
     DataRowIdentifiers,
 )
+from labelbox.schema.task_assignment_status import TaskAssignmentStatus
 from labelbox.schema.labeling_service import (
     LabelingService,
     LabelingServiceStatus,
@@ -1465,6 +1466,51 @@ class Project(DbObject, Updateable, Deletable):
         )
         res = self.client.execute(query_str, {id_param: self.uid})
         return res["extendReservations"]
+
+    def bulk_assign_data_rows(
+        self,
+        user_id: str,
+        data_row_ids: List[str],
+        allowed_statuses: Optional[List[TaskAssignmentStatus]] = None,
+    ) -> bool:
+        """Assigns multiple data rows to a user in bulk.
+
+        Reserves the specified data rows in the project's initial labeling
+        queue for the given user. Only data rows whose current assignment
+        status matches ``allowed_statuses`` will be assigned.
+
+        Args:
+            user_id: The ID of the user to assign the data rows to.
+            data_row_ids: List of data row IDs to assign.
+            allowed_statuses: Optional list of statuses that a data row must
+                currently have in order to be assigned. Defaults to ``[FREE]``
+                on the server (i.e. only unassigned rows). Pass
+                ``[TaskAssignmentStatus.FREE, TaskAssignmentStatus.RESERVED]``
+                to allow reassignment of already-reserved rows.
+        Returns:
+            True if the bulk assignment succeeded.
+        Raises:
+            LabelboxError: If the GraphQL mutation fails.
+        """
+        if not data_row_ids:
+            return True
+
+        query_str = """mutation BulkAssignDataRowsPyApi($input: BulkAssignDataRowsInput!) {
+            bulkAssignDataRows(input: $input) {
+                success
+            }
+        }"""
+
+        input_dict: Dict[str, Any] = {
+            "projectId": self.uid,
+            "userId": user_id,
+            "dataRowIds": data_row_ids,
+        }
+        if allowed_statuses is not None:
+            input_dict["allowedStatuses"] = [s.value for s in allowed_statuses]
+
+        result = self.client.execute(query_str, {"input": input_dict})
+        return result["bulkAssignDataRows"]["success"]
 
     def enable_model_assisted_labeling(self, toggle: bool = True) -> bool:
         """Turns model assisted labeling either on or off based on input

--- a/libs/labelbox/src/labelbox/schema/task_assignment_status.py
+++ b/libs/labelbox/src/labelbox/schema/task_assignment_status.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class TaskAssignmentStatus(str, Enum):
+    """Status filter for bulk data row assignment.
+
+    FREE - only assign data rows that are currently unassigned.
+    RESERVED - only assign data rows that are currently reserved by another user.
+    """
+
+    FREE = "FREE"
+    RESERVED = "RESERVED"

--- a/libs/labelbox/tests/integration/test_api_keys.py
+++ b/libs/labelbox/tests/integration/test_api_keys.py
@@ -151,8 +151,12 @@ def test_create_api_key_invalid_email_formats(client):
 
 
 def test_create_api_key_invalid_validity_values(client):
-    """Test that providing invalid validity values causes failure."""
-    user_email = client.get_user().email
+    """Test that providing invalid validity values causes failure.
+
+    Validity checks are pure input validation and run before any API calls,
+    so a dummy email is sufficient here.
+    """
+    user_email = "placeholder@labelbox.com"
 
     # Test with negative validity
     with pytest.raises(ValueError) as excinfo:
@@ -200,8 +204,12 @@ def test_create_api_key_invalid_validity_values(client):
 
 
 def test_create_api_key_invalid_time_unit(client):
-    """Test that providing invalid time unit causes failure."""
-    user_email = client.get_user().email
+    """Test that providing invalid time unit causes failure.
+
+    time_unit checks are pure input validation and run before any API calls,
+    so a dummy email is sufficient here.
+    """
+    user_email = "placeholder@labelbox.com"
 
     # Test with None time unit
     with pytest.raises(ValueError) as excinfo:

--- a/libs/labelbox/tests/integration/test_bulk_assign.py
+++ b/libs/labelbox/tests/integration/test_bulk_assign.py
@@ -1,0 +1,42 @@
+from labelbox import Project
+from labelbox.schema.task_assignment_status import TaskAssignmentStatus
+
+
+def test_bulk_assign_data_rows(
+    configured_batch_project_with_label, project_based_user
+):
+    project, _, data_row, _ = configured_batch_project_with_label
+    user = project_based_user
+
+    result = project.bulk_assign_data_rows(
+        user_id=user.uid,
+        data_row_ids=[data_row.uid],
+    )
+    assert result is True
+
+
+def test_bulk_assign_data_rows_with_allowed_statuses(
+    configured_batch_project_with_label, project_based_user
+):
+    project, _, data_row, _ = configured_batch_project_with_label
+    user = project_based_user
+
+    result = project.bulk_assign_data_rows(
+        user_id=user.uid,
+        data_row_ids=[data_row.uid],
+        allowed_statuses=[
+            TaskAssignmentStatus.FREE,
+            TaskAssignmentStatus.RESERVED,
+        ],
+    )
+    assert result is True
+
+
+def test_bulk_assign_empty_list(configured_batch_project_with_label):
+    project, _, _, _ = configured_batch_project_with_label
+
+    result = project.bulk_assign_data_rows(
+        user_id="any_user_id",
+        data_row_ids=[],
+    )
+    assert result is True

--- a/libs/labelbox/tests/integration/test_bulk_assign.py
+++ b/libs/labelbox/tests/integration/test_bulk_assign.py
@@ -1,4 +1,3 @@
-from labelbox import Project
 from labelbox.schema.task_assignment_status import TaskAssignmentStatus
 
 

--- a/libs/labelbox/tests/unit/test_unit_project_bulk_assign.py
+++ b/libs/labelbox/tests/unit/test_unit_project_bulk_assign.py
@@ -37,9 +37,7 @@ def project(mock_client):
 
 
 def test_bulk_assign_sends_correct_mutation_and_variables(project, mock_client):
-    mock_client.execute.return_value = {
-        "bulkAssignDataRows": {"success": True}
-    }
+    mock_client.execute.return_value = {"bulkAssignDataRows": {"success": True}}
     data_row_ids = ["dr_1", "dr_2", "dr_3"]
 
     result = project.bulk_assign_data_rows("user_123", data_row_ids)
@@ -61,9 +59,7 @@ def test_bulk_assign_sends_correct_mutation_and_variables(project, mock_client):
 
 
 def test_bulk_assign_omits_allowed_statuses_when_none(project, mock_client):
-    mock_client.execute.return_value = {
-        "bulkAssignDataRows": {"success": True}
-    }
+    mock_client.execute.return_value = {"bulkAssignDataRows": {"success": True}}
 
     project.bulk_assign_data_rows("user_123", ["dr_1"])
 
@@ -72,9 +68,7 @@ def test_bulk_assign_omits_allowed_statuses_when_none(project, mock_client):
 
 
 def test_bulk_assign_serializes_allowed_statuses(project, mock_client):
-    mock_client.execute.return_value = {
-        "bulkAssignDataRows": {"success": True}
-    }
+    mock_client.execute.return_value = {"bulkAssignDataRows": {"success": True}}
 
     project.bulk_assign_data_rows(
         "user_123",
@@ -90,9 +84,7 @@ def test_bulk_assign_serializes_allowed_statuses(project, mock_client):
 
 
 def test_bulk_assign_single_status(project, mock_client):
-    mock_client.execute.return_value = {
-        "bulkAssignDataRows": {"success": True}
-    }
+    mock_client.execute.return_value = {"bulkAssignDataRows": {"success": True}}
 
     project.bulk_assign_data_rows(
         "user_123",

--- a/libs/labelbox/tests/unit/test_unit_project_bulk_assign.py
+++ b/libs/labelbox/tests/unit/test_unit_project_bulk_assign.py
@@ -1,0 +1,123 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from labelbox.schema.project import Project
+from labelbox.schema.task_assignment_status import TaskAssignmentStatus
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+@pytest.fixture
+def project(mock_client):
+    return Project(
+        mock_client,
+        {
+            "id": "test_project_id",
+            "name": "test",
+            "createdAt": "2021-06-01T00:00:00.000Z",
+            "updatedAt": "2021-06-01T00:00:00.000Z",
+            "autoAuditNumberOfLabels": 1,
+            "autoAuditPercentage": 100,
+            "dataRowCount": 1,
+            "description": "test",
+            "editorTaskType": "MODEL_CHAT_EVALUATION",
+            "lastActivityTime": "2021-06-01T00:00:00.000Z",
+            "allowedMediaType": "IMAGE",
+            "setupComplete": "2021-06-01T00:00:00.000Z",
+            "modelSetupComplete": None,
+            "uploadType": "Auto",
+            "isBenchmarkEnabled": False,
+            "isConsensusEnabled": False,
+        },
+    )
+
+
+def test_bulk_assign_sends_correct_mutation_and_variables(project, mock_client):
+    mock_client.execute.return_value = {
+        "bulkAssignDataRows": {"success": True}
+    }
+    data_row_ids = ["dr_1", "dr_2", "dr_3"]
+
+    result = project.bulk_assign_data_rows("user_123", data_row_ids)
+
+    assert result is True
+    mock_client.execute.assert_called_once()
+    args, _ = mock_client.execute.call_args
+    query_str, params = args
+
+    assert "BulkAssignDataRowsPyApi" in query_str
+    assert "bulkAssignDataRows" in query_str
+    assert params == {
+        "input": {
+            "projectId": "test_project_id",
+            "userId": "user_123",
+            "dataRowIds": ["dr_1", "dr_2", "dr_3"],
+        }
+    }
+
+
+def test_bulk_assign_omits_allowed_statuses_when_none(project, mock_client):
+    mock_client.execute.return_value = {
+        "bulkAssignDataRows": {"success": True}
+    }
+
+    project.bulk_assign_data_rows("user_123", ["dr_1"])
+
+    _, params = mock_client.execute.call_args[0]
+    assert "allowedStatuses" not in params["input"]
+
+
+def test_bulk_assign_serializes_allowed_statuses(project, mock_client):
+    mock_client.execute.return_value = {
+        "bulkAssignDataRows": {"success": True}
+    }
+
+    project.bulk_assign_data_rows(
+        "user_123",
+        ["dr_1"],
+        allowed_statuses=[
+            TaskAssignmentStatus.FREE,
+            TaskAssignmentStatus.RESERVED,
+        ],
+    )
+
+    _, params = mock_client.execute.call_args[0]
+    assert params["input"]["allowedStatuses"] == ["FREE", "RESERVED"]
+
+
+def test_bulk_assign_single_status(project, mock_client):
+    mock_client.execute.return_value = {
+        "bulkAssignDataRows": {"success": True}
+    }
+
+    project.bulk_assign_data_rows(
+        "user_123",
+        ["dr_1"],
+        allowed_statuses=[TaskAssignmentStatus.RESERVED],
+    )
+
+    _, params = mock_client.execute.call_args[0]
+    assert params["input"]["allowedStatuses"] == ["RESERVED"]
+
+
+def test_bulk_assign_empty_data_rows_returns_true_without_execute(
+    project, mock_client
+):
+    result = project.bulk_assign_data_rows("user_123", [])
+
+    assert result is True
+    mock_client.execute.assert_not_called()
+
+
+def test_bulk_assign_returns_false_on_server_failure(project, mock_client):
+    mock_client.execute.return_value = {
+        "bulkAssignDataRows": {"success": False}
+    }
+
+    result = project.bulk_assign_data_rows("user_123", ["dr_1"])
+
+    assert result is False


### PR DESCRIPTION
# Description
https://www.loom.com/share/1fd2774a6e2b4138ad9f453c95379076

## Summary

- Add `bulk_assign_data_rows()` method to the `Project` class, calling the existing `bulkAssignDataRows` GraphQL mutation
- Add `TaskAssignmentStatus` enum (`FREE`, `RESERVED`) for filtering which data rows can be assigned
- Export `TaskAssignmentStatus` from the top-level `labelbox` package

## Usage

```python
from labelbox import Client, TaskAssignmentStatus

client = Client(api_key="<your_api_key>")
project = client.get_project("<project_id>")

# Assign data rows to a labeler (only unassigned rows by default)
project.bulk_assign_data_rows(
    user_id="<user_id>",
    data_row_ids=["<data_row_id_1>", "<data_row_id_2>"],
)

# Optionally allow reassigning already-reserved rows
project.bulk_assign_data_rows(
    user_id="<user_id>",
    data_row_ids=["<data_row_id_1>"],
    allowed_statuses=[TaskAssignmentStatus.FREE, TaskAssignmentStatus.RESERVED],
)

```
Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you provided a description?
- [ ] Are your changes properly formatted?

## New Feature Submissions

- [ ] Does your submission pass tests?
- [ ] Have you added thorough tests for your new feature?
- [ ] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Have you added a Docstring?

## Changes to Core Features

- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you updated any code comments, as applicable?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `Project.bulk_assign_data_rows` GraphQL mutation wrapper and new public enum, plus updates CI to use different staging API key secret names; main risk is API/permission mismatches or CI failures due to secret configuration changes.
> 
> **Overview**
> Adds bulk data-row assignment to the Python SDK via `Project.bulk_assign_data_rows`, calling the `bulkAssignDataRows` GraphQL mutation with optional `allowed_statuses` filtering.
> 
> Introduces and exports `TaskAssignmentStatus` (`FREE`, `RESERVED`), and adds unit + integration tests covering request serialization, empty-input behavior, and status filtering.
> 
> Also refactors `ApiKey.create_api_key` to run validity/time-unit/role input validation earlier (tests updated accordingly), tightens typing in `DataRowItemBase.build`, and updates GitHub Actions workflow/action matrices to use new staging API key secret identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3be99b721d44c0babaf59ff26463cc18795243fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->