### PR TITLE
Fix bulk_assign tests to not depend on removed member mutation

### DIFF
--- a/libs/labelbox/tests/integration/test_bulk_assign.py
+++ b/libs/labelbox/tests/integration/test_bulk_assign.py
@@ -1,11 +1,9 @@
 from labelbox.schema.task_assignment_status import TaskAssignmentStatus
 
 
-def test_bulk_assign_data_rows(
-    configured_batch_project_with_label, project_based_user
-):
+def test_bulk_assign_data_rows(configured_batch_project_with_label, client):
     project, _, data_row, _ = configured_batch_project_with_label
-    user = project_based_user
+    user = client.get_user()
 
     result = project.bulk_assign_data_rows(
         user_id=user.uid,
@@ -15,10 +13,10 @@ def test_bulk_assign_data_rows(
 
 
 def test_bulk_assign_data_rows_with_allowed_statuses(
-    configured_batch_project_with_label, project_based_user
+    configured_batch_project_with_label, client
 ):
     project, _, data_row, _ = configured_batch_project_with_label
-    user = project_based_user
+    user = client.get_user()
 
     result = project.bulk_assign_data_rows(
         user_id=user.uid,


### PR DESCRIPTION
# Description

`test_bulk_assign_data_rows` and `test_bulk_assign_data_rows_with_allowed_statuses` depended on the `project_based_user` fixture, which provisions an org member via the `addMembersToOrganization` mutation. That mutation was removed from the API in intelligence **#11829** (`a2bdf13f69`, 2022-11-15), so the fixture has been erroring at setup ever since — invisible because the integration suite has been chronically red.

## Fix

`bulk_assign_data_rows` is a **live** SDK feature; only its test setup was broken. There's no public-API way to create an assignable member without email-invite acceptance (`organization.invite_user()` returns a pending `Invite`, not a `User` with a usable `uid`). Since the test only needs a valid member `uid`, it now assigns to the current authenticated user via `client.get_user()`. This keeps the feature under test instead of deleting coverage.

- Rewrote the two tests to use `client.get_user()` and dropped the `project_based_user` dependency.
- `test_bulk_assign_empty_list` was already independent and unchanged.

## Note
`project_based_user` remains (used only by `test_user_management::test_member_management`, which is already `@skip`ped). Its broader cleanup / member-management rewrite is out of scope here.

## Verification
- Collects cleanly (3 tests), `ruff format --check` + `ruff check` clean (ruff 0.8.2, matching CI).
- The self-assignment behavior can only be fully confirmed by the integration job against staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production SDK or API surface modifications.
> 
> **Overview**
> Integration tests for **`bulk_assign_data_rows`** no longer use the **`project_based_user`** fixture, which relied on the removed **`addMembersToOrganization`** GraphQL mutation and failed at setup.
> 
> Both affected tests now take the **`client`** fixture and use **`client.get_user()`** as the assignee so they still exercise bulk assign with a valid member **`uid`**. **`test_bulk_assign_empty_list`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b21eba0cf2794e99eb3f7ebd4b0c8b7b6a05e80c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->