### PR TITLE
Prep 7.12.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@
 project = 'Python SDK reference'
 copyright = '2025, Labelbox'
 author = 'Labelbox'
-release = '7.11.0'
+release = '7.12.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/libs/labelbox/CHANGELOG.md
+++ b/libs/labelbox/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+# Version 7.12.0 (2026-08-25)
+## Fixed
+* Route embedding metadata operations (`Client.create_embedding()`, `Client.get_embeddings()`, `Client.get_embedding_by_id()`, `Embedding.delete()`) through GraphQL so they work with opaque `lbx_` API keys instead of raising `JSONDecodeError` ([#2074](https://github.com/Labelbox/labelbox-python/pull/2074))
+
 # Version 7.11.0 (2026-07-28)
 ## Added
 * Add `User.last_login_at` to expose GraphQL `lastLoginAt` (nullable datetime of last session in the organization) ([#2070](https://github.com/Labelbox/labelbox-python/pull/2070))

--- a/libs/labelbox/pyproject.toml
+++ b/libs/labelbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labelbox"
-version = "7.11.0"
+version = "7.12.0"
 description = "Labelbox Python API"
 authors = [{ name = "Labelbox", email = "engineering@labelbox.com" }]
 dependencies = [

--- a/libs/labelbox/src/labelbox/__init__.py
+++ b/libs/labelbox/src/labelbox/__init__.py
@@ -1,6 +1,6 @@
 name = "labelbox"
 
-__version__ = "7.11.0"
+__version__ = "7.12.0"
 
 from labelbox.client import Client
 from labelbox.schema.annotation_import import (


### PR DESCRIPTION
## Context
- The GraphQL routing fix for embedding metadata operations is already on `develop` via #2074, but the published SDK is still 7.11.0
- Customers hitting `JSONDecodeError` with opaque `lbx_` API keys only get the fix after a versioned release (Prep → tag → Publish)
- This is the standard Prep step; same shape as #2069 / #2071

## In scope
- Cut release **7.12.0** so `pip install labelbox` ships the embedding metadata GraphQL routing fix
- Document that change in the changelog for 7.12.0

## Out of scope
- GitHub release/tag and PyPI Publish (next steps after merge)
- Any further SDK code changes
- The remaining direct ADV calls (`import_vectors_from_file`, `get_imported_vector_count`) that #2074 intentionally left on `AdvClient`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version and documentation updates with no runtime code changes in this diff.
> 
> **Overview**
> Bumps the **labelbox** package from **7.11.0** to **7.12.0** across `pyproject.toml`, `labelbox.__version__`, and the Sphinx docs `release` field so the next publish ships a new SDK version.
> 
> Adds a **7.12.0** changelog entry (2026-08-25) under **Fixed**, calling out that embedding metadata APIs (`Client.create_embedding()`, `Client.get_embeddings()`, `Client.get_embedding_by_id()`, `Embedding.delete()`) are routed through GraphQL for opaque `lbx_` API keys ([#2074](https://github.com/Labelbox/labelbox-python/pull/2074)). This PR does not change SDK implementation—only release metadata and release notes for code already on `develop`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de436bff2ac799fa778c6cdb38da724bdb3b55f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->