### PR TITLE
Add ModelRun.total_cost and total_data_rows

### DIFF
--- a/libs/labelbox/src/labelbox/schema/model_run.py
+++ b/libs/labelbox/src/labelbox/schema/model_run.py
@@ -87,13 +87,18 @@ class ModelRun(DbObject):
             """
             try:
                 res = self.client.execute(query_str, {"modelRunId": self.uid})
-                self._cost_and_usage = res["modelFoundryModelRunInfo"] or {}
             except (ResourceNotFoundError, InternalServerError):
                 # Model Runs not backed by a Foundry model job have no
                 # cost/usage info to report; cache the empty result. Transient
                 # errors (network, timeout, rate limit) are intentionally not
                 # caught so they propagate and the next access can retry.
-                self._cost_and_usage = {}
+                res = None
+            # execute() returns None for a RESOURCE_NOT_FOUND response (it does
+            # not raise unless raise_return_resource_not_found=True), so guard
+            # against a missing payload before indexing into it.
+            self._cost_and_usage = (res or {}).get(
+                "modelFoundryModelRunInfo"
+            ) or {}
         return self._cost_and_usage
 
     @property

--- a/libs/labelbox/src/labelbox/schema/model_run.py
+++ b/libs/labelbox/src/labelbox/schema/model_run.py
@@ -70,10 +70,7 @@ class ModelRun(DbObject):
     def _get_cost_and_usage(self) -> Dict[str, Any]:
         """Lazily fetches and caches cost and data row count for this Model Run.
 
-        The data is rehydrated in real time from Model Foundry (which in turn
-        sources it from the model service); nothing is persisted on the Model
-        Run itself. Returns an empty dict for Model Runs that were not produced
-        by a Foundry app (i.e. that have no associated model job).
+        Returns an empty dict when no cost/usage information is available.
         """
         if getattr(self, "_cost_and_usage", None) is None:
             query_str = """
@@ -88,14 +85,10 @@ class ModelRun(DbObject):
             try:
                 res = self.client.execute(query_str, {"modelRunId": self.uid})
             except (ResourceNotFoundError, InternalServerError):
-                # Model Runs not backed by a Foundry model job have no
-                # cost/usage info to report; cache the empty result. Transient
-                # errors (network, timeout, rate limit) are intentionally not
+                # No cost/usage info available; cache the empty result.
+                # Transient errors (network, timeout, rate limit) are not
                 # caught so they propagate and the next access can retry.
                 res = None
-            # execute() returns None for a RESOURCE_NOT_FOUND response (it does
-            # not raise unless raise_return_resource_not_found=True), so guard
-            # against a missing payload before indexing into it.
             self._cost_and_usage = (res or {}).get(
                 "modelFoundryModelRunInfo"
             ) or {}
@@ -103,16 +96,17 @@ class ModelRun(DbObject):
 
     @property
     def total_cost(self) -> Optional[float]:
-        """Total cost (USD) of this Model Run, fetched in real time from Model
-        Foundry. ``None`` if the run is not Foundry-backed or cost is not yet
-        available.
+        """Total cost (USD) of this Model Run.
+
+        ``None`` if cost is not available for this run.
         """
         return self._get_cost_and_usage().get("cost")
 
     @property
     def total_data_rows(self) -> Optional[int]:
-        """Number of data rows processed by this Model Run, fetched in real time
-        from Model Foundry. ``None`` if the run is not Foundry-backed.
+        """Number of data rows processed by this Model Run.
+
+        ``None`` if not available for this run.
         """
         return self._get_cost_and_usage().get("totalDataRows")
 

--- a/libs/labelbox/src/labelbox/schema/model_run.py
+++ b/libs/labelbox/src/labelbox/schema/model_run.py
@@ -16,7 +16,7 @@ from typing import (
     Union,
 )
 
-from lbox.exceptions import LabelboxError
+from lbox.exceptions import InternalServerError, ResourceNotFoundError
 
 from labelbox.orm.db_object import DbObject, experimental
 from labelbox.orm.model import Entity, Field, Relationship
@@ -88,9 +88,11 @@ class ModelRun(DbObject):
             try:
                 res = self.client.execute(query_str, {"modelRunId": self.uid})
                 self._cost_and_usage = res["modelFoundryModelRunInfo"] or {}
-            except LabelboxError:
+            except (ResourceNotFoundError, InternalServerError):
                 # Model Runs not backed by a Foundry model job have no
-                # cost/usage info to report.
+                # cost/usage info to report; cache the empty result. Transient
+                # errors (network, timeout, rate limit) are intentionally not
+                # caught so they propagate and the next access can retry.
                 self._cost_and_usage = {}
         return self._cost_and_usage
 

--- a/libs/labelbox/src/labelbox/schema/model_run.py
+++ b/libs/labelbox/src/labelbox/schema/model_run.py
@@ -16,6 +16,8 @@ from typing import (
     Union,
 )
 
+from lbox.exceptions import LabelboxError
+
 from labelbox.orm.db_object import DbObject, experimental
 from labelbox.orm.model import Entity, Field, Relationship
 from labelbox.orm.query import results_query_part
@@ -64,6 +66,52 @@ class ModelRun(DbObject):
         TRAINING_MODEL = "TRAINING_MODEL"
         COMPLETE = "COMPLETE"
         FAILED = "FAILED"
+
+    def _get_cost_and_usage(self) -> Dict[str, Any]:
+        """Lazily fetches and caches cost and data row count for this Model Run.
+
+        The data is rehydrated in real time from Model Foundry (which in turn
+        sources it from the model service); nothing is persisted on the Model
+        Run itself. Returns an empty dict for Model Runs that were not produced
+        by a Foundry app (i.e. that have no associated model job).
+        """
+        if getattr(self, "_cost_and_usage", None) is None:
+            query_str = """
+                query GetModelRunCostInfoPyApi($modelRunId: ID!) {
+                    modelFoundryModelRunInfo(where: {modelRunId: $modelRunId}) {
+                        cost
+                        status
+                        totalDataRows
+                    }
+                }
+            """
+            try:
+                res = self.client.execute(query_str, {"modelRunId": self.uid})
+                self._cost_and_usage = res["modelFoundryModelRunInfo"] or {}
+            except LabelboxError:
+                # Model Runs not backed by a Foundry model job have no
+                # cost/usage info to report.
+                self._cost_and_usage = {}
+        return self._cost_and_usage
+
+    @property
+    def total_cost(self) -> Optional[float]:
+        """Total cost (USD) of this Model Run, fetched in real time from Model
+        Foundry. ``None`` if the run is not Foundry-backed or cost is not yet
+        available.
+        """
+        return self._get_cost_and_usage().get("cost")
+
+    @property
+    def total_data_rows(self) -> Optional[int]:
+        """Number of data rows processed by this Model Run, fetched in real time
+        from Model Foundry. ``None`` if the run is not Foundry-backed.
+        """
+        return self._get_cost_and_usage().get("totalDataRows")
+
+    def refresh_cost_and_usage(self) -> None:
+        """Clears the cached cost/usage so the next access re-fetches live data."""
+        self._cost_and_usage = None
 
     def upsert_labels(
         self,

--- a/libs/labelbox/tests/unit/test_unit_model_run.py
+++ b/libs/labelbox/tests/unit/test_unit_model_run.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock
+
+from lbox.exceptions import LabelboxError
+
+from labelbox.schema.model_run import ModelRun
+
+
+def _make_model_run(client):
+    return ModelRun(
+        client,
+        {
+            "id": "model-run-1",
+            "name": "test run",
+            "createdAt": "2021-06-01T00:00:00.000Z",
+            "updatedAt": "2021-06-01T00:00:00.000Z",
+            "createdBy": "user-1",
+            "modelId": "model-1",
+            "trainingMetadata": {},
+            "modelAppId": "app-1",
+        },
+    )
+
+
+def test_total_cost_and_data_rows_are_fetched_and_cached():
+    client = MagicMock()
+    client.execute.return_value = {
+        "modelFoundryModelRunInfo": {
+            "cost": 3.5,
+            "status": "finished",
+            "totalDataRows": 12,
+        }
+    }
+    model_run = _make_model_run(client)
+
+    assert model_run.total_cost == 3.5
+    assert model_run.total_data_rows == 12
+
+    # Cost/usage is rehydrated once and cached across property reads.
+    assert client.execute.call_count == 1
+    # The model run id is passed to the Foundry query.
+    assert client.execute.call_args[0][1] == {"modelRunId": "model-run-1"}
+
+
+def test_refresh_cost_and_usage_refetches():
+    client = MagicMock()
+    client.execute.return_value = {
+        "modelFoundryModelRunInfo": {
+            "cost": 1.0,
+            "status": "finished",
+            "totalDataRows": 1,
+        }
+    }
+    model_run = _make_model_run(client)
+
+    assert model_run.total_cost == 1.0
+    model_run.refresh_cost_and_usage()
+    assert model_run.total_cost == 1.0
+    assert client.execute.call_count == 2
+
+
+def test_cost_and_usage_none_for_non_foundry_run():
+    client = MagicMock()
+    client.execute.side_effect = LabelboxError("model job not found")
+    model_run = _make_model_run(client)
+
+    assert model_run.total_cost is None
+    assert model_run.total_data_rows is None

--- a/libs/labelbox/tests/unit/test_unit_model_run.py
+++ b/libs/labelbox/tests/unit/test_unit_model_run.py
@@ -42,7 +42,7 @@ def test_total_cost_and_data_rows_are_fetched_and_cached():
 
     # Cost/usage is rehydrated once and cached across property reads.
     assert client.execute.call_count == 1
-    # The model run id is passed to the Foundry query.
+    # The model run id is passed to the query.
     assert client.execute.call_args[0][1] == {"modelRunId": "model-run-1"}
 
 
@@ -82,7 +82,7 @@ def test_cost_and_usage_none_for_non_foundry_run(error):
 @pytest.mark.parametrize(
     "execute_result",
     [
-        None,  # RESOURCE_NOT_FOUND -> execute() returns None, does not raise
+        None,  # execute() can return None instead of a payload
         {"modelFoundryModelRunInfo": None},
     ],
 )

--- a/libs/labelbox/tests/unit/test_unit_model_run.py
+++ b/libs/labelbox/tests/unit/test_unit_model_run.py
@@ -79,6 +79,22 @@ def test_cost_and_usage_none_for_non_foundry_run(error):
     assert model_run.total_data_rows is None
 
 
+@pytest.mark.parametrize(
+    "execute_result",
+    [
+        None,  # RESOURCE_NOT_FOUND -> execute() returns None, does not raise
+        {"modelFoundryModelRunInfo": None},
+    ],
+)
+def test_cost_and_usage_none_when_payload_missing(execute_result):
+    client = MagicMock()
+    client.execute.return_value = execute_result
+    model_run = _make_model_run(client)
+
+    assert model_run.total_cost is None
+    assert model_run.total_data_rows is None
+
+
 def test_transient_errors_propagate_and_are_not_cached():
     client = MagicMock()
     client.execute.side_effect = NetworkError(Exception("boom"))

--- a/libs/labelbox/tests/unit/test_unit_model_run.py
+++ b/libs/labelbox/tests/unit/test_unit_model_run.py
@@ -1,6 +1,11 @@
 from unittest.mock import MagicMock
 
-from lbox.exceptions import LabelboxError
+import pytest
+from lbox.exceptions import (
+    InternalServerError,
+    NetworkError,
+    ResourceNotFoundError,
+)
 
 from labelbox.schema.model_run import ModelRun
 
@@ -58,10 +63,38 @@ def test_refresh_cost_and_usage_refetches():
     assert client.execute.call_count == 2
 
 
-def test_cost_and_usage_none_for_non_foundry_run():
+@pytest.mark.parametrize(
+    "error",
+    [
+        ResourceNotFoundError(message="model run not found"),
+        InternalServerError("no model job for run"),
+    ],
+)
+def test_cost_and_usage_none_for_non_foundry_run(error):
     client = MagicMock()
-    client.execute.side_effect = LabelboxError("model job not found")
+    client.execute.side_effect = error
     model_run = _make_model_run(client)
 
     assert model_run.total_cost is None
     assert model_run.total_data_rows is None
+
+
+def test_transient_errors_propagate_and_are_not_cached():
+    client = MagicMock()
+    client.execute.side_effect = NetworkError(Exception("boom"))
+    model_run = _make_model_run(client)
+
+    with pytest.raises(NetworkError):
+        _ = model_run.total_cost
+
+    # The failure is not cached, so a later successful access recovers.
+    client.execute.side_effect = None
+    client.execute.return_value = {
+        "modelFoundryModelRunInfo": {
+            "cost": 2.0,
+            "status": "finished",
+            "totalDataRows": 5,
+        }
+    }
+    assert model_run.total_cost == 2.0
+    assert model_run.total_data_rows == 5


### PR DESCRIPTION
## What

Adds two lazy properties to `ModelRun`:

```python
model_run = client.get_model_run(model_run_id)
model_run.total_cost       # float | None  (USD)
model_run.total_data_rows  # int | None    (data rows processed)
model_run.refresh_cost_and_usage()  # bust the cache
```

## Why

Model Foundry users (DoubleVerify) currently log cost and dataset size by hand. This lets them pull both straight off the `ModelRun` they already fetch — matching the workflow in their existing scripts (`client.get_model_run(...)`).

## How

On first access, a single `modelFoundryModelRunInfo` query is issued (which proxies to model_service's already-computed per-job cost + data-row count) and cached on the instance. **Nothing is persisted** on the run — it's real-time rehydration. Runs not backed by a Foundry model job return `None` (the `LabelboxError` is swallowed).

The `get_model_run` query itself is unchanged, so existing fetches stay cheap; the extra round trip only happens when cost/usage is actually read. (A server-side `ModelRun.totalCost` field resolver was rejected because `DbObject` selects all fields on every fetch, which would hit model_service on every `get_model_run`.)

## Part of a 3-PR stack (deploy in order)

1. python-monorepo model_service — populates `total_data_rows` (Labelbox/python-monorepo#2502)
2. intelligence — exposes `totalDataRows` on GraphQL (Labelbox/intelligence#29662)
3. **this PR** — SDK properties

## Test

`tests/unit/test_unit_model_run.py` — fetch + cache, refresh re-fetch, and `None` for non-Foundry runs. 3 tests passing (`pytest tests/unit/test_unit_model_run.py`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only SDK surface and optional GraphQL round-trip; no changes to auth, persistence, or existing `get_model_run` behavior.
> 
> **Overview**
> Adds **lazy, cached** Model Foundry cost/usage on `ModelRun`: `total_cost` (USD), `total_data_rows`, and `refresh_cost_and_usage()` to invalidate the cache.
> 
> On first property access, the SDK issues one `modelFoundryModelRunInfo` GraphQL query (not on `get_model_run`), stores the result on the instance, and both properties share that fetch. **Resource not found** and **internal server** errors are treated as “no Foundry job” and yield `None`; **network/transient** errors are **not** cached and still propagate.
> 
> New unit tests cover caching, refresh, missing payloads, non-Foundry runs, and transient error recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0023b44ee203a4dd5b213b58fcbec249446abea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->