### PR TITLE
[PLT-0] Skip test_labeling_frontend_connecting_to_project (removed capability)

### DIFF
--- a/libs/labelbox/tests/integration/test_labeling_frontend.py
+++ b/libs/labelbox/tests/integration/test_labeling_frontend.py
@@ -11,6 +11,11 @@ def test_get_labeling_frontends(client):
     assert len(filtered_frontends)
 
 
+@pytest.mark.skip(
+    reason="Manual connect of the legacy 'Editor' labeling frontend is no longer "
+    "supported: the backend's getEditorType only accepts modern Pictor editors and "
+    "projects auto-attach the correct frontend (intelligence #30098)."
+)
 def test_labeling_frontend_connecting_to_project(project):
     client = project.client
     default_labeling_frontend = next(


### PR DESCRIPTION
## Summary

`test_labeling_frontend_connecting_to_project` has been failing on all 5 Python versions in the `develop` integration suite. The root cause is a **removed backend capability**, not a stale assertion.

Per intelligence **#30098** ("Remove legacy custom and DICOM editors"), the backend's `getEditorType` now only accepts modern **Pictor** editor URLs. Projects auto-attach the correct frontend, and a manual `project.labeling_frontend.connect(<legacy "Editor" frontend>)` is now rejected with `MalformedQueryException: Unsupported labeling frontend`. The test fails at the `connect()` call before reaching any later assertions.

This is the only remaining deterministic (non-environmental) code failure from the `develop` CI cleanup effort.

## Changes

- Add an unconditional `@pytest.mark.skip` to `test_labeling_frontend_connecting_to_project` in `libs/labelbox/tests/integration/test_labeling_frontend.py`, with a `reason=` citing intelligence #30098.
- Test body left unchanged so the change is fully reversible if the capability returns or the test is rewritten against a supported Pictor frontend.
- `test_get_labeling_frontends` is untouched.

**Skip vs. delete:** skipping (rather than deleting) keeps the code in place and documents *why* inline, pending a separate follow-up on whether the SDK `connect`/`disconnect` methods should be deprecated or rewritten against a modern Pictor frontend.

## Test Plan

Verified locally:
- `test_labeling_frontend_connecting_to_project` reports `SKIPPED` with the reason (no live backend needed).
- Both tests still collect (`--collect-only` → 2 items); `test_get_labeling_frontends` unaffected.
- ruff 0.8.2 `check` and `format --check` pass (matching CI's bundled ruff).

CI will confirm the test is skipped across all Python versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or runtime behavior impact.
> 
> **Overview**
> Marks **`test_labeling_frontend_connecting_to_project`** as skipped so the `develop` integration suite stops failing on a removed backend behavior.
> 
> The test manually connects the legacy **"Editor"** frontend via `project.labeling_frontend.connect()`, which the API now rejects (`MalformedQueryException: Unsupported labeling frontend`) after intelligence **#30098**—only modern Pictor editors are accepted and projects auto-attach the right frontend. The skip reason documents that in-line; the test body is unchanged for a possible future rewrite against a supported frontend. **`test_get_labeling_frontends`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 305720d6f1d70fbe2b3743bbf9e3db7085def108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->