### PR TITLE
[PLT-4090] Add batch_ids filter to project.get_overview()

### DIFF
--- a/libs/labelbox/CHANGELOG.md
+++ b/libs/labelbox/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+# Version 7.9.0 (Unreleased)
+## Added
+* Add optional `batch_ids` parameter to `Project.get_overview()` to return workflow state counts scoped to one or more batches ([#TBD](https://github.com/Labelbox/labelbox-python/pull/TBD))
+
 # Version 7.8.0 (2026-06-11)
 ## Added
 * Add `ModelRun.total_cost` and `ModelRun.total_data_rows` properties to retrieve inference cost and data row count for a model run ([#2057](https://github.com/Labelbox/labelbox-python/pull/2057))

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -86,7 +86,7 @@ if TYPE_CHECKING:
     pass
 
 
-_MAX_BATCH_IDS = 2000
+_MAX_BATCH_IDS = 1000
 
 
 def _validate_batch_ids(batch_ids: List[str]) -> None:

--- a/libs/labelbox/src/labelbox/schema/project.py
+++ b/libs/labelbox/src/labelbox/schema/project.py
@@ -86,6 +86,20 @@ if TYPE_CHECKING:
     pass
 
 
+_MAX_BATCH_IDS = 2000
+
+
+def _validate_batch_ids(batch_ids: List[str]) -> None:
+    if not isinstance(batch_ids, list):
+        raise ValueError("batch_ids filter expects a list.")
+    if len(batch_ids) == 0:
+        raise ValueError("batch_ids filter expects a non-empty list.")
+    if len(batch_ids) > _MAX_BATCH_IDS:
+        raise ValueError(
+            f"batch_ids filter only supports a max of {_MAX_BATCH_IDS} items."
+        )
+
+
 DataRowPriority = int
 LabelingParameterOverrideInput = Tuple[DataRowIdentifier, DataRowPriority]
 
@@ -1737,7 +1751,9 @@ class Project(DbObject, Updateable, Deletable):
         ]
 
     def get_overview(
-        self, details=False
+        self,
+        details: bool = False,
+        batch_ids: Optional[List[str]] = None,
     ) -> Union[ProjectOverview, ProjectOverviewDetailed]:
         """Return the overview of a project.
 
@@ -1745,30 +1761,45 @@ class Project(DbObject, Updateable, Deletable):
         which is equivalent to the Overview tab of a project.
 
         Args:
-            details (bool, optional): Whether to include detailed queue information for review and rework queues.
-                Defaults to False.
+            details (bool, optional): Whether to include detailed queue information for
+                review and rework queues. Defaults to False.
+            batch_ids (Optional[List[str]], optional): When provided, limits counts to data
+                rows in the given batch(es). Multiple batch IDs return combined counts, not
+                per-batch breakdowns. Unknown or foreign batch IDs return zero counts.
+                Defaults to None (project-wide counts).
 
         Returns:
-            Union[ProjectOverview, ProjectOverviewDetailed]: An object representing the project overview.
-                If `details` is False, returns a `ProjectOverview` object.
-                If `details` is True, returns a `ProjectOverviewDetailed` object.
+            Union[ProjectOverview, ProjectOverviewDetailed]: An object representing the
+            project overview. If `details` is False, returns a `ProjectOverview` object.
+            If `details` is True, returns a `ProjectOverviewDetailed` object. When
+            `batch_ids` is set, `issues` is None because issue counts are not
+            batch-scoped.
 
         Raises:
+            ValueError: If `batch_ids` is an empty list or exceeds the maximum allowed size.
             Exception: If there is an error executing the query.
 
         """
-        query = """query ProjectGetOverviewPyApi($projectId: ID!) {
-            project(where: { id: $projectId }) {      
-            workstreamStateCounts {
+        if batch_ids is not None:
+            _validate_batch_ids(batch_ids)
+
+        query = """query ProjectGetOverviewPyApi(
+            $projectId: ID!,
+            $batchIds: [String!],
+            $countInput: DataRowCountQueryInput,
+            $includeIssues: Boolean!
+        ) {
+            project(where: { id: $projectId }) {
+            workstreamStateCounts(batchIds: $batchIds) {
                 state
                 count
             }
             taskQueues {
                 queueType
                 name
-                dataRowCount
+                dataRowCount(input: $countInput)
             }
-            issues {
+            issues @include(if: $includeIssues) {
                 totalCount
             }
             completedDataRowCount
@@ -1776,9 +1807,26 @@ class Project(DbObject, Updateable, Deletable):
         }
         """
 
+        variables: Dict[str, Any] = {
+            "projectId": self.uid,
+            "batchIds": batch_ids,
+            "includeIssues": batch_ids is None,
+        }
+        if batch_ids is not None:
+            variables["countInput"] = {
+                "searchQuery": {
+                    "scope": {"projectId": self.uid},
+                    "query": [
+                        {"ids": batch_ids, "operator": "is", "type": "batch"}
+                    ],
+                }
+            }
+        else:
+            variables["countInput"] = None
+
         # Must use experimental to access "issues"
         result = self.client.execute(
-            query, {"projectId": self.uid}, experimental=True
+            query, variables, experimental=True
         )["project"]
 
         # Reformat category names
@@ -1788,7 +1836,10 @@ class Project(DbObject, Updateable, Deletable):
             if st["state"] != "NotInTaskQueue"
         }
 
-        overview["issues"] = result.get("issues", {}).get("totalCount")
+        if batch_ids is None:
+            overview["issues"] = result.get("issues", {}).get("totalCount")
+        else:
+            overview["issues"] = None
 
         # Rename categories
         overview["to_label"] = overview.pop("unlabeled")

--- a/libs/labelbox/src/labelbox/schema/project_overview.py
+++ b/libs/labelbox/src/labelbox/schema/project_overview.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 from typing_extensions import TypedDict
@@ -16,6 +16,7 @@ class ProjectOverview(BaseModel):
     The `skipped` attribute represents the number of data rows that have been skipped (Skipped).
     The `done` attribute represents the number of data rows that have been marked as Done (Done).
     The `issues` attribute represents the number of data rows with associated issues (Issues).
+    When the overview is scoped to one or more batches, `issues` is `None`.
 
     The following don't appear in the UI
     The `labeled` attribute represents the number of data rows that have been labeled.
@@ -27,7 +28,7 @@ class ProjectOverview(BaseModel):
     in_rework: int
     skipped: int
     done: int
-    issues: int
+    issues: Optional[int] = None
     labeled: int
     total_data_rows: int
 
@@ -60,6 +61,7 @@ class ProjectOverviewDetailed(BaseModel):
     The `skipped` attribute represents the number of data rows that have been skipped (Skipped).
     The `done` attribute represents the number of data rows that have been marked as Done (Done).
     The `issues` attribute represents the number of data rows with associated issues (Issues).
+    When the overview is scoped to one or more batches, `issues` is `None`.
 
     The following don't appear in the UI
     The `labeled` attribute represents the number of data rows that have been labeled.
@@ -71,6 +73,6 @@ class ProjectOverviewDetailed(BaseModel):
     in_rework: _QueueDetail
     skipped: int
     done: int
-    issues: int
+    issues: Optional[int] = None
     labeled: int
     total_data_rows: int

--- a/libs/labelbox/tests/integration/test_batch.py
+++ b/libs/labelbox/tests/integration/test_batch.py
@@ -2,6 +2,7 @@ from typing import List
 from uuid import uuid4
 
 import pytest
+import time
 from lbox.exceptions import (
     LabelboxError,
     MalformedQueryException,
@@ -137,6 +138,43 @@ def test_create_batch_with_data_row_class(
     batch = project.create_batch("test-batch-data-rows", data_rows, 3)
     assert batch.name == "test-batch-data-rows"
     assert batch.size == len(data_rows)
+
+
+def test_get_overview_batch_scoped(project: Project, small_dataset: Dataset):
+    export_task = small_dataset.export()
+    export_task.wait_till_done()
+    stream = export_task.get_buffered_stream()
+    data_rows = [dr.json["data_row"]["id"] for dr in stream]
+
+    batch_a = project.create_batch("batch-a-overview", [data_rows[0]])
+    batch_b = project.create_batch("batch-b-overview", [data_rows[1]])
+
+    timeout_seconds = 60
+    sleep_time = 2
+    overview_a = None
+    overview_b = None
+    while timeout_seconds > 0:
+        overview_a = project.get_overview(batch_ids=[batch_a.uid])
+        overview_b = project.get_overview(batch_ids=[batch_b.uid])
+        if (
+            overview_a.total_data_rows == 1
+            and overview_b.total_data_rows == 1
+        ):
+            break
+        timeout_seconds -= sleep_time
+        time.sleep(sleep_time)
+    else:
+        raise AssertionError(
+            "Timed out waiting for batch-scoped overview counts"
+        )
+
+    assert overview_a.issues is None
+    assert overview_b.issues is None
+    assert overview_a.total_data_rows == 1
+    assert overview_b.total_data_rows == 1
+
+    combined = project.get_overview(batch_ids=[batch_a.uid, batch_b.uid])
+    assert combined.total_data_rows == 2
 
 
 def test_archive_batch(project: Project, small_dataset: Dataset):

--- a/libs/labelbox/tests/unit/test_project.py
+++ b/libs/labelbox/tests/unit/test_project.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
 
-from labelbox.schema.project import Project
+from labelbox.schema.project import Project, _validate_batch_ids
 from labelbox.schema.ontology_kind import EditorTaskType
 
 
@@ -28,6 +28,82 @@ def project_entity():
             "isConsensusEnabled": False,
         },
     )
+
+
+def _workstream_state_counts_response():
+    return {
+        "workstreamStateCounts": [
+            {"state": "Unlabeled", "count": 10},
+            {"state": "InReview", "count": 2},
+            {"state": "InRework", "count": 1},
+            {"state": "Skipped", "count": 0},
+            {"state": "Done", "count": 5},
+            {"state": "Labeled", "count": 8},
+            {"state": "All", "count": 18},
+            {"state": "NotInTaskQueue", "count": 3},
+        ],
+        "taskQueues": [],
+        "issues": {"totalCount": 4},
+        "completedDataRowCount": 5,
+    }
+
+
+def test_get_overview_project_wide(project_entity):
+    client = project_entity.client
+    client.execute.return_value = {"project": _workstream_state_counts_response()}
+
+    overview = project_entity.get_overview()
+
+    assert overview.to_label == 10
+    assert overview.total_data_rows == 18
+    assert overview.issues == 4
+
+    args, kwargs = client.execute.call_args
+    variables = args[1]
+    assert variables["projectId"] == "test"
+    assert variables["batchIds"] is None
+    assert variables["countInput"] is None
+    assert variables["includeIssues"] is True
+    assert kwargs["experimental"] is True
+    query = args[0]
+    assert "issues @include(if: $includeIssues)" in query
+
+
+def test_get_overview_batch_scoped(project_entity):
+    client = project_entity.client
+    client.execute.return_value = {"project": _workstream_state_counts_response()}
+
+    overview = project_entity.get_overview(batch_ids=["batch-1"])
+
+    assert overview.issues is None
+
+    args, kwargs = client.execute.call_args
+    variables = args[1]
+    assert variables["batchIds"] == ["batch-1"]
+    assert variables["includeIssues"] is False
+    assert variables["countInput"] == {
+        "searchQuery": {
+            "scope": {"projectId": "test"},
+            "query": [{"ids": ["batch-1"], "operator": "is", "type": "batch"}],
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    "batch_ids,expected_message",
+    [
+        ([], "batch_ids filter expects a non-empty list."),
+        (["batch-1"] * 2001, "batch_ids filter only supports a max of 2000 items."),
+    ],
+)
+def test_validate_batch_ids_rejects_invalid(batch_ids, expected_message):
+    with pytest.raises(ValueError, match=expected_message):
+        _validate_batch_ids(batch_ids)
+
+
+def test_get_overview_rejects_empty_batch_ids(project_entity):
+    with pytest.raises(ValueError, match="batch_ids filter expects a non-empty list."):
+        project_entity.get_overview(batch_ids=[])
 
 
 @pytest.mark.parametrize(

--- a/libs/labelbox/tests/unit/test_project.py
+++ b/libs/labelbox/tests/unit/test_project.py
@@ -93,7 +93,7 @@ def test_get_overview_batch_scoped(project_entity):
     "batch_ids,expected_message",
     [
         ([], "batch_ids filter expects a non-empty list."),
-        (["batch-1"] * 2001, "batch_ids filter only supports a max of 2000 items."),
+        (["batch-1"] * 1001, "batch_ids filter only supports a max of 1000 items."),
     ],
 )
 def test_validate_batch_ids_rejects_invalid(batch_ids, expected_message):


### PR DESCRIPTION
Ticket: [LINK](https://labelbox.atlassian.net/browse/PLT-4090)

# Description

### Problem
Customers such as Pinterest need to poll batch completion status programmatically (To Label / In Review / In Rework / Done counts per batch). Today the only option is running multiple project exports with batch_ids + workflow_status filters - each export takes minutes. For hourly polling across many batches, this is expensive and slow.

### Solution
Extend Project.get_overview() with an optional batch_ids parameter that returns the same workflow-state counts as the project Overview tab, scoped to one or more batches - without exporting label data.

```python
overview = project.get_overview(batch_ids=[batch.uid])
print(overview.to_label, overview.in_review, overview.in_rework, overview.done)
print(overview.total_data_rows)

# Multiple batches → combined counts (not per-batch breakdown)
overview = project.get_overview(batch_ids=[batch_a.uid, batch_b.uid])

# Per-queue breakdown, also batch-scoped
overview = project.get_overview(batch_ids=[batch.uid], details=True)
```

Query: `ProjectGetOverviewPyApi` (still uses `experimental=True / /_gql` for issues on project-wide calls)

Validation:

batch_ids must be a non-empty list (empty list raises ValueError - backend treats [] as no filter, which would silently return project-wide counts)
Max 1000 batch IDs per call
Return type change: ProjectOverview.issues and ProjectOverviewDetailed.issues are now Optional[int] = None (always populated for project-wide calls; None when batch-scoped)



## Test on Local

Project:
 - 2 batches:
  - 1 (the one that is requested): 3 total, 1 in review, 1 in rework, 1 in done
  - 2: 4 total, all in To Label

### UI view:

<img width="2524" height="1966" alt="image" src="https://github.com/user-attachments/assets/06e813ff-5d45-4300-b375-ed2c52330422" />

### Test script:
```python
#!/usr/bin/env python3
"""Manual smoke test for Project.get_overview(batch_ids=...) against local lb-api.

Prerequisites:
  - intelligence API running on http://localhost:8080 (pm2 start api)
  - Docker infra up (yarn dev:up) for MySQL + Elasticsearch
  - LABELBOX_API_KEY exported (create one in local app: http://localhost:3333)

Usage:
  export LABELBOX_API_KEY="your-local-key"
  python scripts/test_batch_overview_local.py

Optional:
  python scripts/test_batch_overview_local.py --project-id <id> --batch-id <id>
"""

from __future__ import annotations

import argparse
import os
import sys
import time
import uuid

import labelbox as lb
from labelbox.schema.media_type import MediaType

LOCAL_GRAPHQL = "http://localhost:8080/graphql"
LOCAL_REST = "http://localhost:8080/api/v1"
TEST_IMAGE = (
    "https://storage.googleapis.com/lb-artifacts-testing-public/"
    "sdk_integration_test/potato.jpeg"
)
POLL_TIMEOUT_SECONDS = 120
POLL_INTERVAL_SECONDS = 3


def _client() -> lb.Client:
    api_key = os.environ.get("LABELBOX_API_KEY")
    if not api_key:
        print(
            "ERROR: Set LABELBOX_API_KEY (create one in http://localhost:3333)",
            file=sys.stderr,
        )
        sys.exit(1)
    return lb.Client(
        api_key=api_key,
        endpoint=LOCAL_GRAPHQL,
        rest_endpoint=LOCAL_REST,
    )


def _wait_for_batch_counts(project, batch_a_id: str, batch_b_id: str) -> None:
    deadline = time.time() + POLL_TIMEOUT_SECONDS
    while time.time() < deadline:
        overview_a = project.get_overview(batch_ids=[batch_a_id])
        overview_b = project.get_overview(batch_ids=[batch_b_id])
        if (
            overview_a.total_data_rows == 1
            and overview_b.total_data_rows == 1
        ):
            return
        print(
            f"  waiting for ES indexing... "
            f"batch_a={overview_a.total_data_rows}, "
            f"batch_b={overview_b.total_data_rows}"
        )
        time.sleep(POLL_INTERVAL_SECONDS)
    raise TimeoutError(
        "Timed out waiting for batch-scoped overview counts "
        f"(>{POLL_TIMEOUT_SECONDS}s). Is catalog ES indexing healthy?"
    )


def _run_existing(project_id: str, batch_id: str) -> None:
    client = _client()
    project = client.get_project(project_id)
    print(f"Project: {project.uid} ({project.name})")

    project_overview = project.get_overview()
    batch_overview = project.get_overview(batch_ids=[batch_id])

    print("\nProject-wide overview:")
    print(f"  total_data_rows={project_overview.total_data_rows}")
    print(f"  to_label={project_overview.to_label}")
    print(f"  in_review={project_overview.in_review}")
    print(f"  in_rework={project_overview.in_rework}")
    print(f"  done={project_overview.done}")
    print(f"  issues={project_overview.issues}")

    print("\nBatch-scoped overview:")
    print(f"  total_data_rows={batch_overview.total_data_rows}")
    print(f"  to_label={batch_overview.to_label}")
    print(f"  in_review={batch_overview.in_review}")
    print(f"  in_rework={batch_overview.in_rework}")
    print(f"  done={batch_overview.done}")
    print(f"  issues={batch_overview.issues} (expected None)")

    if batch_overview.issues is not None:
        raise AssertionError("Expected issues=None for batch-scoped overview")


def _run_full_smoke() -> None:
    client = _client()
    suffix = uuid.uuid4().hex[:8]
    project = client.create_project(
        name=f"batch-overview-local-{suffix}",
        media_type=MediaType.Image,
    )
    dataset = client.create_dataset(name=f"batch-overview-dataset-{suffix}")

    print(f"Created project {project.uid}")
    print(f"Created dataset {dataset.uid}")

    try:
        task = dataset.create_data_rows(
            [
                {"row_data": TEST_IMAGE, "external_id": f"dr-a-{suffix}"},
                {"row_data": TEST_IMAGE, "external_id": f"dr-b-{suffix}"},
            ]
        )
        task.wait_till_done()
        if task.errors:
            raise RuntimeError(f"Data row creation errors: {task.errors}")

        export_task = dataset.export()
        export_task.wait_till_done()
        data_row_ids = [
            row.json["data_row"]["id"]
            for row in export_task.get_buffered_stream()
        ]
        if len(data_row_ids) < 2:
            raise RuntimeError(
                f"Expected 2 data rows, got {len(data_row_ids)}"
            )

        batch_a = project.create_batch(f"batch-a-{suffix}", [data_row_ids[0]])
        batch_b = project.create_batch(f"batch-b-{suffix}", [data_row_ids[1]])
        print(f"Created batches: {batch_a.uid}, {batch_b.uid}")

        _wait_for_batch_counts(project, batch_a.uid, batch_b.uid)

        overview_a = project.get_overview(batch_ids=[batch_a.uid])
        overview_b = project.get_overview(batch_ids=[batch_b.uid])
        combined = project.get_overview(batch_ids=[batch_a.uid, batch_b.uid])
        project_overview = project.get_overview()

        print("\nBatch A:")
        print(f"  total_data_rows={overview_a.total_data_rows}, issues={overview_a.issues}")
        print("Batch B:")
        print(f"  total_data_rows={overview_b.total_data_rows}, issues={overview_b.issues}")
        print("Combined:")
        print(f"  total_data_rows={combined.total_data_rows}, issues={combined.issues}")
        print("Project-wide:")
        print(f"  total_data_rows={project_overview.total_data_rows}, issues={project_overview.issues}")

        assert overview_a.total_data_rows == 1
        assert overview_b.total_data_rows == 1
        assert combined.total_data_rows == 2
        assert overview_a.issues is None
        assert overview_b.issues is None
        assert combined.issues is None
        assert project_overview.issues is not None

        print("\nSUCCESS: batch-scoped get_overview() works against local lb-api.")
    finally:
        print("\nCleaning up...")
        project.delete()
        dataset.delete()


def main() -> None:
    parser = argparse.ArgumentParser(
        description="Smoke test Project.get_overview(batch_ids=...) locally"
    )
    parser.add_argument("--project-id", help="Existing project ID (skip setup)")
    parser.add_argument("--batch-id", help="Existing batch ID (requires --project-id)")
    args = parser.parse_args()

    if args.project_id or args.batch_id:
        if not args.project_id or not args.batch_id:
            parser.error("--project-id and --batch-id must be used together")
        _run_existing(args.project_id, args.batch_id)
        print("\nSUCCESS")
        return

    _run_full_smoke()


if __name__ == "__main__":
    main()
```

### Execute script:
<img width="1490" height="952" alt="image" src="https://github.com/user-attachments/assets/c8275f5b-198e-4cd7-8f7d-7b6a070e12f9" />




## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document change (fix typo or modifying any markdown files, code comments or anything in the examples folder only)

## All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you provided a description?
- [x] Are your changes properly formatted?

## New Feature Submissions

- [x] Does your submission pass tests?
- [x] Have you added thorough tests for your new feature?
- [x] Have you commented your code, particularly in hard-to-understand areas?
- [x] Have you added a Docstring?

## Changes to Core Features

- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
- [x] Have you updated any code comments, as applicable?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 77cc539e2ba886c397f64596a6face709e05e8fa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->