### PR TITLE
[PLT-4347] Route embedding metadata operations through GraphQL

### DIFF
--- a/libs/labelbox/src/labelbox/adv_client.py
+++ b/libs/labelbox/src/labelbox/adv_client.py
@@ -1,7 +1,7 @@
 import io
 import json
 import logging
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlparse
 
 import requests
@@ -16,19 +16,6 @@ class AdvClient:
         self.endpoint = endpoint
         self.api_key = api_key
         self.session = self._create_session()
-
-    def create_embedding(self, name: str, dims: int) -> Dict[str, Any]:
-        data = {"name": name, "dims": dims}
-        return self._request("POST", "/adv/v1/embeddings", data)
-
-    def delete_embedding(self, id: str):
-        return self._request("DELETE", f"/adv/v1/embeddings/{id}")
-
-    def get_embedding(self, id: str) -> Dict[str, Any]:
-        return self._request("GET", f"/adv/v1/embeddings/{id}")
-
-    def get_embeddings(self) -> List[Dict[str, Any]]:
-        return self._request("GET", "/adv/v1/embeddings").get("results", [])
 
     def import_vectors_from_file(self, id: str, file_path: str, callback=None):
         self._send_ndjson(

--- a/libs/labelbox/src/labelbox/client.py
+++ b/libs/labelbox/src/labelbox/client.py
@@ -2150,8 +2150,21 @@ class Client:
         Returns:
             A new Embedding object.
         """
-        data = self._adv_client.create_embedding(name, dims)
-        return Embedding(self._adv_client, **data)
+        mutation = """
+        mutation CreateEmbeddingPyApi($data: CreateEmbeddingInput!) {
+            createEmbedding(data: $data) {
+                id
+                name
+                dims
+                custom
+            }
+        }
+        """
+        data = self.execute(
+            mutation,
+            {"data": {"name": name, "dims": dims}},
+        )["createEmbedding"]
+        return Embedding(self, **data)
 
     def get_embeddings(self) -> List[Embedding]:
         """
@@ -2160,8 +2173,18 @@ class Client:
         Returns:
             A list of embedding objects.
         """
-        results = self._adv_client.get_embeddings()
-        return [Embedding(self._adv_client, **data) for data in results]
+        query = """
+        query GetEmbeddingsPyApi {
+            embeddings {
+                id
+                name
+                dims
+                custom
+            }
+        }
+        """
+        results = self.execute(query)["embeddings"]
+        return [Embedding(self, **data) for data in results]
 
     def get_embedding_by_id(self, id: str) -> Embedding:
         """
@@ -2173,8 +2196,34 @@ class Client:
         Returns:
             The embedding object.
         """
-        data = self._adv_client.get_embedding(id)
-        return Embedding(self._adv_client, **data)
+        for embedding in self.get_embeddings():
+            if embedding.id == id:
+                return embedding
+        raise ResourceNotFoundError(Embedding, dict(id=id))
+
+    def delete_embedding(self, id: str):
+        """
+        Delete a custom embedding through the GraphQL API.
+
+        Args:
+            id: The embedding ID.
+        """
+        mutation = """
+        mutation DeleteEmbeddingPyApi($data: DeleteEmbeddingInput!) {
+            deleteEmbedding(data: $data)
+        }
+        """
+        return self.execute(mutation, {"data": {"id": id}})["deleteEmbedding"]
+
+    def import_vectors_from_file(self, id: str, file_path: str, callback=None):
+        """Upload embedding vectors directly to ADV."""
+        return self._adv_client.import_vectors_from_file(
+            id, file_path, callback
+        )
+
+    def get_imported_vector_count(self, id: str) -> int:
+        """Return an embedding's imported vector count directly from ADV."""
+        return self._adv_client.get_imported_vector_count(id)
 
     def get_embedding_by_name(self, name: str) -> Embedding:
         """

--- a/libs/labelbox/src/labelbox/schema/embedding.py
+++ b/libs/labelbox/src/labelbox/schema/embedding.py
@@ -1,7 +1,19 @@
-from typing import Optional, Callable, Dict, Any, List
+from typing import Any, Callable, Dict, List, Optional, Protocol
 
-from labelbox.adv_client import AdvClient
 from pydantic import BaseModel, PrivateAttr
+
+
+class EmbeddingClient(Protocol):
+    def delete_embedding(self, id: str): ...
+
+    def import_vectors_from_file(
+        self,
+        id: str,
+        file_path: str,
+        callback: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ): ...
+
+    def get_imported_vector_count(self, id: str) -> int: ...
 
 
 class EmbeddingVector(BaseModel):
@@ -43,9 +55,9 @@ class Embedding(BaseModel):
     name: str
     custom: bool
     dims: int
-    _client: AdvClient = PrivateAttr()
+    _client: EmbeddingClient = PrivateAttr()
 
-    def __init__(self, client: AdvClient, **data):
+    def __init__(self, client: EmbeddingClient, **data):
         super().__init__(**data)
         self._client = client
 

--- a/libs/labelbox/tests/unit/test_client.py
+++ b/libs/labelbox/tests/unit/test_client.py
@@ -1,4 +1,10 @@
+from unittest.mock import Mock
+
+import pytest
+from lbox.exceptions import ResourceNotFoundError
+
 from labelbox.client import Client
+from labelbox.schema.embedding import Embedding
 
 
 # @patch.dict(os.environ, {'LABELBOX_API_KEY': 'bar'})
@@ -14,3 +20,104 @@ def test_headers():
 def test_enable_experimental():
     client = Client(api_key="api_key", enable_experimental=True)
     assert client.enable_experimental
+
+
+def test_create_embedding_uses_graphql():
+    client = Client(api_key="api_key")
+    client.execute = Mock(
+        return_value={
+            "createEmbedding": {
+                "id": "embedding-id",
+                "name": "custom",
+                "dims": 8,
+                "custom": True,
+            }
+        }
+    )
+
+    embedding = client.create_embedding("custom", 8)
+
+    assert embedding.id == "embedding-id"
+    query, variables = client.execute.call_args.args
+    assert "createEmbedding" in query
+    assert variables == {"data": {"name": "custom", "dims": 8}}
+
+
+def test_get_embeddings_uses_graphql():
+    client = Client(api_key="api_key")
+    client.execute = Mock(
+        return_value={
+            "embeddings": [
+                {
+                    "id": "embedding-id",
+                    "name": "custom",
+                    "dims": 8,
+                    "custom": True,
+                }
+            ]
+        }
+    )
+
+    embeddings = client.get_embeddings()
+
+    assert [embedding.id for embedding in embeddings] == ["embedding-id"]
+    assert "embeddings" in client.execute.call_args.args[0]
+
+
+def test_get_embedding_by_id_filters_graphql_results():
+    client = Client(api_key="api_key")
+    client.get_embeddings = Mock(
+        return_value=[
+            Embedding(
+                client,
+                id="embedding-id",
+                name="custom",
+                dims=8,
+                custom=True,
+            )
+        ]
+    )
+
+    assert client.get_embedding_by_id("embedding-id").name == "custom"
+
+    with pytest.raises(ResourceNotFoundError):
+        client.get_embedding_by_id("missing")
+
+
+def test_embedding_delete_uses_graphql():
+    client = Client(api_key="api_key")
+    client.execute = Mock(return_value={"deleteEmbedding": True})
+    embedding = Embedding(
+        client,
+        id="embedding-id",
+        name="custom",
+        dims=8,
+        custom=True,
+    )
+
+    embedding.delete()
+
+    query, variables = client.execute.call_args.args
+    assert "deleteEmbedding" in query
+    assert variables == {"data": {"id": "embedding-id"}}
+
+
+def test_embedding_vector_operations_remain_on_adv():
+    client = Client(api_key="api_key")
+    client._adv_client.import_vectors_from_file = Mock()
+    client._adv_client.get_imported_vector_count = Mock(return_value=12)
+    callback = Mock()
+    embedding = Embedding(
+        client,
+        id="embedding-id",
+        name="custom",
+        dims=8,
+        custom=True,
+    )
+
+    embedding.import_vectors_from_file("vectors.ndjson", callback)
+
+    client._adv_client.import_vectors_from_file.assert_called_once_with(
+        "embedding-id", "vectors.ndjson", callback
+    )
+    assert embedding.get_imported_vector_count() == 12


### PR DESCRIPTION
## Problem

New API keys are opaque `lbx_` secrets. lb-api accepts both legacy JWT keys and opaque keys, but the SDK's embedding methods bypass lb-api and send the customer's bearer token directly to ADV. ADV assumes every token is a JWT, returns a non-JSON 401, and `AdvClient` surfaces that as `JSONDecodeError`.

Fixes [PLT-4347](https://labelbox.atlassian.net/browse/PLT-4347).

## Change

Keep the public SDK API unchanged, but route embedding metadata operations through lb-api's existing GraphQL resolvers:

- `Client.create_embedding()` → `createEmbedding`
- `Client.get_embeddings()` → `embeddings`
- `Client.get_embedding_by_id()` → filters the bounded GraphQL list (organizations are limited to 10 embeddings)
- `Embedding.delete()` → `deleteEmbedding`

`Embedding` now receives the top-level `Client`, which implements the small interface needed by the model.

No platform/ADV authentication changes and no nginx routing changes are required.

## Follow-up: remaining direct ADV calls

These data-plane operations intentionally remain on `AdvClient`:

- `PUT /adv/v1/embeddings/{id}/_import_ndjson` (`Embedding.import_vectors_from_file`)
- `GET /adv/v1/embeddings/{id}/vectors/_count` (`Embedding.get_imported_vector_count`)

They still require a legacy JWT API key today. We are checking Datadog usage before deciding whether to add narrow lb-api proxy endpoints, migrate them another way, or deprecate them. `AdvClient` has been reduced to only those remaining operations so the boundary is explicit.

## Verification

- Full `libs/labelbox/tests/unit` suite with data extras: **291 passed**
- Added coverage for GraphQL create/list/lookup/delete and for the two operations intentionally retained on ADV
- Ruff format check passes for all changed files
- IDE diagnostics: no errors

Made with [Cursor](https://cursor.com)

[PLT-4347]: https://labelbox.atlassian.net/browse/PLT-4347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ