### PR TITLE
Prep 7.7.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@
 project = 'Python SDK reference'
 copyright = '2025, Labelbox'
 author = 'Labelbox'
-release = '7.6.0'
+release = '7.7.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/labelbox/index.rst
+++ b/docs/labelbox/index.rst
@@ -54,6 +54,7 @@ Labelbox Python SDK Documentation
     slice
     step-reasoning-tool
     task
+    task-assignment-status
     task-queue
     user
     user-group-v2

--- a/docs/labelbox/task-assignment-status.rst
+++ b/docs/labelbox/task-assignment-status.rst
@@ -1,0 +1,7 @@
+TaskAssignmentStatus
+====================
+
+.. autoclass:: labelbox.schema.task_assignment_status.TaskAssignmentStatus
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/libs/labelbox/CHANGELOG.md
+++ b/libs/labelbox/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+# Version 7.7.0 (2026-04-29)
+## Added
+* Add `Project.bulk_assign_data_rows()` method for bulk assigning data rows to a user ([#2054](https://github.com/Labelbox/labelbox-python/pull/2054))
+* Add `TaskAssignmentStatus` enum for filtering assignable data row statuses ([#2054](https://github.com/Labelbox/labelbox-python/pull/2054))
+## Fixed
+* Reorder `create_api_key` validation to check input params before making API calls ([#2054](https://github.com/Labelbox/labelbox-python/pull/2054))
+* Fix mypy type error in `DataRowUpsertItem.build` ([#2054](https://github.com/Labelbox/labelbox-python/pull/2054))
+
 # Version 7.6.0 (2026-03-18)
 ## Added
 * Add `Project.sync_external_project()` method for syncing external labels, metrics, and workflow state ([#2042](https://github.com/Labelbox/labelbox-python/pull/2042))

--- a/libs/labelbox/pyproject.toml
+++ b/libs/labelbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labelbox"
-version = "7.6.0"
+version = "7.7.0"
 description = "Labelbox Python API"
 authors = [{ name = "Labelbox", email = "engineering@labelbox.com" }]
 dependencies = [

--- a/libs/labelbox/src/labelbox/__init__.py
+++ b/libs/labelbox/src/labelbox/__init__.py
@@ -1,6 +1,6 @@
 name = "labelbox"
 
-__version__ = "7.6.0"
+__version__ = "7.7.0"
 
 from labelbox.client import Client
 from labelbox.schema.annotation_import import (


### PR DESCRIPTION
## Version 7.7.0

### Added
- `Project.bulk_assign_data_rows()` method for bulk assigning data rows to a user
- `TaskAssignmentStatus` enum for filtering assignable data row statuses

### Fixed
- Reorder `create_api_key` validation to check input params before making API calls
- Fix mypy type error in `DataRowUpsertItem.build`

### Release checklist
- [x] `libs/labelbox/pyproject.toml` version bumped
- [x] `libs/labelbox/src/labelbox/__init__.py` version bumped
- [x] `docs/conf.py` release bumped
- [x] `CHANGELOG.md` updated
- [x] `docs/labelbox/index.rst` updated with new class
- [x] `docs/labelbox/task-assignment-status.rst` added

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-prep and documentation/version bumps only; no runtime logic changes are included in this diff.
> 
> **Overview**
> Bumps the SDK and docs release version from `7.6.0` to `7.7.0` (package metadata, `__version__`, and Sphinx `release`).
> 
> Updates `CHANGELOG.md` with the 7.7.0 release notes (new `Project.bulk_assign_data_rows()` and `TaskAssignmentStatus`, plus two bugfixes), and extends the Sphinx docs to include a new `task-assignment-status` page in the toctree that autodocuments `TaskAssignmentStatus`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87c86e0e73d2cdc3ebb3864d6321fefcaa4ee46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->