### PR TITLE
Prep 7.10.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@
 project = 'Python SDK reference'
 copyright = '2025, Labelbox'
 author = 'Labelbox'
-release = '7.9.0'
+release = '7.10.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/libs/labelbox/CHANGELOG.md
+++ b/libs/labelbox/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+# Version 7.10.0 (2026-07-22)
+## Added
+* Add `Tool.Type.MARKER` for video marker tool ontologies — fetching an ontology containing a marker tool no longer raises `ValueError` ([#2067](https://github.com/Labelbox/labelbox-python/pull/2067))
+## Removed
+* Remove LLM prompt/response and response-creation project support: `Client.create_prompt_response_generation_project()`, `Client.create_response_creation_project()`, `MediaType.LLMPromptCreation`, `MediaType.LLMPromptResponseCreation`, `OntologyKind.ResponseCreation`, `EditorTaskType.ResponseCreation`, and `Project.is_prompt_response()` ([#2063](https://github.com/Labelbox/labelbox-python/pull/2063))
+## Fixed
+* Fix Foundry app lookups to raise `ResourceNotFoundError` for apps that do not exist, instead of a generic `LabelboxError` ([#2065](https://github.com/Labelbox/labelbox-python/pull/2065))
+
 # Version 7.9.0 (2026-07-09)
 ## Added
 * Add optional `batch_ids` parameter to `Project.get_overview()` to return workflow state counts scoped to one or more batches ([#2060](https://github.com/Labelbox/labelbox-python/pull/2060))

--- a/libs/labelbox/pyproject.toml
+++ b/libs/labelbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labelbox"
-version = "7.9.0"
+version = "7.10.0"
 description = "Labelbox Python API"
 authors = [{ name = "Labelbox", email = "engineering@labelbox.com" }]
 dependencies = [

--- a/libs/labelbox/src/labelbox/__init__.py
+++ b/libs/labelbox/src/labelbox/__init__.py
@@ -1,6 +1,6 @@
 name = "labelbox"
 
-__version__ = "7.9.0"
+__version__ = "7.10.0"
 
 from labelbox.client import Client
 from labelbox.schema.annotation_import import (


### PR DESCRIPTION
Release prep for 7.10.0, following the standard pattern (#2061): version bumps + changelog only, no code changes.

### What's in 7.10.0

Everything on develop since v7.9.0:

## Added
* `Tool.Type.MARKER` for video marker tool ontologies (#2067)

## Removed
* LLM prompt/response and response-creation project support (#2063): `Client.create_prompt_response_generation_project()`, `Client.create_response_creation_project()`, `MediaType.LLMPromptCreation`, `MediaType.LLMPromptResponseCreation`, `OntologyKind.ResponseCreation`, `EditorTaskType.ResponseCreation`, `Project.is_prompt_response()`

## Fixed
* Foundry app lookups raise `ResourceNotFoundError` for missing apps instead of a generic `LabelboxError` (#2065)

### Notes for reviewers

* #2063 also removed the `LabelingServiceDashboard` display-string branches for the removed media/task types — implementation detail of the same removal, so no separate changelog bullet.
* #2064, #2066 (test-only) and #2068 (CI/test-infra: staging embedding cleanup) don't touch the SDK surface, so they're omitted per changelog convention.
* The staging embedding cleanup from #2068 has been run, so CI here should be free of the "Max limit of custom embeddings" failures; any remaining integration redness is the known `test_delete_non_existent_schema_id` backend message drift.

### Files

`pyproject.toml`, `__init__.py`, `docs/conf.py` → 7.10.0; `CHANGELOG.md` gains the 7.10.0 section. Same four files as Prep 7.9.0 (#2061).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release prep with no runtime code changes in this PR.
> 
> **Overview**
> **Release prep only** — bumps the published SDK version from **7.9.0** to **7.10.0** in `pyproject.toml`, `labelbox.__version__`, and Sphinx `docs/conf.py`, and adds the **7.10.0** section to `CHANGELOG.md`.
> 
> The new changelog documents what shipped on develop since 7.9.0: **`Tool.Type.MARKER`** for video marker ontologies, **removal** of LLM prompt/response and response-creation project APIs and related enums/methods, and **Foundry** missing-app errors now raising **`ResourceNotFoundError`** instead of **`LabelboxError`**. No implementation changes are in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f453c8cadf8b30b39a556ea2626c0fd0718c3a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->