### PR TITLE
[PLT-4135] Expose User.last_login_at in the Python SDK

### DIFF
--- a/libs/labelbox/CHANGELOG.md
+++ b/libs/labelbox/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+# Version 7.11.0 (Unreleased)
+## Added
+* Add `User.last_login_at` to expose GraphQL `lastLoginAt` (nullable datetime of last session in the organization) ([#TBD](https://github.com/Labelbox/labelbox-python/pull/TBD))
+
 # Version 7.10.0 (2026-07-22)
 ## Added
 * Add `Tool.Type.MARKER` for video marker tool ontologies — fetching an ontology containing a marker tool no longer raises `ValueError` ([#2067](https://github.com/Labelbox/labelbox-python/pull/2067))

--- a/libs/labelbox/CHANGELOG.md
+++ b/libs/labelbox/CHANGELOG.md
@@ -1,8 +1,4 @@
 # Changelog
-# Version 7.11.0 (Unreleased)
-## Added
-* Add `User.last_login_at` to expose GraphQL `lastLoginAt` (nullable datetime of last session in the organization) ([#TBD](https://github.com/Labelbox/labelbox-python/pull/TBD))
-
 # Version 7.10.0 (2026-07-22)
 ## Added
 * Add `Tool.Type.MARKER` for video marker tool ontologies — fetching an ontology containing a marker tool no longer raises `ValueError` ([#2067](https://github.com/Labelbox/labelbox-python/pull/2067))

--- a/libs/labelbox/src/labelbox/schema/issue.py
+++ b/libs/labelbox/src/labelbox/schema/issue.py
@@ -37,7 +37,8 @@ class IssueStatus(str, Enum):
 # ---------------------------------------------------------------------------
 
 _USER_FIELDS = (
-    "id email nickname name picture isViewer isExternalUser createdAt updatedAt"
+    "id email nickname name picture isViewer isExternalUser "
+    "createdAt updatedAt lastLoginAt"
 )
 
 _COMMENT_FIELDS = (

--- a/libs/labelbox/src/labelbox/schema/user.py
+++ b/libs/labelbox/src/labelbox/schema/user.py
@@ -14,6 +14,9 @@ class User(DbObject):
     Attributes:
         updated_at (datetime)
         created_at (datetime)
+        last_login_at (datetime or None): When this user last established a
+            session (login or workspace switch) in this organization. ``None``
+            until the user logs in after last-login tracking was enabled.
         email (str)
         name (str)
         nickname (str)
@@ -28,6 +31,7 @@ class User(DbObject):
 
     updated_at = Field.DateTime("updated_at")
     created_at = Field.DateTime("created_at")
+    last_login_at = Field.DateTime("last_login_at")
     email = Field.String("email")
     name = Field.String("nickname")
     nickname = Field.String("name")

--- a/libs/labelbox/tests/integration/test_user_and_org.py
+++ b/libs/labelbox/tests/integration/test_user_and_org.py
@@ -5,6 +5,9 @@ def test_user(client):
     user = client.get_user()
     assert user.uid is not None
     assert user.organization() == client.get_organization()
+    assert hasattr(user, "last_login_at")
+    # Nullable: None until the user has logged in after tracking was enabled.
+    assert user.last_login_at is None or hasattr(user.last_login_at, "year")
 
 
 def test_organization(client):

--- a/libs/labelbox/tests/unit/schema/test_issue.py
+++ b/libs/labelbox/tests/unit/schema/test_issue.py
@@ -23,6 +23,7 @@ _USER_RAW = {
     "isExternalUser": False,
     "createdAt": _NOW,
     "updatedAt": _NOW,
+    "lastLoginAt": _NOW,
 }
 
 _COMMENT_RAW = {

--- a/libs/labelbox/tests/unit/schema/test_project_issues.py
+++ b/libs/labelbox/tests/unit/schema/test_project_issues.py
@@ -31,6 +31,7 @@ _USER_RAW = {
     "isExternalUser": False,
     "createdAt": _NOW,
     "updatedAt": _NOW,
+    "lastLoginAt": _NOW,
 }
 
 _ISSUE_RAW = {


### PR DESCRIPTION
[https://labelbox.atlassian.net/browse/PLT-4135](https://labelbox.atlassian.net/browse/PLT-4135)

## Context
- Airbnb needs last-login information via the SDK to identify inactive users (e.g. no login in 90+ days)
- GraphQL already exposes `User.lastLoginAt` (PLT-3309); the Python SDK did not map or request that field
- Customers currently have `user.created_at` / `user.updated_at` but no last-login attribute on `User`

## In scope
- Expose `user.last_login_at` on SDK `User` objects returned by the usual user APIs (`get_user`, `get_users`, org users, etc.)
- Value is a UTC datetime when known, or `None` until the user has logged in after last-login tracking was enabled
- Keep Issue/Comment user fragments in sync so nested `User` objects still hydrate correctly

## Out of scope
- Account lockout / enforcement based on last login
- Changing how or how often last login is recorded on the backend

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK field mapping and fragment updates with no auth or enforcement logic changes.
> 
> **Overview**
> Adds **`user.last_login_at`** on SDK `User` objects so customers can read last session time (login or workspace switch) for inactivity workflows. The value is a UTC datetime when the API provides it, or **`None`** until the user has logged in after last-login tracking was enabled.
> 
> Issue/comment GraphQL user fragments now request **`lastLoginAt`** so nested `User` instances on issues and comments hydrate the new field consistently. Integration and unit tests cover the attribute and mock payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9237b4f99d0c2fac03428786cc7f80ab06082935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->