### PR TITLE
Prep 7.8.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@
 project = 'Python SDK reference'
 copyright = '2025, Labelbox'
 author = 'Labelbox'
-release = '7.7.0'
+release = '7.8.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/libs/labelbox/CHANGELOG.md
+++ b/libs/labelbox/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+# Version 7.8.0 (2026-06-11)
+## Added
+* Add `ModelRun.total_cost` and `ModelRun.total_data_rows` properties to retrieve inference cost and data row count for a model run ([#2057](https://github.com/Labelbox/labelbox-python/pull/2057))
+* Add `ModelRun.refresh_cost_and_usage()` to re-fetch live cost and usage data ([#2057](https://github.com/Labelbox/labelbox-python/pull/2057))
+
 # Version 7.7.0 (2026-04-29)
 ## Added
 * Add `Project.bulk_assign_data_rows()` method for bulk assigning data rows to a user ([#2054](https://github.com/Labelbox/labelbox-python/pull/2054))

--- a/libs/labelbox/pyproject.toml
+++ b/libs/labelbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labelbox"
-version = "7.7.0"
+version = "7.8.0"
 description = "Labelbox Python API"
 authors = [{ name = "Labelbox", email = "engineering@labelbox.com" }]
 dependencies = [

--- a/libs/labelbox/src/labelbox/__init__.py
+++ b/libs/labelbox/src/labelbox/__init__.py
@@ -1,6 +1,6 @@
 name = "labelbox"
 
-__version__ = "7.7.0"
+__version__ = "7.8.0"
 
 from labelbox.client import Client
 from labelbox.schema.annotation_import import (


### PR DESCRIPTION
## Version 7.8.0

### Added
- `ModelRun.total_cost` and `ModelRun.total_data_rows` properties to retrieve inference cost and data row count for a model run
- `ModelRun.refresh_cost_and_usage()` to re-fetch live cost and usage data

### Release checklist
- [x] `libs/labelbox/pyproject.toml` version bumped
- [x] `libs/labelbox/src/labelbox/__init__.py` version bumped
- [x] `docs/conf.py` release bumped
- [x] `CHANGELOG.md` updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and version string updates only; no runtime logic changes in this diff.
> 
> **Overview**
> Prepares **release 7.8.0** of the Labelbox Python SDK by bumping the package version from **7.7.0** to **7.8.0** in `pyproject.toml`, `labelbox.__version__`, and Sphinx `docs/conf.py`.
> 
> `CHANGELOG.md` gains a **7.8.0 (2026-06-11)** section that documents the user-facing additions shipped for this release: **`ModelRun.total_cost`** and **`ModelRun.total_data_rows`**, plus **`ModelRun.refresh_cost_and_usage()`** for refreshing cached inference cost and usage (via [#2057](https://github.com/Labelbox/labelbox-python/pull/2057)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 649784478a896ef8e22b8348c91bf1c1a682ff4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->