### PR TITLE
Fix foundry _get_app to raise ResourceNotFoundError for missing apps

### DIFF
--- a/libs/labelbox/src/labelbox/schema/foundry/foundry_client.py
+++ b/libs/labelbox/src/labelbox/schema/foundry/foundry_client.py
@@ -55,6 +55,13 @@ class FoundryClient:
             response = self.client.execute(query_str, params)
         except exceptions.InvalidQueryError:
             raise exceptions.ResourceNotFoundError(App, params)
+        except exceptions.LabelboxError as e:
+            # A missing app used to surface as InvalidQueryError; the API now
+            # returns a generic "not found" LabelboxError instead. Map it back
+            # to ResourceNotFoundError to preserve this method's contract.
+            if "not found" in str(e).lower():
+                raise exceptions.ResourceNotFoundError(App, params)
+            raise exceptions.LabelboxError(f"Unable to get app with id {id}", e)
         except Exception as e:
             raise exceptions.LabelboxError(f"Unable to get app with id {id}", e)
         return App(**response["findModelFoundryApp"])


### PR DESCRIPTION
# Description

`foundry_client._get_app` is documented to raise `ResourceNotFoundError` for a missing app, and did so by mapping the API's `InvalidQueryError`. The API now returns a generic `LabelboxError` (`App with id ... not found`) instead, so it fell through to the generic wrapper and `test_get_app_with_invalid_id` (which asserts `pytest.raises(ResourceNotFoundError)`) failed.

This detects the not-found `LabelboxError` and re-raises `ResourceNotFoundError`, restoring the method's contract. `ResourceNotFoundError` is a subclass of `LabelboxError`, so all other errors still wrap exactly as before.

## Verification
- ✅ **Confirmed on CI**: `test_get_app_with_invalid_id` now **PASSES** against staging (run on `f127af39`).
- `ruff format --check` + `ruff check` clean.

## Note
This PR was originally going to also fix `test_labeling_frontend_connecting_to_project`, but CI revealed that's a **deeper backend removal**, not a stale assertion: connecting the legacy "Editor" labeling frontend now returns `MalformedQueryException: Unsupported labeling frontend` (per intelligence #30098, only modern Pictor editors are accepted; projects auto-attach the correct one). That test is being handled separately as a removed-capability case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)