### PR TITLE
Prep 7.11.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@
 project = 'Python SDK reference'
 copyright = '2025, Labelbox'
 author = 'Labelbox'
-release = '7.10.0'
+release = '7.11.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/libs/labelbox/CHANGELOG.md
+++ b/libs/labelbox/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+# Version 7.11.0 (2026-07-28)
+## Added
+* Add `User.last_login_at` to expose GraphQL `lastLoginAt` (nullable datetime of last session in the organization) ([#2070](https://github.com/Labelbox/labelbox-python/pull/2070))
+
 # Version 7.10.0 (2026-07-22)
 ## Added
 * Add `Tool.Type.MARKER` for video marker tool ontologies — fetching an ontology containing a marker tool no longer raises `ValueError` ([#2067](https://github.com/Labelbox/labelbox-python/pull/2067))

--- a/libs/labelbox/pyproject.toml
+++ b/libs/labelbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labelbox"
-version = "7.10.0"
+version = "7.11.0"
 description = "Labelbox Python API"
 authors = [{ name = "Labelbox", email = "engineering@labelbox.com" }]
 dependencies = [

--- a/libs/labelbox/src/labelbox/__init__.py
+++ b/libs/labelbox/src/labelbox/__init__.py
@@ -1,6 +1,6 @@
 name = "labelbox"
 
-__version__ = "7.10.0"
+__version__ = "7.11.0"
 
 from labelbox.client import Client
 from labelbox.schema.annotation_import import (


### PR DESCRIPTION
## Context
- `User.last_login_at` is already on `develop` via #2070, but the published SDK is still 7.10.0
- Customers only get the field after a versioned release (Prep → tag → Publish)
- This is the standard Prep step; same shape as #2061 / #2069

## In scope
- Cut release **7.11.0** so `pip install labelbox` can ship `User.last_login_at` (nullable datetime of last session in the org)
- Document that change in the changelog for 7.11.0

## Out of scope
- GitHub release/tag and PyPI Publish (next steps after merge)
- Any further SDK code changes